### PR TITLE
update the filenames to check.

### DIFF
--- a/applications/plugins/org.csstudio.ui.menu.web/preferences.ini
+++ b/applications/plugins/org.csstudio.ui.menu.web/preferences.ini
@@ -7,6 +7,6 @@ weblinks=css google
 
 # This defines the Label and link for the web links.
 # Only those listed in ...weblinks above are actually used!
-css=CSS Wiki|https://sourceforge.net/apps/trac/cs-studio
+css=CSS Wiki|https://github.com/ControlSystemStudio/cs-studio/wiki
 google=Google|http://www.google.com
 


### PR DESCRIPTION
I noticed that the eclipse distribution is downloaded again and again because the build script is looking for an incorrect filename.
