### PR TITLE
o.a.archive.engine: Check for invalid time stamps

### DIFF
--- a/applications/plugins/org.csstudio.archive.engine/ArchiveEngine.product
+++ b/applications/plugins/org.csstudio.archive.engine/ArchiveEngine.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="ArchiveEngine" id="org.csstudio.archive.engine.engine" application="org.csstudio.archive.engine.application" version="3.2.1.qualifier" useFeatures="false" includeLaunchers="true">
+<product name="ArchiveEngine" id="org.csstudio.archive.engine.engine" application="org.csstudio.archive.engine.application" version="3.2.2.qualifier" useFeatures="false" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/applications/plugins/org.csstudio.archive.engine/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Engine Plug-in
 Bundle-SymbolicName: org.csstudio.archive.engine;singleton:=true
-Bundle-Version: 3.2.1.qualifier
+Bundle-Version: 3.2.2.qualifier
 Bundle-Activator: org.csstudio.archive.engine.Activator
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Archive Sample Engine, writes data to RDB
@@ -22,4 +22,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.csstudio.utility.test;bundle-version="1.0.0";resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/applications/plugins/org.csstudio.archive.rdb/ChangeLog.html
+++ b/applications/plugins/org.csstudio.archive.rdb/ChangeLog.html
@@ -9,6 +9,11 @@
 
 <p>Version numbers in here refer to the version of the plugin org.csstudio.archive.rdb.</p>
 
+<h2>Version 3.2.2 - 2013-11-04</h2>
+<ul>
+<li>ArchiveEngine test for invalid time stamps.</li>
+</ul>
+
 <h2>Version 3.2.0 - 2013-09-18</h2>
 <ul>
 <li>ArchiveEngine uses PVManager.</li>

--- a/applications/plugins/org.csstudio.archive.rdb/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.rdb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDB Archive library
 Bundle-SymbolicName: org.csstudio.archive.rdb;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.2.2.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Archive RDB support library
 Require-Bundle: org.eclipse.core.runtime,


### PR DESCRIPTION
This includes a workaround for VType bug #209 where out of range nanoseconds
would be reported as 'valid' yet cause a RuntimeException when fetching
the Timestamp.

The fix should show the affected channel name combined with the VType exception.
In the future, as VType.Time.isTimeValid() gets updated, it would show the invalid time stamp as such.
