### PR TITLE
Fix regression: build will fail if empty repository is added.

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -111,9 +111,9 @@
 		<profile>
 			<id>csstudio-local-repo-enable</id>
 			<activation>
-				<property>
-					<name>csstudio.local.repo</name>
-				</property>
+				<file>
+					<exists>${csstudio.local.repo}/artifacts.jar</exists>
+				</file>
 			</activation>
 			<repositories>
 				<repository>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,9 +108,9 @@
 		<profile>
 			<id>csstudio-local-repo-enable</id>
 			<activation>
-				<property>
-					<name>csstudio.local.repo</name>
-				</property>
+				<file>
+					<exists>${csstudio.local.repo}/artifacts.jar</exists>
+				</file>
 			</activation>
 			<repositories>
 				<repository>


### PR DESCRIPTION
Must confirm the repository exists before adding the repository to the build.  This is normally the case when initially populating the local repository.
