### PR TITLE
Date format fix

### DIFF
--- a/core/plugins/org.epics.vtype/src/org/epics/vtype/VTypeToString.java
+++ b/core/plugins/org.epics.vtype/src/org/epics/vtype/VTypeToString.java
@@ -57,7 +57,7 @@ public class VTypeToString {
         return timeFormat.format(time.getTimestamp()) + "(" + time.getTimeUserTag()+ ")";
     }
     
-    private static final TimestampFormat timeFormat = new TimestampFormat("yyyy/MM/dd hh:mm:ss.SSS");
+    private static final TimestampFormat timeFormat = new TimestampFormat("yyyy-MM-dd HH:mm:ss.SSS");
     
     private static void appendTime(StringBuilder builder, Time time) {
         builder.append(", ").append(timeFormat.format(time.getTimestamp()));


### PR DESCRIPTION
This fixes a bug in the tooltip display in OPI (and most likely in other places). The time was shown as 5:50, when it should have been 5:50pm, or 17:50.
