### PR TITLE
o.c.simplepv: Ensure NaN is printed, not U+FFFD

### DIFF
--- a/core/plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
+++ b/core/plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
@@ -488,6 +488,11 @@ public class VTypeHelper {
 						return Double.toString(Double.NaN);
 					}
 
+					// Also check for positive and negative infinity.
+					if(Double.isInfinite(numValue.doubleValue())) {
+						return Double.toString(numValue.doubleValue());
+					}
+
 					NumberFormat numberFormat = formatCacheMap.get(precision);
 					if (numberFormat == null) {
 						numberFormat = new DecimalFormat("0"); //$NON-NLS-1$


### PR DESCRIPTION
This fixes an issue where NaN is displayed as the Unicode replacement character symbol under certain conditions.
