### PR TITLE
o.c.swt.widgets: Allow resources from web links with spaces

### DIFF
--- a/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/util/ResourceUtil.java
+++ b/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/util/ResourceUtil.java
@@ -105,6 +105,7 @@ public class ResourceUtil {
 
         // Must be a URL
         // Allow URLs with spaces. Ideally, the URL class would handle this?
+        urlString = urlString.replaceAll(" ", "%20");
         URI uri = new URI(urlString);
         final URL url = uri.toURL();
         return  openURLStream(url);


### PR DESCRIPTION
BOY Images (and *.opi files in general) didn't load if the URL contained
spaces. Need "%20" for that, but at the same time must keep the space
when loading the file locally from file system.

Fixes #401 
