### PR TITLE
All.feature name

### DIFF
--- a/applications/features/org.csstudio.applications.all.feature/.project
+++ b/applications/features/org.csstudio.applications.all.feature/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.csstudio.boy.feature</name>
+	<name>org.csstudio.applications.all.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
When importing into Eclipse, I noticed that the displayed name didn't match what was actually in the directory.
