### PR TITLE
Fix error in IDE about missing exported packages.

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets.symbol/build.properties
+++ b/applications/plugins/org.csstudio.opibuilder.widgets.symbol/build.properties
@@ -1,3 +1,4 @@
+source.. = src
 bin.includes = META-INF/,\
                plugin.xml,\
                html/,\


### PR DESCRIPTION
No source directory specified for this plugin so exported packages could not be resolved.
