### PR TITLE
Update LED widget with multi-state functionality

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY Widgets Plug-in
 Bundle-Description: Widgets for BOY
 Bundle-SymbolicName: org.csstudio.opibuilder.widgets;singleton:=true
-Bundle-Version: 3.2.16.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Activator: org.csstudio.opibuilder.widgets.Activator
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Require-Bundle: org.eclipse.ui;resolution:=optional,

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LEDEditPart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LEDEditPart.java
@@ -7,14 +7,19 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.widgets.editparts;
 
+
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.csstudio.opibuilder.properties.IWidgetPropertyChangeHandler;
+import org.csstudio.opibuilder.util.OPIColor;
+import org.csstudio.opibuilder.widgets.model.AbstractBoolWidgetModel;
 import org.csstudio.opibuilder.widgets.model.LEDModel;
+import org.csstudio.swt.widgets.figures.AbstractBoolFigure;
 import org.csstudio.swt.widgets.figures.LEDFigure;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.swt.graphics.Color;
 
 /**
  * LED EditPart
@@ -96,7 +101,132 @@ public class LEDEditPart extends AbstractBoolEditPart{
 			addPropertyChangeListener(sizeListener);
 		getWidgetModel().getProperty(AbstractWidgetModel.PROP_HEIGHT).
 			addPropertyChangeListener(sizeListener);
+	
+		//nStates
+		getWidgetModel().getProperty(LEDModel.PROP_NSTATES).addPropertyChangeListener(new PropertyChangeListener() {
+			@Override
+			public void propertyChange(PropertyChangeEvent evt) {
+				initializeNStatesProperties((Integer)evt.getOldValue(), (Integer)evt.getNewValue(), (LEDFigure)getFigure(), getWidgetModel());
+			}
+		});
 		
+		
+		//stateFallbackLabel
+		getWidgetModel().getProperty(LEDModel.PROP_STATE_FALLBACK_LABEL).addPropertyChangeListener(new PropertyChangeListener() {
+			@Override
+			public void propertyChange(PropertyChangeEvent evt) {
+				initializeStateFallbackLabel((String)evt.getOldValue(), (String)evt.getNewValue(), (LEDFigure)getFigure(), getWidgetModel());
+			}
+		});
+		
+		
+		//stateFallbackColor
+		getWidgetModel().getProperty(LEDModel.PROP_STATE_FALLBACK_COLOR).addPropertyChangeListener(new PropertyChangeListener() {
+			@Override
+			public void propertyChange(PropertyChangeEvent evt) {
+				initializeStateFallbackColor(((OPIColor)evt.getOldValue()).getSWTColor(), ((OPIColor)evt.getNewValue()).getSWTColor(), (LEDFigure)getFigure(), getWidgetModel());
+			}
+		});
+		
+		
+		for(int idx=0; idx<LEDFigure.MAX_NSTATES; idx++) {
+			final int state = idx;
+			//stateLabelN
+			getWidgetModel().getProperty(String.format(LEDModel.PROP_STATE_LABEL, state)).addPropertyChangeListener(new PropertyChangeListener() {
+				@Override
+				public void propertyChange(PropertyChangeEvent evt) {
+					initializeStateLabel(state, (String)evt.getOldValue(), (String)evt.getNewValue(), (LEDFigure)getFigure(), getWidgetModel());
+				}
+			});
+			//stateColorN
+			getWidgetModel().getProperty(String.format(LEDModel.PROP_STATE_COLOR, state)).addPropertyChangeListener(new PropertyChangeListener() {
+				@Override
+				public void propertyChange(PropertyChangeEvent evt) {
+					initializeStateColor(state, ((OPIColor)evt.getOldValue()).getSWTColor(), ((OPIColor)evt.getNewValue()).getSWTColor(), (LEDFigure)getFigure(), getWidgetModel());
+				}
+			});
+			//stateValueN
+			getWidgetModel().getProperty(String.format(LEDModel.PROP_STATE_VALUE, state)).addPropertyChangeListener(new PropertyChangeListener() {
+				@Override
+				public void propertyChange(PropertyChangeEvent evt) {
+					initializeStateValue(state, (Double)evt.getOldValue(), (Double)evt.getNewValue(), (LEDFigure)getFigure(), getWidgetModel());
+				}
+			});
+		}
 	}
 
+	@Override
+	protected void initializeCommonFigureProperties(
+			final AbstractBoolFigure abstractFigure, final AbstractBoolWidgetModel abstractModel) {
+		
+		super.initializeCommonFigureProperties(abstractFigure, abstractModel);
+		
+		LEDModel model = (LEDModel)abstractModel;
+		LEDFigure figure = (LEDFigure)abstractFigure;
+		
+		initializeNStatesProperties(LEDFigure.MAX_NSTATES, model.getNStates(), figure, model);
+		initializeStateFallbackLabel(null, model.getStateFallbackLabel(), figure, model);
+		initializeStateFallbackColor(null, model.getStateFallbackColor(), figure, model);
+		for(int state = 0; state < LEDFigure.MAX_NSTATES; state++) {
+			initializeStateColor(state, null, model.getStateColor(state), figure, model);
+			initializeStateLabel(state, null, model.getStateLabel(state), figure, model);
+			initializeStateValue(state, 0.0, model.getStateValue(state), figure, model);
+		}
+	}
+	
+	protected void initializeNStatesProperties(int oldNStates, int newNStates, LEDFigure figure, LEDModel model) {
+		if(newNStates <= 2) {
+			model.setPropertyVisible(LEDModel.PROP_ON_COLOR, true);
+			model.setPropertyVisible(LEDModel.PROP_ON_LABEL, true);
+			model.setPropertyVisible(LEDModel.PROP_OFF_COLOR, true);
+			model.setPropertyVisible(LEDModel.PROP_OFF_LABEL, true);
+			model.setPropertyVisibleAndSavable(LEDModel.PROP_NSTATES, true, false);
+			model.setPropertyVisibleAndSavable(LEDModel.PROP_STATE_FALLBACK_COLOR, false, false);
+			model.setPropertyVisibleAndSavable(LEDModel.PROP_STATE_FALLBACK_LABEL, false, false);
+			for(int idx = 0; idx<oldNStates; idx++) {
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_COLOR, idx), false, false);
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_LABEL, idx), false, false);
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_VALUE, idx), false, false);
+			}
+		} else if(newNStates > 2) {
+			model.setPropertyVisible(LEDModel.PROP_ON_COLOR, false);
+			model.setPropertyVisible(LEDModel.PROP_ON_LABEL, false);
+			model.setPropertyVisible(LEDModel.PROP_OFF_COLOR, false);
+			model.setPropertyVisible(LEDModel.PROP_OFF_LABEL, false);
+			model.setPropertyVisibleAndSavable(LEDModel.PROP_NSTATES, true, true);
+			model.setPropertyVisibleAndSavable(LEDModel.PROP_STATE_FALLBACK_COLOR, true, true);
+			model.setPropertyVisibleAndSavable(LEDModel.PROP_STATE_FALLBACK_LABEL, true, true);
+			for(int idx = 0; idx<newNStates; idx++) {
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_COLOR, idx), true, true);
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_LABEL, idx), true, true);
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_VALUE, idx), true, true);
+			}
+			for(int idx = newNStates; idx<oldNStates; idx++) {
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_COLOR, idx), false, false);
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_LABEL, idx), false, false);
+				model.setPropertyVisibleAndSavable(String.format(LEDModel.PROP_STATE_VALUE, idx), false, false);
+			}
+		}
+		figure.setNStates(newNStates);
+	}
+	
+	protected void initializeStateFallbackLabel(String oldLabel, String newLabel, LEDFigure figure, LEDModel model) {
+		figure.setStateFallbackLabel(newLabel);
+	}
+	
+	protected void initializeStateFallbackColor(Color oldColor, Color newColor, LEDFigure figure, LEDModel model) {
+		figure.setStateFallbackColor(newColor);
+	}
+	
+	protected void initializeStateLabel(int state, String oldLabel, String newLabel, LEDFigure figure, LEDModel model) {
+		figure.setStateLabel(state, newLabel);
+	}
+	
+	protected void initializeStateColor(int state, Color oldColor, Color newColor, LEDFigure figure, LEDModel model) {
+		figure.setStateColor(state, newColor);
+	}
+	
+	protected void initializeStateValue(int state, double oldValue, double newValue, LEDFigure figure, LEDModel model) {
+		figure.setStateValue(state, newValue);
+	}
 }

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
@@ -8,7 +8,13 @@
 package org.csstudio.opibuilder.widgets.model;
 
 import org.csstudio.opibuilder.properties.BooleanProperty;
+import org.csstudio.opibuilder.properties.ColorProperty;
+import org.csstudio.opibuilder.properties.DoubleProperty;
+import org.csstudio.opibuilder.properties.IntegerProperty;
+import org.csstudio.opibuilder.properties.StringProperty;
 import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
+import org.csstudio.swt.widgets.figures.LEDFigure;
+import org.eclipse.swt.graphics.Color;
 
 
 /**
@@ -19,6 +25,17 @@ import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
 public class LEDModel extends AbstractBoolWidgetModel {
 
 	
+	/** Generic category class. This could be used generally if the equivalent does not already exist. */
+	public class GenericCategory implements WidgetPropertyCategory {
+		public String label;
+		public GenericCategory(String label) {
+			this.label = label;
+		}
+		@Override
+		public String toString() {
+			return label;
+		}
+	}
 	
 	/** The ID of the effect 3D property. */
 	public static final String PROP_EFFECT3D = "effect_3d"; //$NON-NLS-1$
