### PR TITLE
AlarmConfigTool handles lack of preferences gracefully

### DIFF
--- a/applications/plugins/org.csstudio.alarm.beast.configtool/src/org/csstudio/alarm/beast/configtool/Application.java
+++ b/applications/plugins/org.csstudio.alarm.beast.configtool/src/org/csstudio/alarm/beast/configtool/Application.java
@@ -85,9 +85,9 @@ public class Application implements IApplication
             return parser.getHelp();
 
         this.url = url.get();
-        this.user = user.get().isEmpty() ? null : user.get();
-        this.password = password.get().isEmpty() ? null : password.get();
-        this.schema = schema.get().isEmpty() ? "" : schema.get();
+        this.user = (user.get() == null || user.get().isEmpty()) ? null : user.get();
+        this.password = (password.get() == null || password.get().isEmpty()) ? null : password.get();
+        this.schema = (schema.get() == null || schema.get().isEmpty()) ? "" : schema.get();
         if (do_list.get())
         {
             mode = Mode.LIST;

--- a/applications/plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/Preferences.java
+++ b/applications/plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/Preferences.java
@@ -125,7 +125,7 @@ public class Preferences
     public static String getRDB_Schema()
     {
         final String schema = getString(RDB_SCHEMA);
-        if (schema.endsWith("."))
+        if (schema != null && schema.endsWith("."))
             return schema.substring(0, schema.length()-1);
         return schema;
     }


### PR DESCRIPTION
Modification to AlarmConfigTool so if no user, password or schema are supplied (either from an ini file or the command line) the tool exits gracefully.
