### PR TITLE
Allow unsigned data in intensity graph

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/IntensityGraphEditPart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/IntensityGraphEditPart.java
@@ -71,6 +71,8 @@ public class IntensityGraphEditPart extends AbstractPVWidgetEditPart {
 		graph.setMax(model.getMaximum());
 		graph.setDataWidth(model.getDataWidth());
 		graph.setDataHeight(model.getDataHeight());
+		graph.setUnsigned(model.isUnsigned());
+		graph.setUnsignedBits(model.getUnsignedBits());
 		graph.setColorMap(model.getColorMap());
 		graph.setShowRamp(model.isShowRamp());
 		graph.setCropLeft(model.getCropLeft());
@@ -155,8 +157,13 @@ public class IntensityGraphEditPart extends AbstractPVWidgetEditPart {
 		*/
 	private void updatePropSheet() {
 		boolean rgbMode = getWidgetModel().isRGBMode();
+		boolean unsigned = getWidgetModel().isUnsigned();
 		getWidgetModel().setPropertyVisible(
 				IntensityGraphModel.PROP_COLOR_DEPTH, rgbMode);
+		getWidgetModel().setPropertyVisible(
+				IntensityGraphModel.PROP_UNSIGNED, !rgbMode);
+		getWidgetModel().setPropertyVisible(
+				IntensityGraphModel.PROP_UNSIGNED_BITS, !rgbMode && unsigned);
 		getWidgetModel().setPropertyVisible(
 				IntensityGraphModel.PROP_COLOR_MAP, !rgbMode);
 		getWidgetModel().setPropertyVisible(
@@ -256,6 +263,16 @@ public class IntensityGraphEditPart extends AbstractPVWidgetEditPart {
 			}
 		};
 		setPropertyChangeHandler(IntensityGraphModel.PROP_DATA_HEIGHT, handler);
+
+		handler = new IWidgetPropertyChangeHandler(){
+			@Override
+            public boolean handleChange(Object oldValue, Object newValue,
+					IFigure figure) {
+				((IntensityGraphFigure)figure).setUnsignedBits((Integer)newValue);
+				return true;
+			}
+		};
+		setPropertyChangeHandler(IntensityGraphModel.PROP_UNSIGNED_BITS, handler);
 
 		handler = new IWidgetPropertyChangeHandler(){
 			@Override
@@ -390,6 +407,15 @@ public class IntensityGraphEditPart extends AbstractPVWidgetEditPart {
 			public void propertyChange(PropertyChangeEvent evt) {
 				updatePropSheet();
 				((IntensityGraphFigure)getFigure()).setInRGBMode((Boolean)(evt.getNewValue()));				
+			}
+		});
+
+		getWidgetModel().getProperty(IntensityGraphModel.PROP_UNSIGNED).addPropertyChangeListener(new PropertyChangeListener() {
+
+			@Override
+			public void propertyChange(PropertyChangeEvent evt) {
+				updatePropSheet();
+				((IntensityGraphFigure)getFigure()).setUnsigned((Boolean)evt.getNewValue());
 			}
 		});
 

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/IntensityGraphModel.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/IntensityGraphModel.java
@@ -181,6 +181,10 @@ public class IntensityGraphModel extends AbstractPVWidgetModel {
 		
 	public static final String PROP_COLOR_DEPTH = "color_depth"; //$NON-NLS-1$
 	
+	public static final String PROP_UNSIGNED = "unsigned"; //$NON-NLS-1$
+
+	public static final String PROP_UNSIGNED_BITS = "unsigned_bits"; //$NON-NLS-1$
+
 	public static final String PROP_SINGLE_LINE_PROFILING = "single_line_profiling"; //$NON-NLS-1$
 	
 	public static final String PROP_ROI_COLOR= "roi_color"; //$NON-NLS-1$
@@ -264,6 +268,12 @@ public class IntensityGraphModel extends AbstractPVWidgetModel {
 		addProperty(new ComboProperty(PROP_COLOR_DEPTH, "Color Depth", 
 				WidgetPropertyCategory.Behavior, ColorDepth.stringValues(), 0), true);
 		
+		addProperty(new BooleanProperty(PROP_UNSIGNED, "Unsigned Data",
+				WidgetPropertyCategory.Behavior, false));
+
+		addProperty(new IntegerProperty(PROP_UNSIGNED_BITS, "Unsigned Length (bits)",
+				WidgetPropertyCategory.Behavior, 0));
+
 		addProperty(new BooleanProperty(PROP_SINGLE_LINE_PROFILING, "Profile on Single Line",
 				WidgetPropertyCategory.Behavior, false),true);
 		
@@ -425,6 +435,20 @@ public class IntensityGraphModel extends AbstractPVWidgetModel {
 		return (Integer) getCastedPropertyValue(PROP_DATA_HEIGHT);
 	}
 	
+	/**
+	 * @return if the data is unsigned
+	 */
+	public boolean isUnsigned() {
+		return (Boolean) getCastedPropertyValue(PROP_UNSIGNED);
+	}
+
+	/**
+	 * @return the number of unsigned bits
+	 */
+	public int getUnsignedBits() {
+		return (Integer) getCastedPropertyValue(PROP_UNSIGNED_BITS);
+	}
+
 	/**
 	 * @return the graph area width
 	 */

--- a/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/IntensityGraphFigure.java
+++ b/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/IntensityGraphFigure.java
@@ -344,6 +344,22 @@ public class IntensityGraphFigure extends Figure implements Introspectable {
 			}
 		}
 		
+		private synchronized IPrimaryArrayWrapper convertFromUnsignedArray(IPrimaryArrayWrapper data, int bits) {
+			if(bits == 0) {
+				return data;
+			}
+			double[] result = new double[data.getSize()];
+			double offset = Math.pow(2, bits);
+			for(int i=0; i<data.getSize(); i++) {
+				if(data.get(i) < 0) {
+					result[i] = data.get(i) + offset;
+				} else {
+					result[i] = data.get(i);
+				}
+			}
+			return new DoubleArrayWrapper(result);
+		}
+
 		
 		private synchronized IPrimaryArrayWrapper cropDataArray(int left, int right, int top, int bottom){
 			if((left != 0 || right != 0 || top != 0 || bottom != 0) &&
@@ -443,7 +459,10 @@ public class IntensityGraphFigure extends Figure implements Introspectable {
 					return;
 				
 				croppedDataArray = cropDataArray(cropLeft, cropRight, cropTop, cropBottom);
-				
+				if(unsigned) {
+					croppedDataArray = convertFromUnsignedArray(croppedDataArray, unsignedBits);
+				}
+
 				fireProfileDataChanged(croppedDataArray, croppedDataWidth, croppedDataHeight);
 //				for(ROIFigure roiFigure : roiMap.values()){
 //					roiFigure.fireROIUpdated();
@@ -676,6 +695,8 @@ public class IntensityGraphFigure extends Figure implements Introspectable {
 
 	private int dataWidth, dataHeight;
 	private int cropLeft, cropRight, cropTop, cropBottom;
+	private int unsignedBits;
+	private boolean unsigned;
 //	private double[] dataArray;
 	private IPrimaryArrayWrapper dataArray;
 	
@@ -1057,6 +1078,14 @@ public class IntensityGraphFigure extends Figure implements Introspectable {
 		return dataWidth;
 	}
 
+	public boolean isUnsigned() {
+		return unsigned;
+	}
+
+	public int getUnsignedBits() {
+		return unsignedBits;
+	}
+
 	public GraphArea getGraphArea() {
 		return graphArea;
 	}
@@ -1419,6 +1448,17 @@ public class IntensityGraphFigure extends Figure implements Introspectable {
 		updateCroppedDataSize();
 		dataDirty = true;
 		repaint();
+	}
+
+	public void setUnsigned(boolean unsigned) {
+		this.unsigned = unsigned;
+	}
+
+	/**
+	 * @param bits the number of bits in the unsigned data, or zero
+	 */
+	public final void setUnsignedBits(int bits) {
+		this.unsignedBits = bits;
 	}
 
 	/**Set if the input data is in RGB mode. For example, the input data is a 1D array of


### PR DESCRIPTION
Adds options to the Intensity Graph widget that make it possible to display unsigned data.
