### PR TITLE
Set tab order for RGB sliders & spinners in OPIColorDialog

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/visualparts/OPIColorDialog.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/visualparts/OPIColorDialog.java
@@ -234,6 +234,11 @@ public class OPIColorDialog extends HelpTrayDialog {
 		
 		blueScale.addSelectionListener(new RGBEditListener(2));
 		blueSpinner.addSelectionListener(new RGBEditListener(2));
+		
+		rgbGroup.setTabList(new Control[] {
+			redScale, greenScale, blueScale,
+			redSpinner, greenSpinner, blueSpinner
+		});
 
 	}
 	


### PR DESCRIPTION
This commit sets the tab order for the RGB sliders and spinners in `OPIColorDialog` to: red/green/blue sliders; followed by red/green/blue spinners.

This means that if you type a value into the red spinner, pressing Tab takes you to to the green spinner.

Chances are that if you've typed in one of the red/green/blue values, you want to type in the others; this makes it easier to do that.
