### PR TITLE
Display trailing zero when precision is specified in exponential mode.

### DIFF
--- a/core/plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
+++ b/core/plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java
@@ -529,7 +529,7 @@ public class VTypeHelper {
 				final StringBuffer pattern = new StringBuffer(10);
 				pattern.append("0."); //$NON-NLS-1$
 				for (int i = 0; i < precision; ++i)
-					pattern.append('#'); //$NON-NLS-1$
+					pattern.append('0'); //$NON-NLS-1$
 				pattern.append("E0"); //$NON-NLS-1$
 				numberFormat = new DecimalFormat(pattern.toString());
 				formatCacheMap.put(-precision, numberFormat);


### PR DESCRIPTION
When a precision is selected in exponential mode this wouldn't display trailing zeros, meaning that the number would 'jump' around as the number of digits shown changes.
