### PR TITLE
Bugfix: the axis got messed up (#419)

### DIFF
--- a/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/Model.java
+++ b/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/Model.java
@@ -1136,21 +1136,27 @@ public class Model
 		}
 		
 		if (graphSettings != null) {
-			for (AxisSettings s : graphSettings.getAxisSettingsList()) {
-				ColorSettings fc = s.getForegroundColor();
-				ColorSettings gc = s.getMajorGridColor();
-				AxisConfig config = new AxisConfig(true, s.getTitle(), 
-						FontDataUtil.getFontData(s.getTitleFont()), 
-						FontDataUtil.getFontData(s.getScaleFont()), 
-						new RGB(fc.getRed(),fc.getGreen(),fc.getBlue()), 
-						s.getRange().getLower(), s.getRange().getUpper(),
-						s.isAutoScale(), s.isLogScale(), s.isShowMajorGrid(),
-						s.isDashGridLine(),new RGB(gc.getRed(),gc.getGreen(),gc.getBlue()),
-						s.isAutoFormat(), s.isDateEnabled(), s.getFormatPattern());
-				if (timeAxis == null) {
-					timeAxis = config;
-				} else {
-					addAxis(config);
+			//backward compatibility for those plts created with duplicated info (axis 
+			//tag and axis settings both describing the same axis)
+			if (graphSettings.getAxisSettingsList().size() == axes.size() + 1 || axes.size() == 0) {
+				timeAxis = null;
+				axes.clear();
+				for (AxisSettings s : graphSettings.getAxisSettingsList()) {
+					ColorSettings fc = s.getForegroundColor();
+					ColorSettings gc = s.getMajorGridColor();
+					AxisConfig config = new AxisConfig(true, s.getTitle(), 
+							FontDataUtil.getFontData(s.getTitleFont()), 
+							FontDataUtil.getFontData(s.getScaleFont()), 
+							new RGB(fc.getRed(),fc.getGreen(),fc.getBlue()), 
+							s.getRange().getLower(), s.getRange().getUpper(),
+							s.isAutoScale(), s.isLogScale(), s.isShowMajorGrid(),
+							s.isDashGridLine(),new RGB(gc.getRed(),gc.getGreen(),gc.getBlue()),
+							s.isAutoFormat(), s.isDateEnabled(), s.getFormatPattern());
+					if (timeAxis == null) {
+						timeAxis = config;
+					} else {
+						addAxis(config);
+					}
 				}
 			}
 		

--- a/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/persistence/XYGraphSettingsUtil.java
+++ b/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/persistence/XYGraphSettingsUtil.java
@@ -1,5 +1,7 @@
 package org.csstudio.trends.databrowser2.persistence;
 
+import java.util.List;
+
 import org.csstudio.swt.xygraph.figures.Annotation;
 import org.csstudio.swt.xygraph.figures.Annotation.CursorLineStyle;
 import org.csstudio.swt.xygraph.figures.Axis;
@@ -95,17 +97,27 @@ public class XYGraphSettingsUtil {
 		xyGraph.setTransparent(settings.isTransparent());
 
 		int i = 0;
-		for (AxisSettings axisSettings : settings.getAxisSettingsList())
-			restoreAxisPropsFromSettings(xyGraph.getAxisList().get(i++),
+		List<Axis> axisList = xyGraph.getAxisList();
+		for (AxisSettings axisSettings : settings.getAxisSettingsList()) {
+			if (axisList.size() > i) {
+				restoreAxisPropsFromSettings(axisList.get(i++),
 					axisSettings);
+			}
+		}
 		i = 0;
+		List<Trace> traceList = xyGraph.getPlotArea().getTraceList();
 		for (TraceSettings traceSettings : settings.getTraceSettingsList())
-			restoreTracePropsFromSettings(xyGraph, xyGraph.getPlotArea()
+			if (traceList.size() > i) {
+				restoreTracePropsFromSettings(xyGraph, xyGraph.getPlotArea()
 					.getTraceList().get(i++), traceSettings);
+			}
 		i = 0;
+		List<Annotation> annotationList = xyGraph.getPlotArea().getAnnotationList();
 		for (AnnotationSettings annotationSettings : settings.getAnnotationSettingsList())
-			restoreAnnotationPropsFromSettings(xyGraph, xyGraph.getPlotArea()
+			if (annotationList.size() > i) {
+				restoreAnnotationPropsFromSettings(xyGraph, xyGraph.getPlotArea()
 					.getAnnotationList().get(i++), annotationSettings);
+			}
 	}
 
 	private static void saveAnnotationPropsToSettings(XYGraph xyGraph,


### PR DESCRIPTION
Fixed the issue described in #419. It happened with PLT files created after XYGraphSettings were introduced and before the recent refactorization (in those case the plt file contained the axis settings twice: once within the <axis> tag and once withing the <axisSettings> tag).
