### PR TITLE
Remove unused "platform-version" property from core/applications POMs

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -71,7 +71,6 @@
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
 				<rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>
-				<platform-version>[4.3,4.4)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>
@@ -88,7 +87,6 @@
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
 				<rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>
-				<platform-version>[4.3,4.4)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>
@@ -105,7 +103,6 @@
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.3</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.2</rap-site>
 				<rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/2.2/gef</rap-incubator-site>
-				<platform-version>[4.2,4.3)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -70,7 +70,6 @@
 				<eclipse-site>http://download.eclipse.org/releases/luna</eclipse-site>
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
-				<platform-version>[4.3,4.4)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>
@@ -86,7 +85,6 @@
 				<eclipse-site>http://download.eclipse.org/releases/luna</eclipse-site>
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
-				<platform-version>[4.3,4.4)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>
@@ -102,7 +100,6 @@
 				<eclipse-site>http://download.eclipse.org/releases/kepler</eclipse-site>
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.3</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.2</rap-site>
-				<platform-version>[4.2,4.3)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>


### PR DESCRIPTION
This commit removes the (apparently unused) `platform-version` property from the `core` and `applications` POMs.

Also, aren't they wrong?
- For the Kepler (4.3) profile, it's set to `[4.2,4.3)` (i.e. include 4.2, exclude 4.3).
- For the Luna (4.4) profiles, it's set to `[4.3,4.4)` (i.e. include 4.3, exclude 4.4).
