### PR TITLE
SNS: Fix logbook 'title' length overrun

### DIFF
--- a/products/SNS/plugins/org.csstudio.logbook.sns/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.logbook.sns/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SNS Elog
 Bundle-SymbolicName: org.csstudio.logbook.sns;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.2.1.qualifier
 Bundle-Activator: org.csstudio.logbook.sns.Activator
 Require-Bundle: org.junit4,
  org.eclipse.core.runtime,


### PR DESCRIPTION
logbook API doesn't support title per se.
SNS implementation uses first line as title, and that could create an
overrun.
Now 'title' is shortened.
