### PR TITLE
SNS build: Update Java and patch 3.7.2 target w/ 4.3.1 Mac OS launcher

### DIFF
--- a/products/SNS/product/org.csstudio.sns.updatesite/TargetPlatforms.tracwiki
+++ b/products/SNS/product/org.csstudio.sns.updatesite/TargetPlatforms.tracwiki
@@ -7,14 +7,14 @@ the 64 bit products.
 Oracle Java 7 for Mac OS X is 64 bit.
 
 == Mac OS X ==
-Started out with {{{os=macosx, ws=carbon, arch=x86}}} for Mac OS X 10.5 and 10.6.
+Architecture started with {{{os=macosx, ws=carbon, arch=x86}}} for Mac OS X 10.5 and 10.6, then switched to {{{ws=cocoa}}}.
+As of CSS 3.2.x, CSS source code requires Java 7.
+Oracle provides Java 7 as a JRE, which installs as a web browser plugin,
+and as a JDK, which installs such that "java -version" on the command line will report 1.7.
 
-Then switched to {{{ws=cocoa}}}.
-
-Eventually, CSS source code updates required Java 7.
 The Eclipse 3.7.2 target launcher, however, does not work with Oracle Java 7.
 Options {{{-vm /path/to/jdk1.7/bin/java}}} have no effect.
-The launch will fail and configuration/*.log will show that Java 6 is used, whatever you try to use Java 7:
+The launch will fail and configuration/*.log will show that Java 6 is used, whatever you select Java 7:
 {{{
 java.version=1.6.0_45
 java.vendor=Apple Inc.
@@ -27,21 +27,30 @@ java -showversion -XX:MaxPermSize=256m -Xms1024m -Xmx1024m -XstartOnFirstThread 
 
 See also http://stackoverflow.com/questions/10352715/how-do-i-run-eclipse-using-oracles-new-1-7-jdk-for-the-mac
 
-One workaround is to patch the generated product with the launcher binary from Eclipse 4.3:
+Workaround is to patch the generated product with the launcher binary from Eclipse 4.3.1.
+By replacing the launcher of the 3.7.2 target platform and delta pack with the corresponding files from Eclipse 4.3.1,
+an 'export' or headless build will result in a usable Mac OS X applications:
 {{{
-cp ECLIPSE4/org.eclipse.equinox.launcher.cocoa.macosx.x86_64_1.1.200.v20130327-1440/eclipse_1507.so CSS/plugins/org.eclipse.equinox.launcher.cocoa.macosx.x86_64_1.1.101.v20120109-1504/eclipse_1408.so 
+# Hack 3.7.2 launcher binary (exe. and shared lib), replace with the one from 4.3.1
+cp Eclipse/4.3.1/rcp/Eclipse.app/Contents/MacOS/eclipse \
+   Eclipse/3.7.2/delta/features/org.eclipse.equinox.executable_3.5.1.v20111216-1653-7P7NFUIFIbaUcU77s0KQWHw5HZTZ/bin/cocoa/macosx/x86_64/Eclipse.app/Contents/MacOS/launcher
+
+cp Eclipse/4.3.1/rcp/plugins/org.eclipse.equinox.launcher.cocoa.macosx.x86_64_1.1.200.v20130807-1835/eclipse_1508.so \
+   Eclipse/3.7.2/delta/plugins/org.eclipse.equinox.launcher.cocoa.macosx.x86_64_1.1.101.v20120109-1504/eclipse_1408.so 
+
+# Since binaries were changed, the associated signage info needs to be removed:
+cd Eclipse/3.7.2/delta/plugins/org.eclipse.equinox.launcher.cocoa.macosx.x86_64_1.1.101.v20120109-1504/META-INF
+rm ECLIPSE*
+# Edit MANIFEST.MF, remove all "SHA1-Digest" entries
 }}}
 
-A really terrible hack is to replace the `org.eclipse.equinox.launcher.cocoa.macosx.x86_64_1.1.101.v20120109-1504/eclipse_1408.so` of the 3.7.2 target platform and delta pack with the `eclipse_1507.so` from Eclipse 4.3.
-This will allow a headless build of binaries that run on Mac OS X 10.8 with Java 7.
-When doing this, note that the signage info also needs to be removed (`META-INF/ECLIPSEF.*`, `SHA1-Digest: ` entries in `MANIFEST.MF`).
-
+If the development platform is Mac OS, you also need to update the IDE's launcher files.
+In practice it is easier to build on Linux and then only update the launcher files in the delta pack.
 
 Before Eclipse 4.3, support for the new Oracle/Open JDK layout also requires manual creation of (empty) Classes directory:
 {{{
 sudo mkdir /Library/Java/JavaVirtualMachines/jdk1.7.0_17.jdk/Contents/Home/Classes
 }}}
-
 
 
 == Update from P2 Repository ==

--- a/products/SNS/product/org.csstudio.sns.updatesite/settings.sh
+++ b/products/SNS/product/org.csstudio.sns.updatesite/settings.sh
@@ -8,7 +8,7 @@ export VERSION=3.2.11
 if [ `hostname` = 'ics-web4.sns.ornl.gov' ]
 then
    # Must use Java 7
-   export JAVA_HOME=/usr/local/java/jdk1.7.0_21
+   export JAVA_HOME=/usr/local/java/jdk1.7.0_45
 
    # Top of repository tree
    export TOP=/usr/local/hudson/config/jobs/CSS/workspace
@@ -26,7 +26,7 @@ then
 
    export JRE_Win64=/home/kasemir/Eclipse/CSS_Additions/Win64/jre/
 else
-   export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_21.jdk/Contents/Home
+   export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home
    export TOP=/Users/ky9/git/cs-studio_3
    export WORKSPACE=/Users/ky9/Eclipse/Workspace4.3_3.7_target
    export ECLIPSE=/Users/ky9/Eclipse/3.7.2/rcp
@@ -38,7 +38,7 @@ else
    then
       echo "On OS X, to make new Oracle JDK look like old Apple JDK for Eclipse 3.x"
       echo "that RCP headless build still expects, do this:"
-      echo "ln -s $JAVA_HOME/jre/lib $JAVA_HOME/Classes"
+      echo "sudo ln -s $JAVA_HOME/jre/lib $JAVA_HOME/Classes"
       exit -1
    fi
 fi


### PR DESCRIPTION
Update built info to work around #168 

Previous details from 4.3M7 updated w/ 4.3.1. New launcher avoids "css.app is damaged and can't be opened" error
