### PR TITLE
Many MANIFEST.MF: Replace org.junit4 with org.junit (4.8.2)

### DIFF
--- a/applications/plugins/org.csstudio.alarm.beast.annunciator/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.annunciator/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.alarm.beast.annunciator;singleton:=true
 Bundle-Version: 3.1.0.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
-Require-Bundle: org.junit4;bundle-version="4.3.1",
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.help;bundle-version="3.4.1",
  org.eclipse.ui;bundle-version="3.5.0",

--- a/applications/plugins/org.csstudio.alarm.beast.configtool/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.configtool/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.alarm.beast.configtool;singleton:=true
 Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Bundle-Description: BEAST Command-line configuration tool
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.logging;bundle-version="0.0.1",
  org.csstudio.security;bundle-version="1.0.0",

--- a/applications/plugins/org.csstudio.alarm.beast.msghist/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.msghist/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Description: Table viewer for CSS Message log
 Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Bundle-Localization: plugin
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.jface;resolution:=optional,
  org.eclipse.rap.jface;resolution:=optional,
  org.eclipse.core.runtime,

--- a/applications/plugins/org.csstudio.alarm.beast.notifier/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.notifier/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.alarm.beast.notifier;singleton:=true
 Bundle-Version: 3.2.2.qualifier
 Bundle-Vendor: Fred Arnaud <frederic.arnaud@iter.org> - ITER
 Bundle-Description: BEAST Alarm Notification
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.alarm.beast;bundle-version="3.2.0",
  org.csstudio.apputil,

--- a/applications/plugins/org.csstudio.alarm.beast.server/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.server/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.alarm.beast.server;singleton:=true
 Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Bundle-Description: BEAST Alarm Server
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.logging;bundle-version="0.0.1",
  org.epics.util;bundle-version="0.1.0",

--- a/applications/plugins/org.csstudio.alarm.beast.ui.alarmtable/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.ui.alarmtable/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.2.1.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Bundle-Description: BEAST Alarm Table
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui;resolution:=optional,
  org.eclipse.rap.ui;resolution:=optional,

--- a/applications/plugins/org.csstudio.alarm.beast.ui.alarmtree/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.ui.alarmtree/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.0.1.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Bundle-Description: BEAST Alarm Tree
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.jface;resolution:=optional,
  org.eclipse.rap.jface;resolution:=optional,
  org.eclipse.core.runtime,

--- a/applications/plugins/org.csstudio.alarm.beast.ui.areapanel/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.ui.areapanel/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.ui;bundle-version="3.6.0";resolution:=optional,
  org.eclipse.rap.ui;resolution:=optional,

--- a/applications/plugins/org.csstudio.alarm.beast.ui/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.ui/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Bundle-Description: BEAST User Interface library
 Bundle-Localization: plugin
-Require-Bundle: org.junit4;bundle-version="4.3.1",
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.5.0";resolution:=optional,
  org.eclipse.ui;resolution:=optional,

--- a/applications/plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.alarm.beast;singleton:=true
 Bundle-Version: 3.2.2.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Bundle-Description: BEAST library: Alarm model, ...
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.help,
  org.csstudio.csdata;bundle-version="3.0.0",

--- a/applications/plugins/org.csstudio.apputil.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.apputil.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.csstudio.apputil;bundle-version="3.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
-Require-Bundle: org.junit4
+Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/applications/plugins/org.csstudio.archive.config.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.config.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.archive.config.test
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.apputil;bundle-version="3.0.0",
  org.csstudio.archive.config;bundle-version="1.0.0",
  org.csstudio.archive.config.rdb;bundle-version="1.0.0"

--- a/applications/plugins/org.csstudio.archive.engine/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.engine/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.csstudio.archive.engine.Activator
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Archive Sample Engine, writes data to RDB
 Require-Bundle: org.eclipse.core.runtime,
- org.junit4,
+ org.junit;bundle-version="4.8.2",
  javax.servlet,
  org.csstudio.logging;bundle-version="0.0.1",
  org.csstudio.security;bundle-version="1.0.0",

--- a/applications/plugins/org.csstudio.archive.reader.archiverecord/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.reader.archiverecord/META-INF/MANIFEST.MF
@@ -9,6 +9,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.csstudio.utility.pv;bundle-version="1.1.1",
  org.csstudio.utility.pv.epics;bundle-version="1.1.1",
  org.csstudio.archive.reader;bundle-version="2.0.2",
