### PR TITLE
o.c.scan.server: Report interrupted (aborted) get/putcallback as such

### DIFF
--- a/applications/plugins/org.csstudio.scan.server/src/org/csstudio/scan/device/PVDevice.java
+++ b/applications/plugins/org.csstudio.scan.server/src/org/csstudio/scan/device/PVDevice.java
@@ -221,6 +221,9 @@ public class PVDevice extends Device
             {
                 value = getDisconnectedValue();
             }
+            // Report InterruptedException (from abort) as such
+            if (ex instanceof InterruptedException)
+                throw new InterruptedException("Failed to read " + getName());
             throw new Exception("Failed to read " + getName(), ex);
         }
     }	
@@ -300,6 +303,10 @@ public class PVDevice extends Device
 		        write_result.get(millisec, TimeUnit.MILLISECONDS);
 		    else
 		        write_result.get();
+		}
+		catch (InterruptedException ex)
+		{   // Report InterruptedException (from abort) as such
+            throw new InterruptedException("Interrupted while writing " + value + " to " + getName());
 		}
 		catch (Exception ex)
 		{

--- a/applications/plugins/org.csstudio.scan.ui/ChangeLog.html
+++ b/applications/plugins/org.csstudio.scan.ui/ChangeLog.html
@@ -9,9 +9,10 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.scan.</p>
 
-<h2>Version 4.0.1 - 2014-08-21</h2>
+<h2>Version 4.0.1 - 2014-09-04</h2>
 <ul>
   <li>'Abort' no longer displayed in red; only 'Failure' is considered an error. New 'State' PV.</li>
+  <li>'Abort' while waiting for put or get callback reported as 'Aborted', not error.</li>
 </ul>
 
 <h2>Version 4.0.0 - 2014-06-02</h2>


### PR DESCRIPTION
Was reporting general exception, which then shows on higher level as
error instead of the intentional abort
