### PR TITLE
o.c.archive.engine: For -skip_last, assume current time as last stamp

### DIFF
--- a/applications/plugins/org.csstudio.archive.engine/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Engine Plug-in
 Bundle-SymbolicName: org.csstudio.archive.engine;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.csstudio.archive.engine.Activator
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Archive Sample Engine, writes data to RDB

--- a/applications/plugins/org.csstudio.archive.engine/pom.xml
+++ b/applications/plugins/org.csstudio.archive.engine/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.archive.engine</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/model/EngineModel.java
+++ b/applications/plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/model/EngineModel.java
@@ -237,15 +237,15 @@ public class EngineModel
                      group.getName(), name, channel.getGroup(0).getName()));
 
         // Channel is new to this engine.
-        // See if there's already a sample in the archive,
-        // because we won't be able to go back-in-time before that sample.
-    	final VType last_sample;
-
-    	if (last_sample_time == null)
-    		last_sample = null;
-    	else // Create fake string sample with that time
-        	last_sample = new ArchiveVString(last_sample_time,
-                             AlarmSeverity.NONE, "", "Last timestamp in archive");
+        // If there's already a sample in the archive, we won't go back-in-time before that sample,
+        // because it may be an "Archive Off" or "Channel Disconnected" indicator.
+        // We need to show that it's now fine again, even if the original time stamp
+        // of the channel hasn't changed.
+        // Create fake string sample with that time, using the current time
+        // if we don't have a known last value resulting from the "-skip_last" option.
+        final VType last_sample = last_sample_time == null
+        ? new ArchiveVString(Timestamp.now(),  AlarmSeverity.NONE, "", "Engine start time")
+        : new ArchiveVString(last_sample_time, AlarmSeverity.NONE, "", "Last timestamp in archive");
 
     	// Determine buffer capacity
         int buffer_capacity = (int) (write_period / sample_mode.getPeriod() * buffer_reserve);

--- a/applications/plugins/org.csstudio.archive.rdb/ChangeLog.html
+++ b/applications/plugins/org.csstudio.archive.rdb/ChangeLog.html
@@ -9,11 +9,15 @@
 
 <p>Version numbers in here refer to the version of the plugin org.csstudio.archive.rdb.</p>
 
+<h2>Version 4.0.0 - 2014-08-15</h2>
+<ul>
+<li>For -skip_last, assume current time as last time stamp</li>
+</ul>
+
 <h2>Version 3.2.15 - 2014-03-03</h2>
 <ul>
 <li>Configurable archive reader 'fetch_size' to avoid out-of-memory</li>
 </ul>
-
 
 <h2>Version 3.2.14 - 2014-01-28</h2>
 <ul>

--- a/applications/plugins/org.csstudio.archive.rdb/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.archive.rdb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RDB Archive library
 Bundle-SymbolicName: org.csstudio.archive.rdb;singleton:=true
-Bundle-Version: 3.2.15.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Description: Archive RDB support library
 Require-Bundle: org.eclipse.core.runtime,

--- a/applications/plugins/org.csstudio.archive.rdb/pom.xml
+++ b/applications/plugins/org.csstudio.archive.rdb/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.archive.rdb</artifactId>
-  <version>3.2.15-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Fixes #646 