- org.junit4;bundle-version="4.8.1"
+ org.junit;bundle-version="4.8.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/applications/plugins/org.csstudio.archive.reader.channelarchiver/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.reader.channelarchiver/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.archive.reader.channelarchiver;singleton:=true
 Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.archive.reader;bundle-version="3.2.0",
  org.csstudio.apputil;bundle-version="1.0.11"
 Bundle-ClassPath: lib/commons-codec/commons-codec-1.3.jar,

--- a/applications/plugins/org.csstudio.archive.reader.rdb.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.reader.rdb.test/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Fragment-Host: org.csstudio.archive.reader.rdb;bundle-version="3.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.apputil;bundle-version="3.0.0"

--- a/applications/plugins/org.csstudio.archive.writer.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.writer.test/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.csstudio.archive.writer.test
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.apputil;bundle-version="3.0.0",
  org.csstudio.archive.writer;bundle-version="1.0.0",
  org.csstudio.archive.writer.rdb;bundle-version="1.0.0",

--- a/applications/plugins/org.csstudio.debugging.jmsmonitor/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.debugging.jmsmonitor/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Localization: plugin
 Bundle-Description: JMS Message Monitor/Debug tool
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.ui,
  org.eclipse.ui.views,

--- a/applications/plugins/org.csstudio.debugging.rdbshell/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.debugging.rdbshell/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: RDB Shell
 Bundle-SymbolicName: org.csstudio.debugging.rdbshell;singleton:=true
 Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
-Require-Bundle: org.junit4;bundle-version="4.3.1",
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.ui;bundle-version="3.4.0",
  org.csstudio.platform.utility.rdb;bundle-version="1.0.0"

--- a/applications/plugins/org.csstudio.diag.epics.pvmanager.pvtree/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.diag.epics.pvmanager.pvtree/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.csstudio.diag.epics.pvtree.Plugin
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Display EPICS record link hierarchy
 Bundle-Localization: plugin
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.epics.util;bundle-version="0.1.0",

--- a/applications/plugins/org.csstudio.diag.epics.pvtree/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.diag.epics.pvtree/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.csstudio.diag.epics.pvtree.Plugin
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Display EPICS record link hierarchy
 Bundle-Localization: plugin
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.epics.util;bundle-version="0.1.0",

--- a/applications/plugins/org.csstudio.diag.postanalyser/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.diag.postanalyser/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.2.0.qualifier
 Bundle-Activator: org.csstudio.diag.postanalyser.Activator
 Bundle-Description: Fitting and correlation for Data Browser
 Bundle-Localization: plugin
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.epics.vtype,

--- a/applications/plugins/org.csstudio.display.pace/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.display.pace/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.display.pace;singleton:=true
 Bundle-Version: 3.2.1.qualifier
 Bundle-Localization: plugin
 Bundle-Description: Tabular editor for PVs used in several devices, with confirmation and logging
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.jface,
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.4.0",

--- a/applications/plugins/org.csstudio.display.rdbtable/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.display.rdbtable/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Description: Generic editor for RDB tables, configured via XML file for the 'SELECT', 'UPDATE', ... commands
-Require-Bundle: org.junit4;bundle-version="4.5.0",
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.core.resources;bundle-version="3.5.0",
  org.eclipse.ui;bundle-version="3.5.0",

--- a/applications/plugins/org.csstudio.email.ui/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.email.ui/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin
-Require-Bundle: org.junit4;resolution:=optional,
+Require-Bundle: org.junit;bundle-version="4.8.2";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.jface;bundle-version="3.5.0";resolution:=optional,
  org.eclipse.help;bundle-version="3.4.1",

--- a/applications/plugins/org.csstudio.logging.jms2rdb/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.logging.jms2rdb/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.logging.jms2rdb;singleton:=true
 Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Tool that writes JMS messages (log, alarm, ...) to an RDB
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.logging;bundle-version="0.0.1",
  org.csstudio.utility.httpd,

--- a/applications/plugins/org.csstudio.opibuilder.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder.test/META-INF/MANIFEST.MF
@@ -8,6 +8,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-ClassPath: lib/rhino/js.jar,
  .
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.resources,
  org.csstudio.utility.pvmanager.loc;bundle-version="3.1.0"

