### PR TITLE
Add Maven property so tests can be skipped from commandline.

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -26,6 +26,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
 		<baselineMode>fail</baselineMode>
+		<skipTests>false</skipTests>
 
 		<!-- SonarQube configuration -->
 		<sonar.language>java</sonar.language>
@@ -399,7 +400,7 @@
 						<exclude>**/*Demo.java</exclude>
 					</excludes>
 
-					<skipTests>false</skipTests>
+					<skipTests>${skipTests}</skipTests>
 					<!--Some tests fail right now -->
 					<testFailureIgnore>true</testFailureIgnore>
 					<failIfNoTests>false</failIfNoTests>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,6 +26,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
 		<baselineMode>fail</baselineMode>
+		<skipTests>false</skipTests>
 
 		<!-- SonarQube configuration -->
 		<sonar.language>java</sonar.language>
@@ -352,7 +353,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<skipTests>false</skipTests>
+					<skipTests>${skipTests}</skipTests>
 					<!--Some tests fail right now -->
 					<testFailureIgnore>true</testFailureIgnore>
 					<failIfNoTests>false</failIfNoTests>


### PR DESCRIPTION
Tired of the tests running when trying to debug an unrelated compile problem.
Now simply add -DskipTests=false to the maven command.
