### PR TITLE
Action button font

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/Draw2DButtonEditPartDelegate.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/Draw2DButtonEditPartDelegate.java
@@ -111,11 +111,11 @@ public class Draw2DButtonEditPartDelegate implements IButtonEditPartDelegate{
 					final Object newValue, final IFigure refreshableFigure) {
 				ActionButtonFigure figure = (ActionButtonFigure) refreshableFigure;
 				figure.setText(newValue.toString());
+				figure.calculateTextPosition();
 				return true;
 			}
 		};
 		editpart.setPropertyChangeHandler(ActionButtonModel.PROP_TEXT, textHandler);
-
 
 		//image
 		IWidgetPropertyChangeHandler imageHandler = new IWidgetPropertyChangeHandler() {
@@ -137,7 +137,8 @@ public class Draw2DButtonEditPartDelegate implements IButtonEditPartDelegate{
 			public boolean handleChange(final Object oldValue,
 					final Object newValue, final IFigure refreshableFigure) {
 				ActionButtonFigure figure = (ActionButtonFigure) refreshableFigure;
-				figure.calculateTextPosition((Integer) newValue, figure.getClientArea().height());
+				Integer height = (Integer) editpart.getPropertyValue(ActionButtonModel.PROP_HEIGHT);
+				figure.calculateTextPosition((Integer) newValue, height);
 				return true;
 			}
 		};
@@ -148,7 +149,8 @@ public class Draw2DButtonEditPartDelegate implements IButtonEditPartDelegate{
 			public boolean handleChange(final Object oldValue,
 					final Object newValue, final IFigure refreshableFigure) {
 				ActionButtonFigure figure = (ActionButtonFigure) refreshableFigure;
-				figure.calculateTextPosition(figure.getClientArea().width(), (Integer) newValue);
+				Integer width = (Integer) editpart.getPropertyValue(ActionButtonModel.PROP_WIDTH);
+				figure.calculateTextPosition(width, (Integer) newValue);
 				return true;
 			}
 		};

--- a/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ActionButtonFigure.java
+++ b/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ActionButtonFigure.java
@@ -326,6 +326,7 @@ public class ActionButtonFigure extends Figure implements Introspectable, ITextF
 	@Override
 	public void setFont(Font f) {
 		super.setFont(f);
+		calculateTextPosition();
 		label.revalidate();
 	}
 


### PR DESCRIPTION
Action Button: use getFont() to calculate text position rather than the default FONT (corrects #654 ). Also call calculateTextPosition() whenever text or font changes, and when width or height changes, get the corresponding value from the prop sheet rather than the widget.