@@ -26,6 +43,29 @@ public class LEDModel extends AbstractBoolWidgetModel {
 	/** The ID of the square LED property. */
 	public static final String PROP_SQUARE_LED = "square_led"; //$NON-NLS-1$
 	
+	/** Number of states for this multi state widget */
+	public static final String PROP_NSTATES = "state_count"; //$NON-NLS-1$
+
+	/** Label text for multi state X */
+	public static final String PROP_STATE_LABEL = "state_label_%s";
+	
+	/** Widget color for multi state X */
+	public static final String PROP_STATE_COLOR = "state_color_%s";
+	
+	/** Description for widget color properties */
+	public static final String DESC_STATE_COLOR = "State Color %s";
+	
+	/** State value for multi state X */
+	public static final String PROP_STATE_VALUE = "state_value_%s";
+	
+	/** Description for state value properties */
+	public static final String DESC_STATE_VALUE = "State Value %s";
+	
+	/** State fallback label property */
+	public static final String PROP_STATE_FALLBACK_LABEL = "state_label_fallback";
+	
+	/** State fallback color property */
+	public static final String PROP_STATE_FALLBACK_COLOR = "state_color_fallback";
 	
 	/** The default value of the height property. */	
 	private static final int DEFAULT_HEIGHT = 20;
@@ -51,6 +91,37 @@ public class LEDModel extends AbstractBoolWidgetModel {
 		addProperty(new BooleanProperty(PROP_SQUARE_LED, "Square LED", 
 				WidgetPropertyCategory.Display, false));
 		setPropertyVisible(PROP_BOOL_LABEL_POS, false);
+		
+		addProperty(new IntegerProperty(PROP_NSTATES,
+				"State Count", WidgetPropertyCategory.Behavior, 2, 2, LEDFigure.MAX_NSTATES));
+		setPropertyVisibleAndSavable(PROP_NSTATES, true, false);
+		
+		WidgetPropertyCategory category = new GenericCategory("State Fallback");
+		
+		addProperty(new StringProperty(PROP_STATE_FALLBACK_LABEL,
+				"Label", category, LEDFigure.DEFAULT_STATE_FALLBACK_LABAL));
+		setPropertyVisibleAndSavable(PROP_STATE_FALLBACK_LABEL, false, false);
+		
+		addProperty(new ColorProperty(PROP_STATE_FALLBACK_COLOR,
+				"Color", category, LEDFigure.DEFAULT_STATE_FALLBACK_COLOR.getRGB()));
+		setPropertyVisibleAndSavable(PROP_STATE_FALLBACK_COLOR, false, false);
+		
+		for(int state=0; state<LEDFigure.MAX_NSTATES; state++) {
+			
+			category = new GenericCategory(String.format("State %02d", state+1));
+						
+			addProperty(new StringProperty(String.format(PROP_STATE_LABEL, state),
+					"Label", category, LEDFigure.DEFAULT_STATE_LABELS[state]));
+			setPropertyVisibleAndSavable(String.format(PROP_STATE_LABEL, state), false, false);
+			
+			addProperty(new ColorProperty(String.format(PROP_STATE_COLOR, state),
+					"Color", category, LEDFigure.DEFAULT_STATE_COLORS[state].getRGB()));
+			setPropertyVisibleAndSavable(String.format(PROP_STATE_COLOR, state), false, false);
+			
+			addProperty(new  DoubleProperty(String.format(PROP_STATE_VALUE, state),
+					"Value", category, LEDFigure.DEFAULT_STATE_VALUES[state]));
+			setPropertyVisibleAndSavable(String.format(PROP_STATE_VALUE, state), false, false);
+		}
 	}
 	/**
 	 * The ID of this widget model.
@@ -74,5 +145,29 @@ public class LEDModel extends AbstractBoolWidgetModel {
 	 */
 	public boolean isSquareLED() {
 		return (Boolean) getProperty(PROP_SQUARE_LED).getPropertyValue();
+	}
+	
+	public int getNStates() {
+		return (Integer) getProperty(PROP_NSTATES).getPropertyValue();
+	}
+	
+	public String getStateLabel(int state) {
+		return (String) getProperty(String.format(PROP_STATE_LABEL, state)).getPropertyValue();
+	}
+	
+	public double getStateValue(int state) {
+		return (Double) getProperty(String.format(PROP_STATE_VALUE, state)).getPropertyValue();
+	}
+	
+	public Color getStateColor(int state) {
+		return getSWTColorFromColorProperty(String.format(PROP_STATE_COLOR, state));
+	}
+	
+	public String getStateFallbackLabel() {
+		return (String) getProperty(PROP_STATE_FALLBACK_LABEL).getPropertyValue();
+	}
+	
+	public Color getStateFallbackColor() {
+		return getSWTColorFromColorProperty(PROP_STATE_FALLBACK_COLOR);
 	}
 }

