### PR TITLE
Fix a typo that prevents --compute-deps from working.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -24,7 +24,7 @@ computedeps=0
 
 LONGOPTS="help \
 product: \
-computedeps"
+compute-deps"
 
 ORGANIZATION=$1
 shift


### PR DESCRIPTION
This fixes build.sh --compute-deps.
