### PR TITLE
fix a typo: removeListenr

### DIFF
--- a/applications/plugins/org.csstudio.swt.xygraph/src/org/csstudio/swt/xygraph/figures/Axis.java
+++ b/applications/plugins/org.csstudio.swt.xygraph/src/org/csstudio/swt/xygraph/figures/Axis.java
@@ -150,7 +150,7 @@ public class Axis extends LinearScale{
 		listeners.add(listener);
 	}
 
-	public boolean removeListenr(final IAxisListener listener){
+	public boolean removeListener(final IAxisListener listener){
 		return listeners.remove(listener);
 	}
 

--- a/applications/plugins/org.csstudio.swt.xygraph/src/org/csstudio/swt/xygraph/figures/Trace.java
+++ b/applications/plugins/org.csstudio.swt.xygraph/src/org/csstudio/swt/xygraph/figures/Trace.java
@@ -1073,7 +1073,7 @@ public class Trace extends Figure implements IDataProviderListener,
 		if (xAxis == axis)
 			return;
 		if (xAxis != null) {
-			xAxis.removeListenr(this);
+			xAxis.removeListener(this);
 			xAxis.removeTrace(this);
 		}
 
@@ -1121,7 +1121,7 @@ public class Trace extends Figure implements IDataProviderListener,
 		}
 
 		if (yAxis != null) {
-			yAxis.removeListenr(this);
+			yAxis.removeListener(this);
 			yAxis.removeTrace(this);
 		}
 		/*


### PR DESCRIPTION
This changeset fixed a simple typo in a function name in Axis.java and in Trace.java where the function is called.
