### PR TITLE
o.c.ui.menu.app: Define "navigator" location to avoid "Search" gap

### DIFF
--- a/applications/plugins/org.csstudio.ui.menu.app/plugin.xml
+++ b/applications/plugins/org.csstudio.ui.menu.app/plugin.xml
@@ -174,6 +174,18 @@
       </menuContribution>
       <menuContribution
             allPopups="false"
+            locationURI="menu:org.eclipse.ui.main.menu?before=additions">
+         <!-- The "Search" menu anchors itself off path="navigate".
+              If that is not defined, an ActionSetSeparator("navigate")
+              will be auto-created, resulting in an odd gap in the menu bar.
+           -->
+         <separator
+               name="navigate"
+               visible="false">
+         </separator>
+      </menuContribution>
+      <menuContribution
+            allPopups="false"
             locationURI="menu:org.eclipse.ui.main.menu?endof=additions">
          <menu
                id="window"


### PR DESCRIPTION
Fixed #377 
