### PR TITLE
o.c.swt.xygraph: Update version number, add .qualifier

### DIFF
--- a/applications/plugins/org.csstudio.swt.xygraph/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.swt.xygraph/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.rap.draw2d.compatibility;bundle-version="1.5.0";resolution:=optional
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 2.0.2
+Bundle-Version: 2.0.3.qualifier
 Bundle-Name: XYGraph Plug-in
 Bundle-Activator: org.csstudio.swt.xygraph.Activator
 Bundle-ManifestVersion: 2


### PR DESCRIPTION
After IAnnotationListener was added, the version number had not been
updated. This broke the self-update of CSS installations.

Fixes #416

There are a few other plugins that don't have ".qualifier" in their version number.
For those used at SNS, the only other one is org.antlr.runtime.
Since that's an imported plugin, we hope the next person who updates it will update the version number.
For other plugins without ".qualifier" in their version number, it's left to the people who use them to decide if it is required or not.
