### PR TITLE
opibuilder: Add preference for default style 'classic' or 'native'

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
@@ -3,12 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY Widgets Plug-in
 Bundle-Description: Widgets for BOY
 Bundle-SymbolicName: org.csstudio.opibuilder.widgets;singleton:=true
-Bundle-Version: 3.2.9.qualifier
+Bundle-Version: 3.2.16.qualifier
 Bundle-Activator: org.csstudio.opibuilder.widgets.Activator
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.core.runtime,
- org.csstudio.opibuilder,
+ org.csstudio.opibuilder;bundle-version="3.2.16",
  org.csstudio.swt.xygraph,
  org.eclipse.core.resources;resolution:=optional,
  org.eclipse.ui.browser;resolution:=optional,

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ActionButtonModel.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ActionButtonModel.java
@@ -8,6 +8,7 @@
 package org.csstudio.opibuilder.widgets.model;
 
 import org.csstudio.opibuilder.model.AbstractPVWidgetModel;
+import org.csstudio.opibuilder.preferences.PreferencesHelper;
 import org.csstudio.opibuilder.properties.ActionsProperty;
 import org.csstudio.opibuilder.properties.BooleanProperty;
 import org.csstudio.opibuilder.properties.ComboProperty;
@@ -140,7 +141,7 @@ public class ActionButtonModel extends AbstractPVWidgetModel implements ITextMod
 	protected void configureProperties() {
 		
 		addProperty(new ComboProperty(PROP_STYLE, "Style", WidgetPropertyCategory.Basic,
-				Style.stringValues(), Style.NATIVE.ordinal()));
+				Style.stringValues(), getDefaultStyle().ordinal()));
 		
 		addProperty(new StringProperty(PROP_TEXT, "Text",
 				WidgetPropertyCategory.Display, "$(actions)", true)); //$NON-NLS-1$
@@ -177,7 +178,7 @@ public class ActionButtonModel extends AbstractPVWidgetModel implements ITextMod
 				setPropertyValue(PROP_WIDGET_TYPE, "Action Button");
 			}
 			else
-				setStyle(Style.CLASSIC);			
+				setStyle(getDefaultStyle());
 		}		
 	}
 	
@@ -232,6 +233,13 @@ public class ActionButtonModel extends AbstractPVWidgetModel implements ITextMod
 	    return (Boolean)getProperty(PROP_TOGGLE_BUTTON).getPropertyValue();
 	}
 	
+    /** @return Default for 'style' based on preferences */
+    private Style getDefaultStyle() {
+        return PreferencesHelper.isDefaultStyleClassic()
+               ? Style.CLASSIC
+               : Style.NATIVE;
+    }
+    
 	public Style getStyle(){
 		return Style.values()[(Integer)getProperty(PROP_STYLE).getPropertyValue()];
 	}

--- a/applications/plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY base plugin
 Bundle-Description: Base plugin of BOY
 Bundle-SymbolicName: org.csstudio.opibuilder;singleton:=true
-Bundle-Version: 3.2.10.qualifier
+Bundle-Version: 3.2.16.qualifier
 Bundle-Activator: org.csstudio.opibuilder.OPIBuilderPlugin
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-Localization: plugin

--- a/applications/plugins/org.csstudio.opibuilder/preferences.ini
+++ b/applications/plugins/org.csstudio.opibuilder/preferences.ini
@@ -61,10 +61,13 @@ default_email_sender=
 #PV connection layer pv factory ID, for example, utility_pv or pvmanager
 pv_connection_layer=utility_pv
 
+# Widgets that support a 'Native' or 'Classic' style like the Action Button:
+# Should the default style be classic?
+# Also used when loading older *.opi files that do not specify a style
+default_to_classic_style=true
 
 # There are more macros, see source code for
 # org.csstudio.opibuilder.preferences.PreferencesHelper
-
 
 
 #### WebOPI preferences ###

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/CommonPreferencePage.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/CommonPreferencePage.java
@@ -85,6 +85,13 @@ public class CommonPreferencePage extends FieldEditorPreferencePage
 				"Enable this may result in undesired \ninformation displayed in BOY Console.");
 		addField(displaySysOutEditor);
 		
+		BooleanFieldEditor default_type_editor = 
+		        new BooleanFieldEditor(PreferencesHelper.DEFAULT_TO_CLASSIC_STYLE, 
+		                "Default to 'classic' widget style", parent);
+		default_type_editor.getDescriptionControl(parent).setToolTipText(
+		        "Should widgets with 'classic' as well as 'native' style default to 'classic'?");
+		addField(default_type_editor);
+		
 		IntegerFieldEditor urlLoadFieldEditor = 
 			new IntegerFieldEditor(PreferencesHelper.URL_FILE_LOADING_TIMEOUT, 
 					"URL file loading timeout (ms)", parent);

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
@@ -62,6 +62,7 @@ public class PreferencesHelper {
 	public static final String URL_FILE_LOADING_TIMEOUT = "url_file_loading_timeout";//$NON-NLS-1$
 	public static final String OPI_SEARCH_PATH="opi_search_path"; //$NON-NLS-1$
 	public static final String PV_CONNECTION_LAYER = "pv_connection_layer"; //$NON-NLS-1$
+    public static final String DEFAULT_TO_CLASSIC_STYLE = "default_to_classic_style";
 	//The widgets that are hidden from palette.
 	public static final String HIDDEN_WIDGETS="hidden_widgets"; //$NON-NLS-1$
 	
@@ -157,6 +158,11 @@ public class PreferencesHelper {
     	return getString(PV_CONNECTION_LAYER);
     }
 
+    public static boolean isDefaultStyleClassic() {
+        final IPreferencesService service = Platform.getPreferencesService();
+        return service.getBoolean(OPIBuilderPlugin.PLUGIN_ID, DEFAULT_TO_CLASSIC_STYLE, true, null);
+    }
+    
     public static boolean isAdvancedGraphicsDisabled(){
     	final IPreferencesService service = Platform.getPreferencesService();
     	return service.getBoolean(OPIBuilderPlugin.PLUGIN_ID, DISABLE_ADVANCED_GRAPHICS, false, null);


### PR DESCRIPTION
Applies to ActionButton when creating new button or loading older *.opi
files that do not specify the style. For #413
