### PR TITLE
o.c.alarm.beast.server.test: added depends for pvmanager,..

### DIFF
--- a/applications/plugins/org.csstudio.alarm.beast.server.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.alarm.beast.server.test/META-INF/MANIFEST.MF
@@ -8,5 +8,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.utility.test,
  org.csstudio.utility.pvmanager.epics,
- org.csstudio.utility.pvmanager.loc
+ org.csstudio.utility.pvmanager.loc,
+ org.csstudio.utility.pvmanager
 Import-Package: org.epics.pvmanager.jca, org.epics.pvmanager.loc

--- a/applications/plugins/org.csstudio.alarm.beast.server.test/src/org/csstudio/alarm/beast/server/FilterUnitTest.java
+++ b/applications/plugins/org.csstudio.alarm.beast.server.test/src/org/csstudio/alarm/beast/server/FilterUnitTest.java
@@ -155,7 +155,7 @@ public class FilterUnitTest implements FilterListener
 
         // Default time out is 30 seconds
         // Should not get any updates while waiting for the connection...
-        TimeUnit.SECONDS.sleep(Filter.TIMEOUT_SECS / 2);
+        TimeUnit.SECONDS.sleep(30 / 2);
         assertThat(updates.get(), equalTo(0));
         
         // .. but then there should be an update
@@ -171,7 +171,7 @@ public class FilterUnitTest implements FilterListener
         final Timestamp end = Timestamp.now();
         final TimeDuration duration = end.durationFrom(start);
         System.err.println("Timeout was " + duration);
-        assertThat(duration.toSeconds(), greaterThanOrEqualTo(Filter.TIMEOUT_SECS * 0.8));
+        assertThat(duration.toSeconds(), greaterThanOrEqualTo(30 * 0.8));
         
         filter.stop();
     }


### PR DESCRIPTION
 since they were removed from the parent, related to #685
