### PR TITLE
o.c.u.pvmanager, org.epics.vtype: better handling of unsupported notification types

### DIFF
--- a/core/plugins/org.csstudio.utility.pvmanager/src/org/epics/pvmanager/NotificationSupport.java
+++ b/core/plugins/org.csstudio.utility.pvmanager/src/org/epics/pvmanager/NotificationSupport.java
@@ -8,7 +8,7 @@ import org.epics.pvmanager.util.NullUtils;
 
 /**
  * Dedicated notification type support.
- * 
+ *
  * @param <T> type for which the notifications are prepared
  * @author bknerr
  * @since 17.01.2011
@@ -23,7 +23,7 @@ public abstract class NotificationSupport<T> extends TypeSupport<T> {
     public NotificationSupport(Class<T> clazz) {
         super(clazz, NotificationSupport.class);
     }
-    
+
     /**
      * Returns the final value by using the appropriate type support.
      *
@@ -33,17 +33,35 @@ public abstract class NotificationSupport<T> extends TypeSupport<T> {
      * @return the value to be notified
      */
     public static <T> Notification<T> notification(final T oldValue, final T newValue) {
+        NotificationSupport<T> support = findNotificationSupportFor(newValue);
+        return support.prepareNotification(oldValue, newValue);
+    }
+    
+    /**
+     * Retrieves the notification support based on the given value.
+     * <p>
+     * If no support is found, an exception is thrown.
+     * 
+     * @param <T> value type
+     * @param newValue the value; can't be null
+     * @return the notification support
+     */
+    public static <T> NotificationSupport<T> findNotificationSupportFor(final T newValue) {
         @SuppressWarnings("unchecked")
         Class<T> typeClass = (Class<T>) newValue.getClass();
-        NotificationSupport<T> support =
-            (NotificationSupport<T>) findTypeSupportFor(NotificationSupport.class,
-                                                              typeClass);
+        NotificationSupport<T> support
+                = (NotificationSupport<T>) findTypeSupportFor(NotificationSupport.class,
+                        typeClass);
         if (support == null) {
-            throw new RuntimeException("Values for type " + typeClass.getSimpleName() + " are not setup for notification.");
+            String name = typeClass.getSimpleName();
+            if (name == null || name.trim().isEmpty()) {
+                name = typeClass.getName();
+            }
+            throw new RuntimeException("Final value can't be of type " + name + ".");
         }
-        return support.prepareNotification(oldValue, newValue);
-    }    
-    
+        return support;
+    }
+
     /**
      * Given the old and new value, prepare the final value that will be notified.
      * This method is guaranteed to be called in the notification thread (the
@@ -55,7 +73,7 @@ public abstract class NotificationSupport<T> extends TypeSupport<T> {
      * @return the value to be notified
      */
     public abstract Notification<T> prepareNotification(final T oldValue, final T newValue);
-    
+
     /**
      * Support for notification of immutable types. Notification is enabled if
      * the value changed according to {@link Object#equals(java.lang.Object) }.
@@ -66,13 +84,13 @@ public abstract class NotificationSupport<T> extends TypeSupport<T> {
      */
     public static <T> NotificationSupport<T> immutableTypeSupport(final Class<T> clazz) {
         return new NotificationSupport<T>(clazz) {
-          @Override
-          public Notification<T> prepareNotification(final T oldValue, final T newValue) {
-              if (NullUtils.equalsOrBothNull(oldValue, newValue)) {
-                return new Notification<T>(false, null);
+            @Override
+            public Notification<T> prepareNotification(final T oldValue, final T newValue) {
+                if (NullUtils.equalsOrBothNull(oldValue, newValue)) {
+                    return new Notification<T>(false, null);
+                }
+                return new Notification<T>(true, newValue);
             }
-              return new Notification<T>(true, newValue);
-          }
         };
     }
 }

--- a/core/plugins/org.csstudio.utility.pvmanager/src/org/epics/pvmanager/PVReaderDirector.java
+++ b/core/plugins/org.csstudio.utility.pvmanager/src/org/epics/pvmanager/PVReaderDirector.java
@@ -247,6 +247,9 @@ public class PVReaderDirector<T> {
         try {
             // Tries to calculate the value
             newValue = function.readValue();
+            if (newValue != null) {
+                NotificationSupport.findNotificationSupportFor(newValue);
+            }
             calculationSucceeded = true;
         } catch(RuntimeException ex) {
             // Calculation failed
@@ -300,8 +303,10 @@ public class PVReaderDirector<T> {
                             Notification<T> notification =
                                     NotificationSupport.notification(pv.getValue(), finalValue);
                             // Remember to notify anyway if an exception need to be notified
-                            if (notification.isNotificationNeeded() || pv.isLastExceptionToNotify() || pv.isReadConnectionToNotify()) {
+                            if (notification.isNotificationNeeded()) {
                                 pv.setValue(notification.getNewValue());
+                            } else if (pv.isLastExceptionToNotify() || pv.isReadConnectionToNotify()) {
+                                pv.firePvValueChanged();
                             }
                         } else {
                             // Remember to notify anyway if an exception need to be notified

--- a/core/plugins/org.epics.vtype/src/org/epics/vtype/table/VTableFactory.java
+++ b/core/plugins/org.epics.vtype/src/org/epics/vtype/table/VTableFactory.java
@@ -315,24 +315,46 @@ public class VTableFactory {
     } 
 
     public static ListNumberProvider range(final double min, final double max) {
-        return new ListNumberProvider(double.class) {
-
-            @Override
-            public ListNumber createListNumber(final int size) {
-                return ListNumbers.linearListFromRange(min, max, size);
-            }
-        };
+        return new Range(min, max);
     }
     
-    public static ListNumberProvider step(final double initialValue, final double increment) {
-        return new ListNumberProvider(double.class) {
+    private static class Range extends ListNumberProvider {
+        
+        private final double min;
+        private final double max;
 
-            @Override
-            public ListNumber createListNumber(int size) {
-                return ListNumbers.linearList(initialValue, increment, size);
-            }
-        };
+        public Range(double min, double max) {
+            super(double.class);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public ListNumber createListNumber(int size) {
+            return ListNumbers.linearListFromRange(min, max, size);
+        }
+    };
+    
+    public static ListNumberProvider step(final double initialValue, final double increment) {
+        return new Step(initialValue, increment);
     }
+    
+    private static class Step extends ListNumberProvider {
+        
+        private final double initialValue;
+        private final double increment;
+
+        public Step(double initialValue, double increment) {
+            super(double.class);
+            this.initialValue = initialValue;
+            this.increment = increment;
+        }
+
+        @Override
+        public ListNumber createListNumber(int size) {
+            return ListNumbers.linearList(initialValue, increment, size);
+        }
+    };
     
     public static VTable extractRow(VTable vTable, int row) {
         if (vTable == null || row >= vTable.getRowCount() || row < 0) {


### PR DESCRIPTION
Should not use anonymous inner classes, as they don't have a simpleName
Exception should be handled through normal exception support

Solves #164
