### PR TITLE
Fix bug: The length of polyline can be unexpectedly longer on OPI

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/PointListCreationTool.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/feedback/PointListCreationTool.java
@@ -179,6 +179,7 @@ public final class PointListCreationTool extends TargetingTool {
 		setState(STATE_TERMINAL);
 		handleFinished();
 		updateTargetRequest();
+		setCurrentCommand(getCommand());
 		return true;
 	}
 	
@@ -237,6 +238,7 @@ public final class PointListCreationTool extends TargetingTool {
 			}
 
 		updateTargetRequest();
+		setCurrentCommand(getCommand());
 		return true;
 	}
 


### PR DESCRIPTION
Fix bug: The length of polyline can be unexpectedly longer on OPI