### PR TITLE
Add crop option to Linking Container

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activePipClass.java
+++ b/applications/plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activePipClass.java
@@ -108,6 +108,8 @@ public class Opi_activePipClass extends OpiWidget {
 			createPVOutputRule(r, convertPVName(r.getFilePv()), "opi_file", "pvStr0", "OPIFileFromPVRule");
 		}
 		
+		new OpiString(widgetContext, "resize_behaviour", "2");
+
 		log.debug("Edm_activePipClass written.");
 
 	}

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -127,29 +127,22 @@ public class LinkingContainerEditpart extends AbstractContainerEditpart{
 
 		setPropertyChangeHandler(LinkingContainerModel.PROP_GROUP_NAME, handler);
 
-
-		handler = new IWidgetPropertyChangeHandler(){
-			public boolean handleChange(Object oldValue, Object newValue,
-					IFigure figure) {
-				((LinkingContainerFigure)figure).setZoomToFitAll((Boolean)newValue);
-				((LinkingContainerFigure)figure).updateZoom();
-				return true;
-			}
-		};
-		setPropertyChangeHandler(LinkingContainerModel.PROP_ZOOMTOFITALL, handler);
-
 		handler = new IWidgetPropertyChangeHandler() {
-			
 			public boolean handleChange(Object oldValue, Object newValue, IFigure figure) {
-				if((Boolean)newValue)
+				if((int)newValue == LinkingContainerModel.ResizeBehaviour.SIZE_OPI_TO_CONTAINER.ordinal()) {
+					((LinkingContainerFigure)figure).setZoomToFitAll(true);
+				} else {
+					((LinkingContainerFigure)figure).setZoomToFitAll(false);
+				}
+				((LinkingContainerFigure)figure).updateZoom();
+
+				if((int)newValue == LinkingContainerModel.ResizeBehaviour.SIZE_CONTAINER_TO_OPI.ordinal()) {
 					performAutosize();
+				}
 				return false;
 			}
 		};
-		setPropertyChangeHandler(LinkingContainerModel.PROP_AUTO_SIZE, handler);
-		
-
-
+		setPropertyChangeHandler(LinkingContainerModel.PROP_RESIZE_BEHAVIOUR, handler);
 	}
 
 
@@ -275,6 +268,7 @@ public class LinkingContainerEditpart extends AbstractContainerEditpart{
 						childrenRange.height +childrenRange.y+ figure.getInsets().top + figure.getInsets().bottom-1));
 					getWidgetModel().scaleChildren();
 				}
+				((LinkingContainerFigure)getFigure()).setShowScrollBars(getWidgetModel().isShowScrollBars());
 				((LinkingContainerFigure)getFigure()).setZoomToFitAll(getWidgetModel().isAutoFit());
 				((LinkingContainerFigure)getFigure()).updateZoom();				
 			}

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
@@ -9,6 +9,7 @@ package org.csstudio.opibuilder.widgets.model;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Level;
 
 import org.csstudio.opibuilder.OPIBuilderPlugin;
 import org.csstudio.opibuilder.editparts.AbstractBaseEditPart;
@@ -16,16 +17,19 @@ import org.csstudio.opibuilder.model.AbstractContainerModel;
 import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.csstudio.opibuilder.model.DisplayModel;
 import org.csstudio.opibuilder.properties.BooleanProperty;
+import org.csstudio.opibuilder.properties.ComboProperty;
 import org.csstudio.opibuilder.properties.FilePathProperty;
 import org.csstudio.opibuilder.properties.StringProperty;
 import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
 import org.csstudio.opibuilder.util.ResourceUtil;
 import org.csstudio.opibuilder.visualparts.BorderStyle;
+import org.csstudio.opibuilder.widgets.Activator;
 import org.csstudio.opibuilder.widgets.editparts.LinkingContainerEditpart;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.gef.GraphicalViewer;
+import org.osgi.framework.Version;
 
 /**The model for linking container widget.
  * @author Xihui Chen
@@ -38,6 +42,28 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	 */
 	public static final String ID = "org.csstudio.opibuilder.widgets.linkingContainer"; //$NON-NLS-1$	
 	
