### PR TITLE
Fix "class hierarchy inconsistent" errors in o.c.opibuilder.widgets.symbol

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets.symbol/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder.widgets.symbol/META-INF/MANIFEST.MF
@@ -7,10 +7,13 @@ Bundle-Version: 4.4.0.qualifier
 Bundle-Activator: org.csstudio.opibuilder.widgets.symbol.Activator
 Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.core.runtime,
+ org.eclipse.ui.views,
  org.csstudio.opibuilder,
  org.csstudio.opibuilder.widgets,
  org.csstudio.swt.widgets,
- org.apache.commons.lang
+ org.apache.commons.lang,
+ org.csstudio.ui.util,
+ org.eclipse.gef
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Eclipse-BuddyPolicy: registered


### PR DESCRIPTION
Added more required bundles to correct the compilation error.