--- a/applications/plugins/org.csstudio.swt.chart/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.swt.chart/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Localization: plugin
 Bundle-Description: SWT plotting library
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.jface,
  org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/applications/plugins/org.csstudio.swt.widgets.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.swt.widgets.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Fragment-Host: org.csstudio.swt.widgets;bundle-version="1.0.2"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Require-Bundle: org.junit4;bundle-version="4.8.1"
+Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/applications/plugins/org.csstudio.swt.xygraph.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.swt.xygraph.test/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: org.csstudio.swt.xygraph.test
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.csstudio.swt.xygraph;bundle-version="1.1.3"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Require-Bundle: org.junit4
+Require-Bundle: org.junit;bundle-version="4.8.2"
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS

--- a/applications/plugins/org.csstudio.ui.menu.pvscript/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.ui.menu.pvscript/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.ui;bundle-version="3.6.0",
  org.eclipse.help;bundle-version="3.5.0",

--- a/applications/plugins/org.csstudio.utility.jmssendcmd/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.utility.jmssendcmd/META-INF/MANIFEST.MF
@@ -11,4 +11,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.csstudio.apputil;bundle-version="1.0.6",
  org.csstudio.platform.libs.jms;bundle-version="1.1.0",
  org.csstudio.platform.utility.jms;bundle-version="1.0.0",
- org.junit4
+ org.junit;bundle-version="4.8.2"

--- a/applications/plugins/org.csstudio.utility.speech/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.utility.speech/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Speech Plug-in
 Bundle-SymbolicName: org.csstudio.utility.speech
 Bundle-Version: 1.3.1.qualifier
 Require-Bundle: org.eclipse.core.runtime,
- org.junit4;bundle-version="4.3.1"
+ org.junit;bundle-version="4.8.2"
 Export-Package: org.csstudio.utility.speech
 Bundle-ClassPath: lib/cmu_time_awb.jar,
  lib/cmu_us_kal.jar,

--- a/core/plugins/org.csstudio.autocomplete.pvmanager.formula/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.autocomplete.pvmanager.formula/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.autocomplete.pvmanager.formula;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.csstudio.autocomplete.pvmanager.formula.Activator
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.utility.pvmanager.extra,
  org.csstudio.autocomplete

--- a/core/plugins/org.csstudio.autocomplete.pvmanager.loc/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.autocomplete.pvmanager.loc/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.autocomplete.pvmanager.loc;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.csstudio.autocomplete.pvmanager.loc.Activator
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.utility.pvmanager.loc,
  org.csstudio.autocomplete

--- a/core/plugins/org.csstudio.autocomplete.pvmanager.sim/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.autocomplete.pvmanager.sim/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.autocomplete.pvmanager.sim;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.csstudio.autocomplete.pvmanager.sim.Activator
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.utility.pvmanager.sim,
  org.csstudio.autocomplete

--- a/core/plugins/org.csstudio.autocomplete.pvmanager.sys/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.autocomplete.pvmanager.sys/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.autocomplete.pvmanager.sys;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.csstudio.autocomplete.pvmanager.sys.Activator
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.utility.pvmanager.sys,
  org.csstudio.autocomplete

--- a/core/plugins/org.csstudio.autocomplete/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.autocomplete/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.autocomplete;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.csstudio.autocomplete.AutoCompletePlugin
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui;resolution:=optional,
  org.eclipse.rap.ui;resolution:=optional,

--- a/core/plugins/org.csstudio.data.test/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.data.test/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Fragment-Host: org.csstudio.data;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Description: Unit tests for Control System Data Structures
-Require-Bundle: org.junit4;bundle-version="4.8.1"
+Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/core/plugins/org.csstudio.java.test/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.java.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Fragment-Host: org.csstudio.java;bundle-version="3.1.0"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Require-Bundle: org.junit4;bundle-version="4.8.1"
+Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/core/plugins/org.csstudio.platform.libs.jms/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.platform.libs.jms/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 5.4.2.qualifier
 Bundle-Activator: org.csstudio.platform.libs.jms.JmsPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
- org.junit4
+ org.junit;bundle-version="4.8.2"
 Eclipse-LazyStart: true
 Bundle-ClassPath: .,
  libs/activemq-all-5.4.2.jar,