+	/**
+	 * Versions before this didn't have an updated resize behaviour.
+	 */
+	public static final Version VERSION_CHANGE_OF_RESIZE_BEHAVIOUR = new Version(4, 0, 103);
+
+	/**
+	 * How should the container behave when the OPI it is wrapping has content of a different size to the widget.
+	 */
+	public enum ResizeBehaviour {
+		SIZE_OPI_TO_CONTAINER,
+		SIZE_CONTAINER_TO_OPI,
+		CROP_OPI,
+		SCROLL_OPI;
+
+		public final static String[] stringValues = {
+				"Size *.opi to fit the container",
+				"Size the container to fit the linked *.opi",
+				"Don't resize anything, crop if *.opi to large for container",
+				"Don't resize anything, add scrollbars if *.opi to large for container",
+				};
+	}
+
 	/**
 	 * The ID of the resource property.
 	 */
@@ -53,11 +79,20 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	/**
 	 * The ID of the auto zoom property.
 	 */
+	@Deprecated
 	public static final String PROP_ZOOMTOFITALL = "zoom_to_fit"; //$NON-NLS-1$
 	
+	/**
+	 *  The ID of the auto scale property.
+	 */
+	@Deprecated
 	public static final String PROP_AUTO_SIZE = "auto_size"; //$NON-NLS-1$
 	
-	
+	/**
+	 * How the widget should behave when the contents is not the same size as the widget.
+	 */
+	public static final String PROP_RESIZE_BEHAVIOUR = "resize_behaviour"; //$NON-NLS-1$
+
 	/**
 	 * The default value of the height property.
 	 */
@@ -94,7 +129,13 @@ public class LinkingContainerModel extends AbstractContainerModel {
 				WidgetPropertyCategory.Behavior, "")); //$NON-NLS-1$
 		
 		addProperty(new BooleanProperty(PROP_ZOOMTOFITALL, "Zoom to Fit", WidgetPropertyCategory.Display, true));
-		addProperty(new BooleanProperty(PROP_AUTO_SIZE, "Auto Size", WidgetPropertyCategory.Display, false));
+		setPropertyVisibleAndSavable(PROP_ZOOMTOFITALL, false, false);
+
+		addProperty(new BooleanProperty(PROP_AUTO_SIZE, "Auto Size", WidgetPropertyCategory.Display, true));
+		setPropertyVisibleAndSavable(PROP_AUTO_SIZE, false, false);
+
+		addProperty(new ComboProperty(PROP_RESIZE_BEHAVIOUR, "Resize Behaviour",
+				WidgetPropertyCategory.Display, ResizeBehaviour.stringValues, ResizeBehaviour.SIZE_OPI_TO_CONTAINER.ordinal()));
 	}
 
 	@Override
