### PR TITLE
o.c.scan.log.derby: Suppress error "DROP TABLE cannot be performed"

### DIFF
--- a/applications/plugins/org.csstudio.scan.log.derby/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.scan.log.derby/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Derby-based scan log
 Bundle-SymbolicName: org.csstudio.scan.log.derby;singleton:=true
-Bundle-Version: 3.2.1.qualifier
+Bundle-Version: 3.2.2.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/applications/plugins/org.csstudio.scan.log.derby/dbd/scanlog.dbd
+++ b/applications/plugins/org.csstudio.scan.log.derby/dbd/scanlog.dbd
@@ -2,12 +2,18 @@
 --
 -- Commands in here are read by java code to initialize the database
 --
+-- Format must be:
+--  '-- ...' for comment to ignore
+--  'whatever ...;' for commands, may be multi-line, must end in ';'
+--
 --  @author Kay Kasemir
 
 -- Warning if database already exists
 --  CONNECT 'jdbc:derby:/tmp/scan_log_db/scan;create=true';
 
--- These will generate errors when table don't exist...
+-- Derby has no convenient "DROP TABLE IF EXISTS", so
+-- these will generate error 42Y55 when tables don't exist.
+-- Error is ignored in DerbyDataLogger#createTables()
 DROP TABLE scans;
 DROP TABLE devices;
 DROP TABLE samples;

--- a/applications/plugins/org.csstudio.scan.log.derby/src/org/csstudio/scan/log/derby/DerbyDataLogger.java
+++ b/applications/plugins/org.csstudio.scan.log.derby/src/org/csstudio/scan/log/derby/DerbyDataLogger.java
@@ -158,7 +158,9 @@ public class DerbyDataLogger extends RDBDataLogger
 							}
 							catch (SQLException ex)
 							{
-								Logger.getLogger(getClass().getName()).log(Level.INFO, "SQL failed: " + sql, ex);
+							    // Ignore RROR 42Y55: 'DROP TABLE' cannot be performed on '...' because it does not exist.
+							    if (! ex.getSQLState().equals("42Y55"))
+							        Logger.getLogger(getClass().getName()).log(Level.INFO, "SQL failed: " + sql, ex);
 							}
 						}
 						cmd = new StringBuilder();


### PR DESCRIPTION
Happens on first startup because Derby has no convenient
DROP TABLE IF EXISTS
This error is now ignored.

Fixes #254
