### PR TITLE
o.c.scan: Update all ScanCommands to generate XML via DOM formatter.

### DIFF
--- a/applications/plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/WaitForDevicesCommand.java
+++ b/applications/plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/WaitForDevicesCommand.java
@@ -15,8 +15,6 @@
  ******************************************************************************/
 package org.csstudio.scan.commandimpl;
 
-import java.io.PrintStream;
-
 import org.csstudio.scan.command.ScanCommand;
 import org.csstudio.scan.command.SimpleScanCommandFactory;
 import org.csstudio.scan.device.Device;
@@ -39,13 +37,6 @@ public class WaitForDevicesCommand extends ScanCommand
     public Device[] getDevices()
     {
         return devices;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void writeXML(final PrintStream out, final int level)
-    {
-        throw new Error("Internal command");
     }
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan.ui.scantree/test/org/csstudio/scan/ui/scantree/CommandsInfoHeadlessTest.java
+++ b/applications/plugins/org.csstudio.scan.ui.scantree/test/org/csstudio/scan/ui/scantree/CommandsInfoHeadlessTest.java
@@ -17,7 +17,10 @@ package org.csstudio.scan.ui.scantree;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+
 import org.csstudio.scan.command.ScanCommand;
+import org.csstudio.scan.command.XMLCommandWriter;
 import org.csstudio.scan.ui.scantree.gui.CommandsInfo;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
@@ -41,7 +44,7 @@ public class CommandsInfoHeadlessTest
         for (ScanCommand command : commands)
         {
             System.out.println(command.getClass().getName() + ":");
-            command.writeXML(System.out, 1);
+            XMLCommandWriter.write(System.out, Arrays.asList(command));
 
             final Image image = info.getImage(command);
             System.out.println("Icon: " +

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/CommentCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/CommentCommand.java
@@ -15,9 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.List;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Command that adds comment to a scan
@@ -64,11 +64,12 @@ public class CommentCommand extends ScanCommand
 
     /** {@inheritDoc} */
     @Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
     {
-        writeIndent(out, level);
-        out.println("<comment><text>" + comment + "</text></comment>");
-        // NOT calling super.writeXML(out, level);
+        Element element = dom.createElement("text");
+        element.appendChild(dom.createTextNode(comment));
+        command_element.appendChild(element);
+        // NOT calling super.addXMLElements(dom, command_element);
     }
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/ConfigLogCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/ConfigLogCommand.java
@@ -15,9 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.List;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Command that configures logging
@@ -56,18 +56,12 @@ public class ConfigLogCommand extends ScanCommand
 
     /** {@inheritDoc} */
     @Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
     {
-        writeIndent(out, level);
-        out.println("<config_log>");
-        if (automatic)
-        {
-            writeIndent(out, level+1);
-            out.println("<automatic>" + automatic + "</automatic>");
-        }
-        super.writeXML(out, level);
-        writeIndent(out, level);
-        out.println("</config_log>");
+        final Element element = dom.createElement("automatic");
+        element.appendChild(dom.createTextNode(Boolean.toString(automatic)));
+        command_element.appendChild(element);
+        super.addXMLElements(dom, command_element);
     }
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/DelayCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/DelayCommand.java
@@ -15,9 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.List;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Command that delays the scan for some time
@@ -64,15 +64,12 @@ public class DelayCommand extends ScanCommand
 
     /** {@inheritDoc} */
 	@Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
 	{
-	    writeIndent(out, level);
-	    out.println("<delay>");
-        writeIndent(out, level+1);
-        out.println("<seconds>" + seconds + "</seconds>");
-        super.writeXML(out, level);
-        writeIndent(out, level);
-        out.println("</delay>");
+        Element element = dom.createElement("seconds");
+        element.appendChild(dom.createTextNode(Double.toString(seconds)));
+        command_element.appendChild(element);
+        super.addXMLElements(dom, command_element);
 	}
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/IncludeCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/IncludeCommand.java
@@ -15,9 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.List;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Command that includes existing *.scn file with macros
@@ -79,17 +79,17 @@ public class IncludeCommand extends ScanCommand
     
     /** {@inheritDoc} */
     @Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
     {
-        writeIndent(out, level);
-        out.println("<include>");
-        writeIndent(out, level+1);
-        out.println("<scan_file>" + getScanFile() + "</scan_file>");
-        writeIndent(out, level+1);
-        out.println("<macros>" + getMacros() + "</macros>");
-        super.writeXML(out, level);
-        writeIndent(out, level);
-        out.println("</include>");
+        Element element = dom.createElement("scan_file");
+        element.appendChild(dom.createTextNode(getScanFile()));
+        command_element.appendChild(element);
+
+        element = dom.createElement("macros");
+        element.appendChild(dom.createTextNode(getMacros()));
+        command_element.appendChild(element);
+        
+        super.addXMLElements(dom, command_element);
     }
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/LogCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/LogCommand.java
@@ -15,12 +15,12 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.csstudio.scan.device.DeviceInfo;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -77,22 +77,17 @@ public class LogCommand extends ScanCommand
 
     /** {@inheritDoc} */
     @Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
     {
-        writeIndent(out, level);
-        out.println("<log>");
-        writeIndent(out, level+1);
-        out.println("<devices>");
+        final Element devices_element = dom.createElement("devices");
         for (String device : device_names)
         {
-            writeIndent(out, level+2);
-            out.println("<device>" + device + "</device>");
+            final Element element = dom.createElement("device");
+            element.appendChild(dom.createTextNode(device));
+            devices_element.appendChild(element);
         }
-        writeIndent(out, level+1);
-        out.println("</devices>");
-        super.writeXML(out, level);
-        writeIndent(out, level);
-        out.println("</log>");
+        command_element.appendChild(devices_element);
+        super.addXMLElements(dom, command_element);
     }
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/LoopCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/LoopCommand.java
@@ -15,10 +15,10 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Command that performs a loop
@@ -295,52 +295,61 @@ public class LoopCommand extends ScanCommand
 
     /** {@inheritDoc} */
     @Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
     {
-        writeIndent(out, level);
-        out.println("<loop>");
-        writeIndent(out, level+1);
-        out.println("<device>" + device_name + "</device>");
-        writeIndent(out, level+1);
-        out.println("<start>" + start + "</start>");
-        writeIndent(out, level+1);
-        out.println("<end>" + end + "</end>");
-        writeIndent(out, level+1);
-        out.println("<step>" + stepsize + "</step>");
+        Element element = dom.createElement("device");
+        element.appendChild(dom.createTextNode(device_name));
+        command_element.appendChild(element);
+
+        element = dom.createElement("start");
+        element.appendChild(dom.createTextNode(Double.toString(start)));
+        command_element.appendChild(element);
+
+        element = dom.createElement("end");
+        element.appendChild(dom.createTextNode(Double.toString(end)));
+        command_element.appendChild(element);
+
+        element = dom.createElement("step");
+        element.appendChild(dom.createTextNode(Double.toString(stepsize)));
+        command_element.appendChild(element);
+
         if (completion)
         {
-            writeIndent(out, level+1);
-            out.println("<completion>true</completion>");
+            element = dom.createElement("completion");
+            element.appendChild(dom.createTextNode(Boolean.toString(completion)));
+            command_element.appendChild(element);
         }
         if (! wait)
         {
-            writeIndent(out, level+1);
-            out.println("<wait>" + wait + "</wait>");
+            element = dom.createElement("wait");
+            element.appendChild(dom.createTextNode(Boolean.toString(wait)));
+            command_element.appendChild(element);
         }
         if (wait  &&  ! readback.isEmpty())
         {
-            writeIndent(out, level+1);
-            out.println("<readback>" + readback + "</readback>");
+            element = dom.createElement("readback");
+            element.appendChild(dom.createTextNode(readback));
+            command_element.appendChild(element);
         }
         if (tolerance > 0.0)
         {
-            writeIndent(out, level+1);
-            out.println("<tolerance>" + tolerance + "</tolerance>");
+            element = dom.createElement("tolerance");
+            element.appendChild(dom.createTextNode(Double.toString(tolerance)));
+            command_element.appendChild(element);
         }
         if (timeout > 0.0)
         {
-            writeIndent(out, level+1);
-            out.println("<timeout>" + timeout + "</timeout>");
+            element = dom.createElement("timeout");
+            element.appendChild(dom.createTextNode(Double.toString(timeout)));
+            command_element.appendChild(element);
         }
-        writeIndent(out, level+1);
-        out.println("<body>");
+
+        element = dom.createElement("body");
         for (ScanCommand cmd : body)
-            cmd.writeXML(out, level + 2);
-        writeIndent(out, level+1);
-        out.println("</body>");
-        super.writeXML(out, level);
-        writeIndent(out, level);
-        out.println("</loop>");
+            cmd.writeXML(dom, element);
+        command_element.appendChild(element);
+        
+        super.addXMLElements(dom, command_element);
     }
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/ScriptCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/ScriptCommand.java
@@ -15,11 +15,11 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -93,26 +93,22 @@ public class ScriptCommand extends ScanCommand
     
     /** {@inheritDoc} */
     @Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
     {
-        writeIndent(out, level);
-        out.println("<script>");
-        writeIndent(out, level+1);
-        out.print("<path>");
-        out.print(script);
-        out.println("</path>");
-        writeIndent(out, level+1);
-        out.println("<arguments>");
+        Element element = dom.createElement("path");
+        element.appendChild(dom.createTextNode(script));
+        command_element.appendChild(element);
+
+        element = dom.createElement("arguments");
         for (String arg : args)
         {
-            writeIndent(out, level+2);
-            out.println("<argument>" + arg + "</argument>");
+            final Element arg_element = dom.createElement("argument");
+            arg_element.appendChild(dom.createTextNode(arg));
+            element.appendChild(arg_element);
         }
-        writeIndent(out, level+1);
-        out.println("</arguments>");
-        super.writeXML(out, level);
-        writeIndent(out, level);
-        out.println("</script>");
+        command_element.appendChild(element);
+        
+        super.addXMLElements(dom, command_element);
     }
 
     /** {@inheritDoc} */

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/SimpleScanCommandFactory.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/SimpleScanCommandFactory.java
@@ -51,6 +51,23 @@ import org.w3c.dom.Node;
 @SuppressWarnings("nls")
 public class SimpleScanCommandFactory
 {
+    /** Convert command ID "do_some_thing" into "DoSomeThingCommand" class name
+     *  @param id Command ID
+     *  @return Command class name
+     */
+    public static String ID2CommandName(final String id)
+    {
+        final String[] sections = id.split("_");
+        final StringBuilder buf = new StringBuilder();
+        for (String section : sections)
+        {
+            buf.append(section.substring(0, 1).toUpperCase());
+            buf.append(section.substring(1).toLowerCase());
+        }
+        buf.append("Command");
+        return buf.toString();
+    }
+    
     /** Create a {@link ScanCommand} for a command ID
      *
      *  <p>This is the basic implementation that does NOT use the Eclipse registry.
@@ -63,9 +80,7 @@ public class SimpleScanCommandFactory
     public ScanCommand createCommandForID(final String id) throws Exception
     {
         // Guess class name based on the ID: Turn ID "set" into "....SetCommand"
-        final String classname = "org.csstudio.scan.command." +
-                id.substring(0, 1).toUpperCase() +
-                id.substring(1).toLowerCase() + "Command";
+        final String classname = "org.csstudio.scan.command." + ID2CommandName(id);
         try
         {
             final Class<?> command_class = Class.forName(classname);

--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/WaitCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/WaitCommand.java
@@ -15,9 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
-import java.io.PrintStream;
 import java.util.List;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Command that delays the scan until a device reaches a certain value
@@ -155,29 +155,34 @@ public class WaitCommand extends ScanCommand
 
     /** {@inheritDoc} */
     @Override
-    public void writeXML(final PrintStream out, final int level)
+    public void addXMLElements(final Document dom, final Element command_element)
     {
-        writeIndent(out, level);
-        out.println("<wait>");
-        writeIndent(out, level+1);
-        out.println("<device>" + device_name + "</device>");
-        writeIndent(out, level+1);
-        out.println("<value>" + desired_value + "</value>");
-        writeIndent(out, level+1);
-        out.println("<comparison>" + comparison.name() + "</comparison>");
+        Element element = dom.createElement("device");
+        element.appendChild(dom.createTextNode(device_name));
+        command_element.appendChild(element);
+
+        element = dom.createElement("value");
+        element.appendChild(dom.createTextNode(Double.toString(desired_value)));
+        command_element.appendChild(element);
+
+        element = dom.createElement("comparison");
+        element.appendChild(dom.createTextNode(comparison.name()));
+        command_element.appendChild(element);
+        
         if (tolerance > 0.0)
         {
-            writeIndent(out, level+1);
-            out.println("<tolerance>" + tolerance + "</tolerance>");
+            element = dom.createElement("tolerance");
+            element.appendChild(dom.createTextNode(Double.toString(tolerance)));
+            command_element.appendChild(element);
         }
         if (timeout > 0.0)
         {
-            writeIndent(out, level+1);
-            out.println("<timeout>" + timeout + "</timeout>");
+            element = dom.createElement("timeout");
+            element.appendChild(dom.createTextNode(Double.toString(timeout)));
+            command_element.appendChild(element);
         }
-        super.writeXML(out, level);
-        writeIndent(out, level);
-        out.println("</wait>");
+        
+        super.addXMLElements(dom, command_element);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This avoids problems with text that needs to be escaped, fixing #210.

To allow upload and download of scans with '&', '<', .. in SetCommand values to/from scan server, both the CSS GUI and the scan server need to be updated. Probably too much for an existing 3.2.x setup, so not a good candidate for a hotfix.
