### PR TITLE
o.c.logging.jms2rdb: Fix erroneous warning for every correct message

### DIFF
--- a/applications/plugins/org.csstudio.logging.jms2rdb/src/org/csstudio/logging/jms2rdb/LogClientThread.java
+++ b/applications/plugins/org.csstudio.logging.jms2rdb/src/org/csstudio/logging/jms2rdb/LogClientThread.java
@@ -258,7 +258,8 @@ public class LogClientThread extends Thread
                 }
                 rdb_writer.write(map);
             }
-                Activator.getLogger().log(Level.WARNING, "Received unhandled message type {0}" + message, message.getClass().getName());
+            else
+                Activator.getLogger().log(Level.WARNING, "Received unhandled message {0}", message);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Bug had been introduced while fixing #622 