--- a/applications/plugins/org.csstudio.swt.widgets/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.swt.widgets/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: CSS Widgets
 Bundle-Description: Widgets figure for draw2d and SWT applications.
 Bundle-SymbolicName: org.csstudio.swt.widgets
-Bundle-Version: 2.0.2.qualifier
+Bundle-Version: 2.0.3.qualifier
 Bundle-Activator: org.csstudio.swt.widgets.Activator
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Require-Bundle: org.eclipse.ui;resolution:=optional,

--- a/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figureparts/Bulb.java
+++ b/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figureparts/Bulb.java
@@ -91,6 +91,10 @@ public class Bulb extends Figure{
 		repaint();
 	}
 	
+	public Color getBulbColor() {
+		return bulbColor;
+	}
+	
 	private int getHeight() {
 		return bounds.height;
 	}

--- a/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
+++ b/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
@@ -7,6 +7,8 @@
  ******************************************************************************/
 package org.csstudio.swt.widgets.figures;
 
+import java.util.Arrays;
+
 import org.csstudio.swt.widgets.figureparts.Bulb;
 import org.csstudio.swt.widgets.util.GraphicsUtil;
 import org.csstudio.ui.util.CustomMediaFactory;
@@ -35,8 +37,33 @@ public class LEDFigure extends AbstractBoolFigure {
 			CustomMediaFactory.COLOR_WHITE); 
 	private final static Color BLACK_COLOR = CustomMediaFactory.getInstance().getColor(
 			CustomMediaFactory.COLOR_BLACK); 
