### PR TITLE
Wiki link

### DIFF
--- a/applications/plugins/org.csstudio.ui.menu.web/preferences.ini
+++ b/applications/plugins/org.csstudio.ui.menu.web/preferences.ini
@@ -7,6 +7,6 @@ weblinks=css google
 
 # This defines the Label and link for the web links.
 # Only those listed in ...weblinks above are actually used!
-css=CSS Wiki|https://sourceforge.net/apps/trac/cs-studio
+css=CSS Wiki|https://github.com/ControlSystemStudio/cs-studio/wiki
 google=Google|http://www.google.com
 


### PR DESCRIPTION
This just updates the link from the old page at sourceforge to the new one at github.
