### PR TITLE
o.c.startup, o.c.utility.product: Fix -help

### DIFF
--- a/applications/plugins/org.csstudio.utility.product/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.utility.product/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Shared
 Bundle-SymbolicName: org.csstudio.utility.product;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.6",

--- a/applications/plugins/org.csstudio.utility.product/pom.xml
+++ b/applications/plugins/org.csstudio.utility.product/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.product</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/StartupParameters.java
+++ b/applications/plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/StartupParameters.java
@@ -208,6 +208,13 @@ public class StartupParameters implements StartupParametersExtPoint
                 sec_prefs.flush();
                 System.exit(0);
             }
+            // The "comment below" that was mentioned several times above
+            // .. has unfortunately been lost.
+            // Could be related in not continuing further with the product startup,
+            // because as soon as the product looks for preferences, it will use or
+            // even create(!) a workspace. Calling the product with "-help" is not
+            // supposed to create directories and files on the disk,
+            // so best to call System.exit() and NOT allow RCP to continue.
         }
 
         parameters.put(LOGIN_PROMPT_PARAM, login);
@@ -227,24 +234,25 @@ public class StartupParameters implements StartupParametersExtPoint
     private void showHelp()
     {
         System.out.println("Command-line options:");
-        System.out.format("  %-35s : This help\n", HELP);
-        System.out.format("  %-35s : Always present workspace dialog, with preconfigured default\n",
+        System.out.format("  %-40s : This help\n", HELP);
+        System.out.format("  %-40s : Version info\n", "-version");
+        System.out.format("  %-40s : Always present workspace dialog, with preconfigured default\n",
                 WORKSPACE_PROMPT);
-        System.out.format("  %-35s : Present workspace dialog with given default\n",
+        System.out.format("  %-40s : Present workspace dialog with given default\n",
                 WORKSPACE_PROMPT + " /some/workspace");
-        System.out.format("  %-35s : Log all messages to the console\n",
+        System.out.format("  %-40s : Log all messages to the console\n",
                 "-consoleLog");
-        System.out.format("  %-35s : Select workspace on command-line, no prompt\n",
+        System.out.format("  %-40s : Select workspace on command-line, no prompt\n",
                 "-data /some/workspace");
-        System.out.format("  %-35s : Create links to shared folder\n",
+        System.out.format("  %-40s : Create links to shared folder\n",
                 SHARE_LINK + " /path/to/folder=/CSS/Share");
-        System.out.format("  %-35s : Present login dialog (user, password)\n",
+        System.out.format("  %-40s : Present login dialog (user, password)\n",
                 LOGIN_PROMPT);
-        System.out.format("  %-35s : provide the default user in login dialog\n",
+        System.out.format("  %-40s : provide the default user in login dialog\n",
                 USER + " username");
-        System.out.format("  %-35s : provide the password of default user in login dialog\n",
+        System.out.format("  %-40s : provide the password of default user in login dialog\n",
                 PASSWORD + " username");
-        System.out.format("  %-35s : set a password preferences (need to follow with -p)\n",
+        System.out.format("  %-40s : set a password preferences (will prompt for password or use previous -p {password} option)\n",
                 "-set_password preference_name");
     }
 }

--- a/core/plugins/org.csstudio.startup/META-INF/MANIFEST.MF
+++ b/core/plugins/org.csstudio.startup/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CSS Application Startup
 Bundle-SymbolicName: org.csstudio.startup;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.2.1.qualifier
 Bundle-Description: Common CSS Application code
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/core/plugins/org.csstudio.startup/pom.xml
+++ b/core/plugins/org.csstudio.startup/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.startup</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>3.2.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/plugins/org.csstudio.startup/src/org/csstudio/startup/application/Application.java
+++ b/core/plugins/org.csstudio.startup/src/org/csstudio/startup/application/Application.java
@@ -87,31 +87,18 @@ public class Application implements IApplication {
     /** {@inheritDoc} */
     public Object start(final IApplicationContext context) throws Exception
 	{
-		// Display configuration info
-		final String version = (String) context.getBrandingBundle().getHeaders().get("Bundle-Version");
-		final String app_info = context.getBrandingName() + " " + version;
-
-		// Create parser for arguments and run it.
-		final String args[] = (String[]) context.getArguments().get("application.args");
-
-		int pos = 0;
-		while (pos < args.length) {
-			if (args[pos].equals("-help")) {
-				System.out
-						.println(app_info + "\n\nOptions:\n"
-								+ "  -help                         : Display help\n"
-								+ "  -version                      : Display version info\n"
-								+ "  -data /home/fred/Workspace    : Eclipse workspace location\n"
-								+ "  -pluginCustomization /path/to/my/settings.ini: Eclipse plugin defaults\n"
-								+ "  -share_link /absolute/system/path=relative/workspace/path[,another_link]*: Set shared links\n");
-				return IApplication.EXIT_OK;
-			}
-			if (args[pos].equals("-version")) {
+		// Check for '-version' argument.
+        // In general, command-line options are handled via
+        // the extension point org.csstudio.startup.module, entry 'startupParameters'
+        final String args[] = (String[]) context.getArguments().get("application.args");
+		for (String arg : args)
+			if (arg.equals("-version"))
+			{   // Display configuration info
+			    final String version = (String) context.getBrandingBundle().getHeaders().get("Bundle-Version");
+			    final String app_info = context.getBrandingName() + " " + version;
 				System.out.println(app_info);
 				return IApplication.EXIT_OK;
 			}
-			pos++;
-		}
     	
     	// Create the display
 	    final Display display = PlatformUI.createDisplay();
@@ -325,7 +312,23 @@ public class Application implements IApplication {
 		{
 			parameters.putAll(p.readStartupParameters(display, context));
 		}
-		return parameters;
+		
+		// Extension point should have handled command line arguments.
+		// For "-help", it should have displayed all accepted options, then quit.
+        final String args[] = (String[]) context.getArguments().get("application.args");
+        for (String arg : args)
+            if (arg.equals("-help"))
+            {   // If we reach this point, "-help" was requested but not handled.
+                // Display the generic options.
+                System.out.println("Options:\n"
+                        + "  -help                                        : Display help\n"
+                        + "  -version                                     : Display version info\n"
+                        + "  -data /home/fred/Workspace                   : Eclipse workspace location\n"
+                        + "  -pluginCustomization /path/to/my/settings.ini: Eclipse plugin defaults\n");
+                System.exit(0);
+            }
+		
+        return parameters;
 	}
 
 	/**


### PR DESCRIPTION
-help being handled in common Application prevented the
StartupParameters code which actually knew about the supported options
from providing help for them.

Still left "-help" handling code in Application, but it's only used in case the StartupParameters code returns without existing from "-help".

Fixes #758