+
+	private static Color COLOR(int red, int green, int blue) { return CustomMediaFactory.getInstance().getColor(red, green, blue); }
+	
+	public final static int MAX_NSTATES = 16;
+	public final static String[] DEFAULT_STATE_LABELS =
+			new String[] { "S01", "S02", "S03", "S04", "S05", "S06", "S07", "S08", "S09", "S10", "S11", "S12", "S13", "S14", "S15", "S16" };
+	public final static Color[] DEFAULT_STATE_COLORS =
+			new Color[] { COLOR(0,100,0), COLOR(0,255,0), COLOR(255,0,0), COLOR(0,0,255), COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100),
+			COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100), COLOR(100,100,100) };
+	public final static double[] DEFAULT_STATE_VALUES =
+			new double[] { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0 };
+	public final static String DEFAULT_STATE_FALLBACK_LABAL = "ERR";
+	public final static Color DEFAULT_STATE_FALLBACK_COLOR = COLOR(100,100,100);
+	
+	
 	private boolean effect3D = true;
 	private boolean squareLED = false;
+
+	private int nStates = 2;
+	private double stateValue = 0.0;
+	private Color[] stateColors = Arrays.copyOf(DEFAULT_STATE_COLORS, MAX_NSTATES);
+	private String[] stateLabels = Arrays.copyOf(DEFAULT_STATE_LABELS, MAX_NSTATES);
+	private double[] stateValues = Arrays.copyOf(DEFAULT_STATE_VALUES, MAX_NSTATES);
+	private Color stateFallbackColor = DEFAULT_STATE_FALLBACK_COLOR;
+	private String stateFallbackLabel = DEFAULT_STATE_FALLBACK_LABAL;
+	
+	
 	public LEDFigure() {
 		super();
 		bulb = new Bulb();		
@@ -132,7 +159,12 @@ public class LEDFigure extends AbstractBoolFigure {
 				
 				//draw light
 				clientArea.shrink(SQURE_BORDER_WIDTH, SQURE_BORDER_WIDTH);
-				Color fillColor = booleanValue?onColor:offColor;
+				Color fillColor;
+				if(nStates <= 2) {
+					fillColor = booleanValue?onColor:offColor;
+				} else {
+					fillColor = bulb.getBulbColor();
+				}
 		        graphics.setBackgroundColor(fillColor);
 		        graphics.fillRectangle(clientArea);
 				pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), clientArea.x,	clientArea.y,
@@ -149,7 +181,12 @@ public class LEDFigure extends AbstractBoolFigure {
 				graphics.drawRectangle(clientArea);
 				
 				clientArea.shrink(SQURE_BORDER_WIDTH/2, SQURE_BORDER_WIDTH/2);
-				Color fillColor = booleanValue?onColor:offColor;
+				Color fillColor;
+				if(nStates <= 2) {
+					fillColor = booleanValue?onColor:offColor;
+				} else {
+					fillColor = bulb.getBulbColor();
+				}
 		        graphics.setBackgroundColor(fillColor);
 		        graphics.fillRectangle(clientArea);
 			}
@@ -215,5 +252,130 @@ public class LEDFigure extends AbstractBoolFigure {
 		super.updateBoolValue();
 		bulb.setBulbColor(booleanValue ? onColor : offColor);
 		
+	}
+	
+	public int getNStates() {
+		return nStates;
+	}
+	
+	public void setNStates(int nStates) {
+		if(this.nStates != nStates) {
+			this.nStates = nStates;
+			if(nStates <= 2) {
+				updateBoolValue();
+			} else {
+				updateStateValue();
+			}
+		}
+	}
+	
+	public Color getStateFallbackColor() {
+		return stateFallbackColor;
+	}
+	
+	public void setStateFallbackColor(Color color) {
+		if(!stateFallbackColor.equals(color)) {
+			stateFallbackColor = color;
+			updateStateValue();
+		}
+	}
+	
+	public String getStateFallbackLabel() {
+		return stateFallbackLabel;
+	}
+	
+	public void setStateFallbackLabel(String label) {
+		if(!stateFallbackLabel.equals(label)) {
+			stateFallbackLabel = label;
+			updateStateValue();
+		}
+	}
+	
+	public Color getStateColor(int idx) {
+		return stateColors[idx];
+	}
+	
+	public void setStateColor(int idx, Color color) {
+		if(!stateColors[idx].equals(color)) {
+			stateColors[idx] = color;
+			updateStateValue();
+		}
+	}
+	
+	public String getStateLabel(int idx) {
+		return stateLabels[idx];
+	}
+	
+	public void setStateLabel(int idx, String label) {
+		if(!stateLabels[idx].equals(label)) {
+			stateLabels[idx] = label;
+			updateStateValue();
+		}
+	}
+	
+	public Double getStateValue(int idx) {
+		return stateValues[idx];
+	}
+	
+	public void setStateValue(int idx, double value) {
+		if(stateValues[idx] != value) {
+			stateValues[idx] = value;
+			updateStateValue();
+		}
+	}
+	
+	/**
+	 * @param value the value to set
+	 */
+	@Override
+	public void setValue(double value) {
+		if(nStates <= 2) {
+			super.setValue(value);
+		}
+		else if(this.stateValue != value) {
+			this.stateValue = value;
+			updateStateValue();
+		}
+	}
+
+	/**
+	 * @param value the value to set
+	 */
+	@Override
+	public void setValue(long value) {
+		if(nStates <= 2) {
+			super.setValue(value);
+		} else {
+			setValue((double)value);
+		}
+	}
+	
+	protected void updateStateValue() {
+		if(nStates > 2) {
+			boolean fallback = true;
+			for(int idx=0; idx<nStates; idx++) {
+				if(stateValue == stateValues[idx]) {
+					setBulbColorAndLabel(stateColors[idx], stateLabels[idx]);
+					fallback = false;
+					break;
+				}
+			}
+			if(fallback) {
+				setBulbColorAndLabel(stateFallbackColor, stateFallbackLabel);
+			}
+			revalidate();
+			repaint();
+		}
+	}
+	
+	protected void setBulbColorAndLabel(Color color, String label) {
+		// These brightness weightings and threshold determined experimentally.
+		if((color.getRed() * 299) + (color.getGreen() * 587) + (color.getBlue() * 114) > 105000) {
+			boolLabel.setForegroundColor(BLACK_COLOR);
+		} else {
+			boolLabel.setForegroundColor(WHITE_COLOR);
+		}
+		bulb.setBulbColor(color);
+		boolLabel.setText(label);
 	}
 }


### PR DESCRIPTION
Extended LED widget to support multiple states.  Implementation is backwards compatible with existing widget and will generate identical XML if multi-state functionality is NOT used.
