### PR TITLE
o.c.trends.databrowser: Skip printer check on GTK to avoid hangups

### DIFF
--- a/applications/plugins/org.csstudio.trends.databrowser2/ChangeLog.html
+++ b/applications/plugins/org.csstudio.trends.databrowser2/ChangeLog.html
@@ -9,6 +9,12 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.trends.databrowser2.</p>
 
+<h2>Version 3.2.14 - 2014-01-28</h2>
+<ul>
+  <li>Skip printer check on GTK to avoid hangups.</li>
+</ul>
+
+
 <h2>Version 3.2.12 - 2013-11-22</h2>
 <ul>
   <li>Add X and Y labels on the axis when the Show value labels option is activated. </li>

--- a/applications/plugins/org.csstudio.trends.databrowser2/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.trends.databrowser2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Data Browser
 Bundle-SymbolicName: org.csstudio.trends.databrowser2;singleton:=true
-Bundle-Version: 3.2.12.qualifier
+Bundle-Version: 3.2.14.qualifier
 Bundle-Description: Strip chart type display of live and historic data
 Bundle-Activator: org.csstudio.trends.databrowser2.Activator
 Bundle-Localization: plugin

--- a/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/editor/PrintAction.java
+++ b/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/editor/PrintAction.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 import org.csstudio.swt.xygraph.figures.XYGraph;
 import org.csstudio.trends.databrowser2.Messages;
 import org.eclipse.jface.action.Action;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
@@ -49,20 +50,27 @@ public class PrintAction extends Action
         this.shell = shell;
         this.graph = graph;
 
-        // Only enable if printing is supported
-        final PrinterData[] printers = Printer.getPrinterList();
-        final Logger logger = Logger.getLogger(getClass().getName());
-        if (printers != null)
+        // Skip printer check on GTK because of hangups:
+        // https://bugs.eclipse.org/bugs/show_bug.cgi?id=153936,
+        // -Dorg.eclipse.swt.internal.gtk.disablePrinting if there are no printers,
+        // https://github.com/ControlSystemStudio/cs-studio/issues/83
+        if (! SWT.getPlatform().equals("gtk"))
         {
-        	logger.fine("Available printers:");
-        	for (PrinterData p : printers)
-        		logger.fine("Printer: " + p.name + " (" + p.driver + ")");
-        	setEnabled(printers.length > 0);
-        }
-        else
-        {
-        	logger.fine("No available printers");
-        	setEnabled(false);
+            // Only enable if printing is supported.
+            final PrinterData[] printers = Printer.getPrinterList();
+            final Logger logger = Logger.getLogger(getClass().getName());
+            if (printers != null)
+            {
+            	logger.fine("Available printers:");
+            	for (PrinterData p : printers)
+            		logger.fine("Printer: " + p.name + " (" + p.driver + ")");
+            	setEnabled(printers.length > 0);
+            }
+            else
+            {
+            	logger.fine("No available printers");
+            	setEnabled(false);
+            }
         }
     }
 


### PR DESCRIPTION
Avoids #356 
