### PR TITLE
o.c.archive.reader.rdb: Lower log level for severity mapping message.

### DIFF
--- a/applications/plugins/org.csstudio.archive.reader.rdb/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.reader.rdb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RDB Archive Reader
 Bundle-Description: Support for reading archived data from Relational Database (Oracle, MySQL)
 Bundle-SymbolicName: org.csstudio.archive.reader.rdb;singleton:=true
-Bundle-Version: 3.2.1.qualifier
+Bundle-Version: 3.2.11.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",

--- a/applications/plugins/org.csstudio.archive.reader.rdb/src/org/csstudio/archive/reader/rdb/RDBArchiveReader.java
+++ b/applications/plugins/org.csstudio.archive.reader.rdb/src/org/csstudio/archive/reader/rdb/RDBArchiveReader.java
@@ -198,7 +198,7 @@ public class RDBArchiveReader implements ArchiveReader
                 }
                 if (severity == null)
             	{
-                    Activator.getLogger().log(Level.WARNING,
+                    Activator.getLogger().log(Level.FINE,
                         "Undefined severity level {0}", text);
             		severities.put(id, AlarmSeverity.UNDEFINED);     
             	}


### PR DESCRIPTION
Fix #233: SNS Oracle RDB has extra "Unused" severity table entry. It's mapped to
"UNDEFINED" severity and - duh - not used, but kept showing up in the
log...