--- a/core/plugins/org.csstudio.platform.utility.jms/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.platform.utility.jms/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: JMS Utility Plug-in
 Bundle-SymbolicName: org.csstudio.platform.utility.jms;singleton:=true
 Bundle-Version: 1.1.3.qualifier
 Bundle-Activator: org.csstudio.platform.utility.jms.Activator
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.platform.libs.jms;visibility:=reexport,
  org.eclipse.core.runtime
 Export-Package: org.csstudio.platform.utility.jms,

--- a/core/plugins/org.csstudio.simplepv.test/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.simplepv.test/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Xihui Chen<chenx1@ornl.gov>
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.csstudio.simplepv;bundle-version="1.0.0",
  org.eclipse.core.runtime,
- org.junit4
+ org.junit;bundle-version="4.8.2"
 Export-Package: org.csstudio.simplepv.test

--- a/core/plugins/org.csstudio.utility.pv.epics.test/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.utility.pv.epics.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
 Fragment-Host: org.csstudio.utility.pv.epics;bundle-version="3.1.4"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4
+Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/core/plugins/org.csstudio.utility.pv.simu.test/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.utility.pv.simu.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Fragment-Host: org.csstudio.utility.pv.simu;bundle-version="3.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4
+Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/products/SNS/plugins/org.csstudio.diag.pvfields.sns/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.diag.pvfields.sns/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SNS Plugin for PVFields RDB Data
 Bundle-SymbolicName: org.csstudio.diag.pvfields.sns;singleton:=true
 Bundle-Version: 3.2.0.qualifier
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.help,
  org.csstudio.platform.utility.rdb;bundle-version="1.2.0",

--- a/products/SNS/plugins/org.csstudio.diag.pvutil.sns/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.diag.pvutil.sns/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SNS PV Utility SNSRDB Data
 Bundle-SymbolicName: org.csstudio.diag.pvutil.sns;singleton:=true
 Bundle-Version: 3.0.0.qualifier
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.ui.views,

--- a/products/SNS/plugins/org.csstudio.diag.pvutil/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.diag.pvutil/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SNS PV Utility Plug-in
 Bundle-SymbolicName: org.csstudio.diag.pvutil;singleton:=true
 Bundle-Version: 3.0.0.qualifier
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.csstudio.apputil.ui,

--- a/products/SNS/plugins/org.csstudio.diag.rack.sns/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.diag.rack.sns/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: SNS Rack Utility Data Supplier
 Bundle-SymbolicName: org.csstudio.diag.rack.sns;singleton:=true
 Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Dave Purcell <purcelljd@ornl.gov> - SNS
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.ui.views,

--- a/products/SNS/plugins/org.csstudio.diag.rack/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.diag.rack/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Rack Plug-in
 Bundle-SymbolicName: org.csstudio.diag.rack;singleton:=true
 Bundle-Description: Display rack profiles, i.e. devices in rack layout
 Bundle-Version: 3.0.0.qualifier
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.ui.views,

--- a/products/SNS/plugins/org.csstudio.logbook.sns/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.logbook.sns/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: SNS Elog
 Bundle-SymbolicName: org.csstudio.logbook.sns;singleton:=true
 Bundle-Version: 3.2.1.qualifier
 Bundle-Activator: org.csstudio.logbook.sns.Activator
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.csstudio.logbook;bundle-version="3.1.0";visibility:=reexport,
  org.csstudio.platform.utility.rdb;bundle-version="1.6.0",

--- a/products/SNS/plugins/org.csstudio.utility.chat/META-INF/MANIFEST.MF
+++ b/products/SNS/plugins/org.csstudio.utility.chat/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Localization: plugin
-Require-Bundle: org.junit4,
+Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.jface,
  org.eclipse.ui;bundle-version="3.6.0",


### PR DESCRIPTION
Eclipse 3 has junit plugins org.junit (3.8), org.junit (4.8) and org.junit4, and the latter was often picked to get version 4.x.
Eclipse 3 has no longer has org.junit4.

By changing the MANIFEST.MFs to use org.junit;bundle-version="4.8.2", the code works for both branches.

This which makes it a lot easier to compare the two branches, because many plugins only differ regarding the junit settings. Comparing master and 4.x.x now really limits the differences to E4 related things!

Fixes #326 
