### PR TITLE
o.c.apputil.ui.ImageTabFolder: Dialog was partially visible on Linux

### DIFF
--- a/applications/plugins/org.csstudio.apputil.ui/src/org/csstudio/apputil/ui/swt/ImageTabFolder.java
+++ b/applications/plugins/org.csstudio.apputil.ui/src/org/csstudio/apputil/ui/swt/ImageTabFolder.java
@@ -32,9 +32,12 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
+import org.eclipse.ui.PlatformUI;
 
 /** TabFolder that keeps ImagePreview items for a list of image files,
  *  allowing addition, removal of images
@@ -89,13 +92,13 @@ public class ImageTabFolder
         final Button button = new Button(parent, SWT.PUSH);
         if (full)
         {
-        	button.setText(Messages.AddFullScreenshot);
-        	button.setToolTipText(Messages.AddFullScreenshotTT);
+            button.setText(Messages.AddFullScreenshot);
+            button.setToolTipText(Messages.AddFullScreenshotTT);
         }
         else
         {
-        	button.setText(Messages.AddApplicationScreenshot);
-        	button.setToolTipText(Messages.AddApplicationScreenshotTT);
+            button.setText(Messages.AddApplicationScreenshot);
+            button.setToolTipText(Messages.AddApplicationScreenshotTT);
         }
         button.addSelectionListener(new SelectionAdapter()
         {
@@ -109,7 +112,7 @@ public class ImageTabFolder
         return button;
     }
     
-	/** Allow dropping file names (presumably images) */
+    /** Allow dropping file names (presumably images) */
     private void hookDragAndDrop(Composite parent)
     {
         // Use the whole parent as drop target.
@@ -187,37 +190,54 @@ public class ImageTabFolder
     @SuppressWarnings("nls")
     protected void addScreenshot(final boolean full)
     {
-    	// Hide the shell that displays the dialog
-    	// to keep the dialog itself out of the screenshot
-    	tab_folder.getShell().setVisible(false);
-    	
-    	// Take the screen shot
-		final Image image = full
-			? Screenshot.getFullScreenshot()
-			: Screenshot.getApplicationScreenshot();
-
-		// Show the dialog again
-		tab_folder.getShell().setVisible(true);
-
-        // Write to file
-        try
+        // Hide the shell that displays the dialog
+        // to keep the dialog itself out of the screenshot
+        final Shell shell = tab_folder.getShell();
+        shell.setVisible(false);
+        
+        // On Linux (X11, GTK), the dialog's shell may now be hidden, but the
+        // vacated area on the screen is blank, not redrawn.
+        // Force a redraw.
+        final Shell main_shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+        main_shell.forceActive();
+        main_shell.redraw();
+        
+        // Delay screenshot in UI event queue to allow for the refresh
+        final Display display = shell.getDisplay();
+        display.timerExec(500, new Runnable()
         {
-        	final File screenshot_file = File.createTempFile("screenshot", ".png");
-        	screenshot_file.deleteOnExit();
-
-        	final ImageLoader loader = new ImageLoader();
-            loader.data = new ImageData[] { image.getImageData() };
-            image.dispose();
-    	    // Save
-    	    loader.save(screenshot_file.getPath(), SWT.IMAGE_PNG);
-        	
-        	addImage(screenshot_file.getPath());
-        }
-        catch (Exception ex)
-        {
-        	MessageDialog.openError(tab_folder.getShell(),
-        			"Error", ex.getMessage());
-        }
+            @Override
+            public void run()
+            {
+                // Take the screen shot
+                final Image image = full
+                    ? Screenshot.getFullScreenshot()
+                    : Screenshot.getApplicationScreenshot();
+                    
+                // Show the dialog again
+                shell.setVisible(true);
+        
+                // Write to file
+                try
+                {
+                    final File screenshot_file = File.createTempFile("screenshot", ".png");
+                    screenshot_file.deleteOnExit();
+        
+                    final ImageLoader loader = new ImageLoader();
+                    loader.data = new ImageData[] { image.getImageData() };
+                    image.dispose();
+                    // Save
+                    loader.save(screenshot_file.getPath(), SWT.IMAGE_PNG);
+                    
+                    addImage(screenshot_file.getPath());
+                }
+                catch (Exception ex)
+                {
+                    MessageDialog.openError(tab_folder.getShell(),
+                            "Error", ex.getMessage());
+                }
+            }
+        });
     }
     
     /** Remove image from preview and list of images-to-add
@@ -249,9 +269,9 @@ public class ImageTabFolder
     /** Prompt for image file to add */
     protected void addImage()
     {
-		final String filename = SingleSourcePlugin.getUIHelper().openOutsideWorkspaceDialog(
-				getControl().getShell(), SWT.OPEN, null, "*.png");
-		if (filename != null)
-			addImage(filename);
+        final String filename = SingleSourcePlugin.getUIHelper().openOutsideWorkspaceDialog(
+                getControl().getShell(), SWT.OPEN, null, "*.png");
+        if (filename != null)
+            addImage(filename);
     }
 }


### PR DESCRIPTION
When taking CSS window or complete screenshot, on Linux this included a
blank area where the dialog used to be.

This fixes #515, EMail screenshots.

The same problem is also in the ELog, will create separate issue for that because Kunal's code is different from what I had in the EMail handling of the screenshots
