### PR TITLE
o.c.ui.menu.app: Explicitly add 'additions', 'group.editor' to Toolbar

### DIFF
--- a/applications/plugins/org.csstudio.ui.menu.app/src/org/csstudio/ui/menu/app/ApplicationActionBarAdvisor.java
+++ b/applications/plugins/org.csstudio.ui.menu.app/src/org/csstudio/ui/menu/app/ApplicationActionBarAdvisor.java
@@ -107,15 +107,21 @@ public class ApplicationActionBarAdvisor extends ActionBarAdvisor
         final IMenuService menuService = (IMenuService) window.getService(IMenuService.class);
         menuService.populateContributionManager(coolbarPopupMenuManager, "popup:windowCoolbarContextMenu"); //$NON-NLS-1$
 
-        // 'File' and 'User' sections of the cool bar
+        // 'File' section of the cool bar
         final IToolBarManager file_bar = new ToolBarManager();
-        final IToolBarManager user_bar = new ToolBarManager();
-        coolbar.add(new ToolBarContributionItem(file_bar, IWorkbenchActionConstants.M_FILE));
-        coolbar.add(new ToolBarContributionItem(user_bar, TOOLBAR_USER));
-
         // File 'new' and 'save' actions
         file_bar.add(ActionFactory.NEW.create(window));
         file_bar.add(save);
         file_bar.add(new CoolItemGroupMarker(IWorkbenchActionConstants.FILE_END));
+        coolbar.add(new ToolBarContributionItem(file_bar, IWorkbenchActionConstants.M_FILE));
+
+        // 'User' section of the cool bar
+        final IToolBarManager user_bar = new ToolBarManager();
+        coolbar.add(new ToolBarContributionItem(user_bar, TOOLBAR_USER));
+
+        // Explicitly add "additions" and "editor" to work around https://bugs.eclipse.org/bugs/show_bug.cgi?id=422651
+        // After a restart, merging of persisted model, PerspectiveSpacer, contributions resulted in re-arranged toolbar with E4.
+        coolbar.add(new CoolItemGroupMarker(IWorkbenchActionConstants.MB_ADDITIONS));
+        coolbar.add(new CoolItemGroupMarker(IWorkbenchActionConstants.GROUP_EDITOR));
     }
 }


### PR DESCRIPTION
.. because otherwise the tool bar gets messed up under E4. For E3, this
doesn't matter, but best keep the sources the same.

The branch name is wrong: This fixes #325, not 453.
Branch 453 had been closed, and was now re-created for this by accident.
Anyway, this fixes 325 while keeping the master and 4.x branch as similar as possible.