@@ -123,11 +164,15 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	 * @return the auto zoom state
 	 */
 	public boolean isAutoFit() {
-		return (Boolean) getProperty(PROP_ZOOMTOFITALL).getPropertyValue();
+		return (int)getProperty(PROP_RESIZE_BEHAVIOUR).getPropertyValue() == ResizeBehaviour.SIZE_OPI_TO_CONTAINER.ordinal();
 	}
 	
 	public boolean isAutoSize() {
-		return (Boolean) getProperty(PROP_AUTO_SIZE).getPropertyValue();
+		return (int)getProperty(PROP_RESIZE_BEHAVIOUR).getPropertyValue() == ResizeBehaviour.SIZE_CONTAINER_TO_OPI.ordinal();
+	}
+
+	public boolean isShowScrollBars() {
+		return (int)getProperty(PROP_RESIZE_BEHAVIOUR).getPropertyValue() == ResizeBehaviour.SCROLL_OPI.ordinal();
 	}
 	
 	public String getGroupName(){
@@ -154,6 +199,21 @@ public class LinkingContainerModel extends AbstractContainerModel {
 			scaleChildren();
 		
 	}
+
+	@Override
+	public void processVersionDifference(org.osgi.framework.Version boyVersionOnFile) {
+		super.processVersionDifference(boyVersionOnFile);
+		if(boyVersionOnFile.compareTo(VERSION_CHANGE_OF_RESIZE_BEHAVIOUR) < 0) {
+			Activator.getLogger().log(Level.CONFIG, "Converting linking container to new style of resizing behaviour.");
+			if((Boolean)getPropertyValue(PROP_AUTO_SIZE)) {
+				setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SIZE_CONTAINER_TO_OPI.ordinal());
+			} else if((Boolean)getPropertyValue(PROP_ZOOMTOFITALL)) {
+				setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SIZE_OPI_TO_CONTAINER.ordinal());
+			} else {
+				setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SCROLL_OPI.ordinal());
+			}
+		}
+	};
 
 	/**
 	 * Scale its children. 

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
@@ -59,8 +59,8 @@ public class LinkingContainerModel extends AbstractContainerModel {
 		public final static String[] stringValues = {
 				"Size *.opi to fit the container",
 				"Size the container to fit the linked *.opi",
-				"Don't resize anything, crop if *.opi to large for container",
-				"Don't resize anything, add scrollbars if *.opi to large for container",
+				"Don't resize anything, crop if *.opi too large for container",
+				"Don't resize anything, add scrollbars if *.opi too large for container",
 				};
 	}
 

--- a/applications/plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY base plugin
 Bundle-Description: Base plugin of BOY
 Bundle-SymbolicName: org.csstudio.opibuilder;singleton:=true
-Bundle-Version: 4.0.102.qualifier
+Bundle-Version: 4.0.103.qualifier
 Bundle-Activator: org.csstudio.opibuilder.OPIBuilderPlugin
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-Localization: plugin

--- a/applications/plugins/org.csstudio.opibuilder/pom.xml
+++ b/applications/plugins/org.csstudio.opibuilder/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.opibuilder</artifactId>
-  <version>4.0.102-SNAPSHOT</version>
+  <version>4.0.103-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LinkingContainerFigure.java
+++ b/applications/plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LinkingContainerFigure.java
@@ -33,6 +33,7 @@ public class LinkingContainerFigure extends Figure implements Introspectable {
 	
 	private ScalableFreeformLayeredPane pane;
 	
+	private ScrollPane scrollPane;
 	
 	private ZoomManager zoomManager;
 	
@@ -40,7 +41,7 @@ public class LinkingContainerFigure extends Figure implements Introspectable {
 	
 	@SuppressWarnings("deprecation")
 	public LinkingContainerFigure() {
-		ScrollPane scrollPane = new ScrollPane();
+		scrollPane = new ScrollPane();
 		pane = new ScalableFreeformLayeredPane();
 		pane.setLayoutManager(new FreeformLayout());
 		setLayoutManager(new StackLayout());
@@ -120,6 +121,16 @@ public class LinkingContainerFigure extends Figure implements Introspectable {
 
 	public BeanInfo getBeanInfo() throws IntrospectionException {
 		return new DefaultWidgetIntrospector().getBeanInfo(this.getClass());
+	}
+
+	public void setShowScrollBars(boolean showScrollBars) {
+		if(showScrollBars) {
+			scrollPane.setHorizontalScrollBarVisibility(ScrollPane.AUTOMATIC);
+			scrollPane.setVerticalScrollBarVisibility(ScrollPane.AUTOMATIC);
+		} else {
+			scrollPane.setHorizontalScrollBarVisibility(ScrollPane.NEVER);
+			scrollPane.setVerticalScrollBarVisibility(ScrollPane.NEVER);
+		}
 	}
 	
 


### PR DESCRIPTION
This addresses issue #871.

The pair of checkboxes that provide the auto_size and zoom_to_fit options have been removed, and replaced with a combo box that also allows you to chose if you want the crop option as well.

I also incremented the version number in opibuilder, although I'm not sure if it's the correct time to do this.

OPIs made in an older opibuilder should be converted to the new format transparently, while EDM conversions should now use the new crop option.