### PR TITLE
Trend auto refresh bugfix in combination with BEAUtY or old archiver

### DIFF
--- a/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVSamples.java
+++ b/applications/plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVSamples.java
@@ -265,6 +265,9 @@ public class PVSamples extends PlotSamples
     synchronized boolean isHistoryRefreshNeeded(Timestamp startTime, Timestamp endTime) {
     	//if already waiting for history to be loaded, wait on
 	   	if (emptyHistoryOnAdd) return false;
+	   	//if the live samples have more than 15% of capacity left before old data is erased,
+	   	//refresh is not yet needed
+	   	if (samplesAddedSinceLastRefresh < live.getCapacity()*0.85) return false;
     	//if live data hasn't reached capacity, do not refresh anything
     	if (live.getSize() < live.getCapacity() || live.getSize() == 0) return false;
     	//if there is no history data, there is nothing to refresh anyway


### PR DESCRIPTION
Bugfix: BEAUtY and old archiver persist data periodically (e.g. ever 30 seconds). When data are requested by clients only the data that have been persisted is returned. Data that are still in the engine's buffer are not returned. This can cause the automatic refresh to repeatedly fetch data.
