### PR TITLE
o.c.opibuilder: Don't default OPI Runtime perspetive switching to true

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
@@ -65,6 +65,8 @@ public class PreferencesHelper {
 	public static final String OPI_SEARCH_PATH="opi_search_path"; //$NON-NLS-1$
 	public static final String PV_CONNECTION_LAYER = "pv_connection_layer"; //$NON-NLS-1$
     public static final String DEFAULT_TO_CLASSIC_STYLE = "default_to_classic_style";
+	public static final String OPEN_OPI_RUNTIME_PERSPECTIVE="open_opi_runtime_perspective"; //$NON-NLS-1$
+
 	//The widgets that are hidden from palette.
 	public static final String HIDDEN_WIDGETS="hidden_widgets"; //$NON-NLS-1$
 	
@@ -466,6 +468,23 @@ public class PreferencesHelper {
     public static boolean isAboutShowLinks(){
       	final IPreferencesService service = Platform.getPreferencesService();
     	return service.getBoolean(OPIBuilderPlugin.PLUGIN_ID, ABOUT_SHOW_LINKS, true, null);
+    }
+
+    /**
+     * Set if the OPI Runtime Perspective should be opened when a new view is requested.
+     * @param if the OPI Runtime Perspective should be opened.
+     */
+    public static void setSwitchToOpiRuntimePerspective(boolean b) {
+        putBoolean(OPEN_OPI_RUNTIME_PERSPECTIVE, b);
+    }
+
+    /**
+     * Should the OPI Runtime Perspective be opened when a new view is requested.
+     * @return if the OPI Runtime Perspective should be opened.
+     */
+    public static boolean isSwitchToOpiRuntimePerspective() {
+        final IPreferencesService service = Platform.getPreferencesService();
+        return service.getBoolean(OPIBuilderPlugin.PLUGIN_ID, OPEN_OPI_RUNTIME_PERSPECTIVE, false, null);
     }
 
 }

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/RunModeService.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/RunModeService.java
@@ -216,18 +216,21 @@ public class RunModeService {
 					// Open a new view					
 					if(position != Position.DETACHED && position != Position.DEFAULT_VIEW &&
 							!(page.getPerspective().getId().equals(OPIRunnerPerspective.ID))){
-						int openCode=0;
-						if(!OPIBuilderPlugin.isRAP() && PreferencesHelper.isShowOpiRuntimePerspectiveDialog()){
-							TipDialog dialog = new TipDialog(window.getShell(), MessageDialog.QUESTION, 
-									"Switch to OPI Runtime Perspective", 
-									"To open the OPI View in expected position, you need to switch to OPI Runtime perspective."+
-								"\nDo you want to switch to it now?");
-							openCode=dialog.open();								
-							if(!dialog.isShowThisDialogAgain())
-								PreferencesHelper.setShowOpiRuntimePerspectiveDialog(false);
+						if(!OPIBuilderPlugin.isRAP()) {
+							if(PreferencesHelper.isShowOpiRuntimePerspectiveDialog()) {
+								TipDialog dialog = new TipDialog(window.getShell(), MessageDialog.QUESTION, 
+										"Switch to OPI Runtime Perspective", 
+										"To open the OPI View in expected position, you need to switch to OPI Runtime perspective."+
+										"\nDo you want to switch to it now?");
+								PreferencesHelper.setSwitchToOpiRuntimePerspective(dialog.open() == Window.OK);
+								if(!dialog.isShowThisDialogAgain()) {
+									PreferencesHelper.setShowOpiRuntimePerspectiveDialog(false);
+								}
+							}
+							if(PreferencesHelper.isSwitchToOpiRuntimePerspective()) {
+								PerspectiveHelper.showPerspective(OPIRunnerPerspective.ID, window.getActivePage());
+							}
 						}
-						if(openCode==0 ||openCode==Window.OK)
-							PerspectiveHelper.showPerspective(OPIRunnerPerspective.ID, window.getActivePage());						
 					}
 
 					// View will receive input from us, should ignore previous memento


### PR DESCRIPTION
Remember the users choice when dismissing the 'Open OPI in runtime perspective' dialogue, instead of assuming the user wishes to switch to that perspective.
