### PR TITLE
Bug898

### DIFF
--- a/applications/plugins/org.csstudio.vtype.pv.test/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.vtype.pv.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-SymbolicName: org.csstudio.vtype.pv.test
 Fragment-Host: org.csstudio.vtype.pv
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Version: 1.2.101.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-Version: 4.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.8.2"
 Export-Package: org.csstudio.vtype.pv

--- a/applications/plugins/org.csstudio.vtype.pv.test/pom.xml
+++ b/applications/plugins/org.csstudio.vtype.pv.test/pom.xml
@@ -8,7 +8,7 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <groupId>org.csstudio</groupId>
-  <version>1.2.101-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   
   <artifactId>org.csstudio.vtype.pv.test</artifactId>

--- a/applications/plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/PVA_PVTest.java
+++ b/applications/plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/PVA_PVTest.java
@@ -16,6 +16,9 @@ import static org.junit.Assert.assertThat;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.csstudio.vtype.pv.pva.PVA_Context;
 import org.csstudio.vtype.pv.pva.PVA_PVFactory;
@@ -27,21 +30,30 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /** JUnit demo of the PVA_PV
- * 
- *  <p>Requires PVs from V4 pvaSrv/exampleApp/iocBoot/simpleDbPv
- *  
+ *
+ *  <p>Requires PVs from V4 pvDatabaseCPP/exampleServer/iocBoot/exampleServer
+ *
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class PVA_PVTest
 {
     private static PVFactory factory;
 
     @BeforeClass
     public static void setup()
-    {   // Not using PVPool, but directly creating factory
+    {
+        // Set log level
+        final Level level = Level.CONFIG;
+        final Logger logger = Logger.getLogger("");
+        logger.setLevel(level);
+        for (Handler handler : logger.getHandlers())
+            handler.setLevel(level);
+
+        // Not using PVPool, but directly creating factory
         factory = new PVA_PVFactory();
     }
-    
+
     @AfterClass
     public static void shutdown() throws Exception
     {
@@ -54,26 +66,20 @@ public class PVA_PVTest
     {
         for (String type_name[] : new String[][]
             {
-        		{ "Long",   "TESTLONG" },
-        		{ "Double", "TESTDBL" },
-        		{ "Enum",   "TESTDBL.SCAN" },
-        		{ "String", "TESTDBL.DESC" },
-        		{ "Byte",   "TESTDBL.UDF" },
-        		{ "String", "TESTDBL.RTYP" },
-        		
-        		// DTYP is readable via the C++ 'pvget',
-        		// presented as an oddball enum with only one option.
-        		// The Java pvAccess implementation gives
-        		// "WARNING: record type has no device support"
-        		// and the  MonitorRequester.monitorConnect()
-        		// receives an error Status.
-        		// TODO Check in future Java pvAccess version
-        		// { "Enum",   "TESTDBL.DTYP" },
+                { "Double", "pvdouble" },
+        		{ "Long",   "pvdouble.RVAL" },
+        		{ "Enum",   "pvdouble.SCAN" },
+        		{ "String", "pvdouble.DESC" },
+        		{ "Byte",   "pvdouble.UDF" },
+        		{ "String", "pvdouble.RTYP" },
+        		{ "Enum",   "pvdouble.DTYP" },
+                { "Double Array",  "pvdoubleArray" },
+                { "String Array",  "pvstringArray" },
 
         		// Fails in C++ 'pvget -m' as well with
         		// "can not monitor a link field".
         		// TODO Issue initial get?
-        		// { "String", "TESTDBL.INPA" },
+        		// { "String", "pvcounter.INPA" },
             })
         {
         	final String type = type_name[0];
@@ -89,6 +95,12 @@ public class PVA_PVTest
                     System.out.println(pv.getName() + " value changed to " + value);
                     updates.countDown();
                 }
+
+                @Override
+                public void disconnected(final PV pv)
+                {
+                    System.out.println(pv.getName() + " closed");
+                }
             };
             pv.addListener(listener);
             updates.await();
@@ -96,8 +108,8 @@ public class PVA_PVTest
         }
     }
 
-    final private static String name = "TESTDBL";
-    
+    final private static String name = "pvdouble";
+
     @Test(timeout=10000)
     public void testWriteString() throws Exception
     {
@@ -111,7 +123,7 @@ public class PVA_PVTest
         System.out.println(current);
         assertThat(current, instanceOf(VString.class));
         assertThat("Hi", equalTo( ((VString)current).getValue() ));
-        
+
         written = pv.asyncWrite("There");
         written.get(200000, TimeUnit.SECONDS);
 
@@ -120,7 +132,7 @@ public class PVA_PVTest
         System.out.println(current);
         assertThat(current, instanceOf(VString.class));
         assertThat("There", equalTo( ((VString)current).getValue() ));
-        
+
         pv.close();
     }
 
@@ -128,7 +140,7 @@ public class PVA_PVTest
     public void testWriteEnum() throws Exception
     {
         final PV pv = factory.createPV("pva://" + name + ".SCAN", name + ".SCAN");
-        
+
         // .. as number
         Future<?> written = pv.asyncWrite(5);
         written.get(2000000, TimeUnit.SECONDS);
@@ -138,7 +150,7 @@ public class PVA_PVTest
         System.out.println(current);
         assertThat(current, instanceOf(VEnum.class));
         assertThat(5, equalTo( ((VEnum)current).getIndex() ));
-        
+
         written = pv.asyncWrite(6);
         written.get(200000, TimeUnit.SECONDS);
 
@@ -157,24 +169,24 @@ public class PVA_PVTest
         System.out.println(current);
         assertThat(current, instanceOf(VEnum.class));
         assertThat("2 second", equalTo( ((VEnum)current).getValue() ));
-        
+
         written = pv.asyncWrite("1 second");
         written.get(200000, TimeUnit.SECONDS);
-        
+
         get_current = pv.asyncRead();
         current = get_current.get();
         System.out.println(current);
         assertThat(current, instanceOf(VEnum.class));
         assertThat("1 second", equalTo( ((VEnum)current).getValue() ));
-        
+
         pv.close();
     }
-    
+
     @Test(timeout=10000)
     public void testAsynRead() throws Exception
     {
-        final PV pv = factory.createPV("TESTDBL", "TESTDBL");
-        
+        final PV pv = factory.createPV(name, name);
+
         for (int i=0; i<10; ++i)
         {
             final Future<VType> result = pv.asyncRead();
@@ -182,7 +194,7 @@ public class PVA_PVTest
             System.out.println(pv + "  " + pv.read());
             assertThat(value, not(nullValue()));
         }
-        
+
         pv.close();
     }
 }

--- a/applications/plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/PVNameHelperTest.java
+++ b/applications/plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/PVNameHelperTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.csstudio.vtype.pv.pva.PVNameHelper;
+import org.junit.Test;
+
+/** JUnit test of {@link PVNameHelper}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PVNameHelperTest
+{
+    @Test
+    public void testPlainName() throws Exception
+    {
+        final String pv = "channel_name";
+        final PVNameHelper parser = PVNameHelper.forName(pv);
+        System.out.println(pv + " -> " + parser);
+        assertThat(parser.getChannel(), equalTo("channel_name"));
+        assertThat(parser.getReadRequest(), equalTo("field()"));
+        assertThat(parser.getWriteRequest(), equalTo("field(value)"));
+    }
+
+    @Test
+    public void testRequest() throws Exception
+    {
+        final String pv = "channel_name?request=field(some.structure.element)";
+        final PVNameHelper parser = PVNameHelper.forName(pv);
+        System.out.println(pv + " -> " + parser);
+        assertThat(parser.getChannel(), equalTo("channel_name"));
+        assertThat(parser.getReadRequest(), equalTo("field(some.structure.element)"));
+        assertThat(parser.getWriteRequest(), equalTo("field(some.structure.element.value)"));
+
+        try
+        {
+            PVNameHelper.forName("channel_name?unsupported=42");
+            fail("Should only support '?request..' query");
+        }
+        catch (Exception ex)
+        {
+            assertThat(ex.getMessage(), containsString("unsupported"));
+        }
+    }
+
+    @Test
+    public void testPath() throws Exception
+    {
+        String pv = "channel_name/some/structure.element";
+        PVNameHelper parser = PVNameHelper.forName(pv);
+        System.out.println(pv + " -> " + parser);
+        assertThat(parser.getChannel(), equalTo("channel_name"));
+        assertThat(parser.getReadRequest(), equalTo("field(some.structure.element)"));
+        assertThat(parser.getWriteRequest(), equalTo("field(some.structure.element.value)"));
+
+        pv = "channel_name/";
+        parser = PVNameHelper.forName("channel_name/");
+        System.out.println(pv + " -> " + parser);
+        assertThat(parser.getChannel(), equalTo("channel_name"));
+        assertThat(parser.getReadRequest(), equalTo("field()"));
+        assertThat(parser.getWriteRequest(), equalTo("field(value)"));
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.vtype.pv/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Basic PV that provides VType data
 Bundle-SymbolicName: org.csstudio.vtype.pv;singleton:=true
-Bundle-Version: 1.3.2.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-Version: 4.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>
 Require-Bundle: org.junit;bundle-version="4.8.2";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/applications/plugins/org.csstudio.vtype.pv/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.vtype.pv/META-INF/MANIFEST.MF
@@ -10,8 +10,8 @@ Require-Bundle: org.junit;bundle-version="4.8.2";resolution:=optional,
  org.epics.vtype;bundle-version="2.1.0",
  org.csstudio.platform.libs.epics;bundle-version="3.2.0",
  org.epics.util,
- org.epics.pvdata;bundle-version="3.0.3",
- org.epics.pvaccess;bundle-version="3.0.5"
+ org.epics.pvDataJava;bundle-version="3.1.1",
+ org.epics.pvAccessJava;bundle-version="3.1.1"
 Export-Package: org.csstudio.vtype.pv,
  org.csstudio.vtype.pv.jca,
  org.csstudio.vtype.pv.local

--- a/applications/plugins/org.csstudio.vtype.pv/pom.xml
+++ b/applications/plugins/org.csstudio.vtype.pv/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.vtype.pv</artifactId>
-  <version>1.3.2-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_Context.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_Context.java
@@ -6,33 +6,35 @@
  * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.csstudio.vtype.pv.pva;
+import java.util.Arrays;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.epics.pvaccess.ClientFactory;
 import org.epics.pvaccess.client.ChannelProvider;
-import org.epics.pvaccess.client.impl.remote.ClientContextImpl;
+import org.epics.pvaccess.client.ChannelProviderRegistry;
+import org.epics.pvaccess.client.ChannelProviderRegistryFactory;
 
 /** Singleton context for pvAccess
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class PVA_Context
 {
     private static PVA_Context instance;
-    
-    final private ClientContextImpl context;
+
     final private ChannelProvider provider;
 
     private PVA_Context() throws Exception
     {
         ClientFactory.start();
-        context = new ClientContextImpl();
-        context.initialize();
-        
-        Logger.getLogger(getClass().getName()).config(context.getVersion().toString());
-
-        provider = context.getProvider();
+        final ChannelProviderRegistry registry = ChannelProviderRegistryFactory.getChannelProviderRegistry();
+        provider = registry.getProvider("pva");
+        if (provider == null)
+            throw new Exception("Tried to locate 'pva' provider, found " + Arrays.toString(registry.getProviderNames()));
+        Logger.getLogger(getClass().getName()).log(Level.CONFIG, "PVA Provider {0}", provider.getProviderName());
     }
-    
+
     /** @return Singleton instance */
     public static synchronized PVA_Context getInstance() throws Exception
     {
@@ -40,7 +42,7 @@ public class PVA_Context
             instance = new PVA_Context();
         return instance;
     }
-    
+
     /** @return {@link ChannelProvider} */
     public ChannelProvider getProvider()
     {
@@ -52,7 +54,6 @@ public class PVA_Context
      */
     public void close()
     {
-        context.destroy();
         ClientFactory.stop();
     }
 }

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
@@ -272,9 +272,22 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
             if (current instanceof VEnum)
             {
                 final int index = enum_labels.indexOf(new_value);
-                if (index < 0)
-                    throw new Exception("Cannot obtain label's index for enum PV " + getName());
-                new_value = index;
+                if (index >= 0)
+                    new_value = index;
+                else
+                    if (new_value instanceof String)
+                    {   // Try parsing number from string
+                        try
+                        {
+                            new_value = Integer.valueOf((String) new_value);
+                        }
+                        catch (NumberFormatException ex)
+                        {
+                            throw new Exception("Cannot obtain index for enum PV " + getName() + " from value " + new_value);
+                        }
+                    }
+                    else
+                        throw new Exception("Cannot obtain label's index for enum PV " + getName() + " from value " + new_value);
             }
         }
 

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
@@ -86,13 +86,19 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
                              .createChannel(request_helper.getChannel(), this, priority);
     }
 
-    /** Is read request for a specific sub-field of a structure?
+    /** Is read request for a specific sub-(sub-sub)-field of a structure?
      *  @param read_request Read request
      *  @return Name of specific structure field
      */
     private Optional<String> checkForStructureField(final PVStructure read_request)
     {
-        final PVStructure element = read_request.getSubField(PVStructure.class, "field");
+        // read_request = structure
+        //                   structure field   <-- Marks this is a request for fields
+        //                        structure some_field
+        //                            structure some_subfield
+        // TODO: Locate the deepest sub field? Or follow a path?
+        // This currently only goes one level down just like pvmanager.pva
+        PVStructure element = read_request.getSubField(PVStructure.class, "field");
         if (element != null)
         {
             final String[] fields = element.getStructure().getFieldNames();

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
@@ -228,9 +228,6 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
         {
             try
             {
-                // TODO Copy only changes?
-                // System.out.println(update.getChangedBitSet());
-                // System.out.println(struct);
                 handleValueUpdate(update.getPVStructure());
             }
             catch (Exception ex)

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
@@ -17,7 +17,7 @@ import org.epics.pvaccess.client.Channel;
 import org.epics.pvaccess.client.Channel.ConnectionState;
 import org.epics.pvaccess.client.ChannelProvider;
 import org.epics.pvaccess.client.ChannelRequester;
-import org.epics.pvaccess.client.CreateRequest;
+import org.epics.pvdata.copy.CreateRequest;
 import org.epics.pvdata.monitor.Monitor;
 import org.epics.pvdata.monitor.MonitorElement;
 import org.epics.pvdata.monitor.MonitorRequester;
@@ -97,7 +97,9 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
     public void channelCreated(final Status status, final Channel channel)
     {
         if (status.isSuccess())
+        {
             logger.log(Level.FINE, "Channel {0} created", channel.getChannelName());
+        }
         else
             logger.log(Level.WARNING, "Channel {0} status {1}",
                                    new Object[] { channel.getChannelName(), status.getMessage() });

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVGetHandler.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVGetHandler.java
@@ -18,6 +18,7 @@ import org.epics.pvaccess.client.ChannelGetRequester;
 import org.epics.pvdata.misc.BitSet;
 import org.epics.pvdata.pv.PVStructure;
 import org.epics.pvdata.pv.Status;
+import org.epics.pvdata.pv.Structure;
 import org.epics.vtype.VType;
 
 /** A {@link ChannelGetRequester} for reading a value from a {@link PVA_PV},
@@ -29,8 +30,6 @@ import org.epics.vtype.VType;
 class PVGetHandler extends PVRequester implements ChannelGetRequester, Future<VType>
 {
     final private PVA_PV pv;
-
-    private volatile PVStructure data; // TODO Remove in 4.4 when getDone receives the data
 
     final private CountDownLatch updates = new CountDownLatch(1);
     private volatile VType value = null;
@@ -45,7 +44,7 @@ class PVGetHandler extends PVRequester implements ChannelGetRequester, Future<VT
     // ChannelGetRequester
     @Override
     public void channelGetConnect(final Status status, final ChannelGet channelGet,
-            final PVStructure pvStructure, final BitSet bitSet)
+            final Structure structure)
     {
         if (! status.isSuccess())
         {
@@ -54,18 +53,13 @@ class PVGetHandler extends PVRequester implements ChannelGetRequester, Future<VT
         }
         else
         {
-            data = pvStructure;
-            channelGet.get(true);
+            channelGet.get();
         }
     }
 
-    // TODO: Update to 4.4
-    // In 4.3, channelGetConnect() receives the structure which getDone() will see filled with data.
-    // In 4.4., getDone() will receive the filled structure
-
     // ChannelGetRequester
     @Override
-    public void getDone(final Status status)
+    public void getDone(final Status status, final ChannelGet channelGet, final PVStructure data, final BitSet bitSet)
     {
         if (! status.isSuccess())
             error = new Exception("Get failed for " + pv.getName() + ": " + status);

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVNameHelper.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVNameHelper.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Helper for analyzing PV Names
+ *
+ *  <p>Handles these types of names:
+ *  <pre>
+ *  pva://channel_name
+ *  pva://channel_name?request=field(some.structure.element)
+ *  pva://channel_name/some/structure.element
+ *  </pre>
+ *
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class PVNameHelper
+{
+    final private static Pattern REQUEST_PATTERN = Pattern.compile("\\?request=field\\((.*)\\)");
+    final private static int REQUEST_FIELD_START = "?request=".length();
+
+    final private String channel, read, write;
+
+    /** Create parser
+     *
+     *  @param pv_name PV name
+     *  @return {@link PVNameHelper}
+     *  @throws Exception on error
+     */
+    public static PVNameHelper forName(final String pv_name) throws Exception
+    {   // Does name include "?request.."?
+        int pos = pv_name.indexOf('?');
+        if (pos >= 0)
+            return PVNameHelper.forNameWithRequest(pv_name.substring(0, pos), pv_name.substring(pos));
+        // Does name include "/some/path"?
+        pos = pv_name.indexOf('/');
+        if (pos >= 0)
+            return PVNameHelper.forNameWithPath(pv_name.substring(0, pos), pv_name.substring(pos+1));
+        // Plain channel name
+        return new PVNameHelper(pv_name, "field()", "field(value)");
+    }
+
+    /** @param channel Channel name
+     *  @param request "?request..."
+     *  @return {@link PVNameHelper}
+     *  @throws Exception on error
+     */
+    private static PVNameHelper forNameWithRequest(final String channel, final String request) throws Exception
+    {
+        final Matcher matcher = REQUEST_PATTERN.matcher(request);
+        if (! matcher.matches())
+            throw new Exception("Expect ?request=field(...) but got \"" + request + "\"");
+        final String field = matcher.group(1);
+        final String write = field.isEmpty()
+            ? "field(value)"
+            : "field(" + field + ".value)";
+        return new PVNameHelper(channel, request.substring(REQUEST_FIELD_START), write);
+    }
+
+    /** @param channel Channel name
+     *  @param path "to/some/element" (without initial '/')
+     *  @return {@link PVNameHelper}
+     *  @throws Exception on error
+     */
+    private static PVNameHelper forNameWithPath(final String channel, final String path) throws Exception
+    {
+        final String field = path.replace('/', '.');
+        final String write = field.isEmpty()
+                ? "field(value)"
+                : "field(" + field + ".value)";
+        return new PVNameHelper(channel, "field(" + field + ")",  write);
+    }
+
+    /** Private to enforce use of <code>forName</code> */
+    private PVNameHelper(final String channel, final String read, final String write) throws Exception
+    {
+        if (channel.isEmpty())
+            throw new Exception("Empty channel name");
+        this.channel = channel;
+        this.read = read;
+        this.write = write;
+    }
+
+    /** @return Channel name */
+    public String getChannel()
+    {
+        return channel;
+    }
+
+    /** @return Request "field(..)" for reading */
+    public String getReadRequest()
+    {
+        return read;
+    }
+
+    /** @return Request "field(..)" for writing */
+    public String getWriteRequest()
+    {
+        return write;
+    }
+
+    /** @return Debug representation */
+    @Override
+    public String toString()
+    {
+        return "Channel '" + channel +
+                "', read request '" + read +
+                "', write request '" + write + "'";
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVPutHandler.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVPutHandler.java
@@ -66,7 +66,7 @@ class PVPutHandler extends PVRequester implements ChannelPutRequester, Future<Ob
             // Locate the value field
             PVField field = write_structure.getSubField("value");
 
-            // It it enumerated? Write to index field
+            // Enumerated? Write to value.index
             if (field instanceof PVStructure  &&  "enum_t".equals(field.getField().getID()))
                 field = ((PVStructure)field).getSubField("index");
 

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
@@ -116,23 +116,22 @@ class PVStructureHelper
         final ScalarType type = ((ScalarArray) field).getElementType();
         switch (type)
         {
-        // TODO Implement all array types
-//            return new VTypeForFloat(struct);
-//            return new VTypeForLong(struct);
-//            return new VTypeForShort(struct);
-//            return new VTypeForByte(struct);
         case pvDouble:
-        case pvFloat:
             return new VTypeForDouble(struct);
+        case pvFloat:
+            return new VTypeForFloat(struct);
         case pvInt:
         case pvUInt:
+            return new VTypeForIntArray(struct);
         case pvLong:
         case pvULong:
+            return new VTypeForLong(struct);
         case pvShort:
         case pvUShort:
+            return new VTypeForShort(struct);
         case pvByte:
         case pvUByte:
-            return new VTypeForIntArray(struct);
+            return new VTypeForByteArray(struct);
         case pvString:
             return new VTypeForStringArray(struct);
         default:

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
@@ -117,18 +117,18 @@ class PVStructureHelper
         switch (type)
         {
         case pvDouble:
-            return new VTypeForDouble(struct);
+            return new VTypeForDoubleArray(struct);
         case pvFloat:
-            return new VTypeForFloat(struct);
+            return new VTypeForFloatArray(struct);
         case pvInt:
         case pvUInt:
             return new VTypeForIntArray(struct);
         case pvLong:
         case pvULong:
-            return new VTypeForLong(struct);
+            return new VTypeForLongArray(struct);
         case pvShort:
         case pvUShort:
-            return new VTypeForShort(struct);
+            return new VTypeForShortArray(struct);
         case pvByte:
         case pvUByte:
             return new VTypeForByteArray(struct);

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
@@ -42,9 +42,9 @@ class PVStructureHelper
     public static VType getVType(final PVStructure struct) throws Exception
     {
         final String type = struct.getStructure().getID();
-        if (type.equals("uri:ev4:nt/2012/pwd:NTScalar"))
+        if (type.equals("epics:nt/NTScalar:1.0"))
             return decodeNTScalar(struct);
-        if (type.equals("uri:ev4:nt/2012/pwd:NTEnum"))
+        if (type.equals("epics:nt/NTEnum:1.0"))
             return new VTypeForEnum(struct);
         return ValueFactory.newVString(type,
                 ValueFactory.newAlarm(AlarmSeverity.UNDEFINED, "Unknown type"),

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
@@ -9,6 +9,7 @@ package org.csstudio.vtype.pv.pva;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.epics.pvdata.factory.ConvertFactory;
 import org.epics.pvdata.pv.Convert;
@@ -36,11 +37,16 @@ class PVStructureHelper
     final public static Convert convert = ConvertFactory.getConvert();
 
     /** @param struct {@link PVStructure} to read
+     *  @param field Specific field to read, i.e. don't go by NT* type
      *  @return {@link VType} for data in the structure
      *  @throws Exception on error
      */
-    public static VType getVType(final PVStructure struct) throws Exception
+    public static VType getVType(final PVStructure struct, Optional<String> field) throws Exception
     {
+        // TODO
+        if (field.isPresent())
+            System.out.println("Should extract " + field.get() + " from " + struct + " ...");
+
         final String type = struct.getStructure().getID();
         if (type.equals("epics:nt/NTScalar:1.0"))
             return decodeNTScalar(struct);

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForByte.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForByte.java
@@ -24,7 +24,7 @@ class VTypeForByte extends VTypeTimeAlarmDisplayBase implements VByte
     public VTypeForByte(final PVStructure struct)
     {
         super(struct);
-        value = PVStructureHelper.convert.toByte((PVScalar) struct.getSubField("value"));
+        value = PVStructureHelper.convert.toByte(struct.getSubField(PVScalar.class, "value"));
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForByteArray.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForByteArray.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.List;
+
+import org.epics.pvdata.pv.PVScalarArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.util.array.ArrayByte;
+import org.epics.util.array.ArrayInt;
+import org.epics.util.array.ListByte;
+import org.epics.util.array.ListInt;
+import org.epics.vtype.ArrayDimensionDisplay;
+import org.epics.vtype.VByteArray;
+import org.epics.vtype.VType;
+import org.epics.vtype.VTypeToString;
+import org.epics.vtype.ValueUtil;
+
+/** Hold/decode data of {@link PVStructure} in {@link VType}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class VTypeForByteArray extends VTypeTimeAlarmDisplayBase implements VByteArray
+{
+    final private ListByte value;
+
+    public VTypeForByteArray(final PVStructure struct)
+    {
+        super(struct);
+        final PVScalarArray pv_array = struct.getSubField(PVScalarArray.class, "value");
+        final int length = pv_array.getLength();
+        final byte[] data = new byte[length];
+        PVStructureHelper.convert.toByteArray(pv_array, 0, length, data, 0);
+        value = new ArrayByte(data);
+    }
+
+    @Override
+    public List<ArrayDimensionDisplay> getDimensionDisplay()
+    {
+        return ValueUtil.defaultArrayDisplay(this);
+    }
+
+    @Override
+    public ListInt getSizes()
+    {
+        return new ArrayInt(value.size());
+    }
+
+    @Override
+    public ListByte getData()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return VTypeToString.toString(this);
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForDouble.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForDouble.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.vtype.pv.pva;
 
+import org.epics.pvdata.pv.PVScalar;
 import org.epics.pvdata.pv.PVStructure;
 import org.epics.vtype.VDouble;
 import org.epics.vtype.VType;
@@ -23,7 +24,7 @@ class VTypeForDouble extends VTypeTimeAlarmDisplayBase implements VDouble
     public VTypeForDouble(final PVStructure struct)
     {
         super(struct);
-        value = struct.getDoubleField("value").get();
+        value = PVStructureHelper.convert.toDouble((PVScalar) struct.getSubField("value"));
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForDouble.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForDouble.java
@@ -24,7 +24,7 @@ class VTypeForDouble extends VTypeTimeAlarmDisplayBase implements VDouble
     public VTypeForDouble(final PVStructure struct)
     {
         super(struct);
-        value = PVStructureHelper.convert.toDouble((PVScalar) struct.getSubField("value"));
+        value = PVStructureHelper.convert.toDouble(struct.getSubField(PVScalar.class, "value"));
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForDoubleArray.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForDoubleArray.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.List;
+
+import org.epics.pvdata.pv.PVScalarArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.util.array.ArrayDouble;
+import org.epics.util.array.ArrayInt;
+import org.epics.util.array.ListDouble;
+import org.epics.util.array.ListInt;
+import org.epics.vtype.ArrayDimensionDisplay;
+import org.epics.vtype.VDoubleArray;
+import org.epics.vtype.VType;
+import org.epics.vtype.VTypeToString;
+import org.epics.vtype.ValueUtil;
+
+/** Hold/decode data of {@link PVStructure} in {@link VType}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class VTypeForDoubleArray extends VTypeTimeAlarmDisplayBase implements VDoubleArray
+{
+    final private ListDouble value;
+
+    public VTypeForDoubleArray(final PVStructure struct)
+    {
+        super(struct);
+        final PVScalarArray pv_array = struct.getSubField(PVScalarArray.class, "value");
+        final int length = pv_array.getLength();
+        final double[] data = new double[length];
+        PVStructureHelper.convert.toDoubleArray(pv_array, 0, length, data, 0);
+        value = new ArrayDouble(data);
+    }
+
+    @Override
+    public List<ArrayDimensionDisplay> getDimensionDisplay()
+    {
+        return ValueUtil.defaultArrayDisplay(this);
+    }
+
+    @Override
+    public ListInt getSizes()
+    {
+        return new ArrayInt(value.size());
+    }
+
+    @Override
+    public ListDouble getData()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return VTypeToString.toString(this);
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForEnum.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForEnum.java
@@ -9,6 +9,7 @@ package org.csstudio.vtype.pv.pva;
 
 import java.util.List;
 
+import org.epics.pvdata.pv.PVInt;
 import org.epics.pvdata.pv.PVStructure;
 import org.epics.vtype.VEnum;
 import org.epics.vtype.VType;
@@ -26,8 +27,8 @@ class VTypeForEnum extends VTypeTimeAlarmBase implements VEnum
     public VTypeForEnum(final PVStructure struct) throws Exception
     {
         super(struct);
-        final PVStructure section = struct.getStructureField("value");
-        value = section.getIntField("index").get();
+        final PVStructure section = struct.getSubField(PVStructure.class, "value");
+        value = section.getSubField(PVInt.class, "index").get();
 
         labels = PVStructureHelper.getStrings(section, "choices");
     }

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForEnum.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForEnum.java
@@ -29,7 +29,6 @@ class VTypeForEnum extends VTypeTimeAlarmBase implements VEnum
         super(struct);
         final PVStructure section = struct.getSubField(PVStructure.class, "value");
         value = section.getSubField(PVInt.class, "index").get();
-
         labels = PVStructureHelper.getStrings(section, "choices");
     }
 

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForFloat.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForFloat.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.vtype.pv.pva;
 
+import org.epics.pvdata.pv.PVFloat;
 import org.epics.pvdata.pv.PVStructure;
 import org.epics.vtype.VFloat;
 import org.epics.vtype.VType;
@@ -23,7 +24,7 @@ class VTypeForFloat extends VTypeTimeAlarmDisplayBase implements VFloat
     public VTypeForFloat(final PVStructure struct)
     {
         super(struct);
-        value = struct.getFloatField("value").get();
+        value = struct.getSubField(PVFloat.class, "value").get();
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForFloatArray.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForFloatArray.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.List;
+
+import org.epics.pvdata.pv.PVScalarArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.util.array.ArrayFloat;
+import org.epics.util.array.ArrayInt;
+import org.epics.util.array.ListFloat;
+import org.epics.util.array.ListInt;
+import org.epics.vtype.ArrayDimensionDisplay;
+import org.epics.vtype.VFloatArray;
+import org.epics.vtype.VType;
+import org.epics.vtype.VTypeToString;
+import org.epics.vtype.ValueUtil;
+
+/** Hold/decode data of {@link PVStructure} in {@link VType}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class VTypeForFloatArray extends VTypeTimeAlarmDisplayBase implements VFloatArray
+{
+    final private ListFloat value;
+
+    public VTypeForFloatArray(final PVStructure struct)
+    {
+        super(struct);
+        final PVScalarArray pv_array = struct.getSubField(PVScalarArray.class, "value");
+        final int length = pv_array.getLength();
+        final float[] data = new float[length];
+        PVStructureHelper.convert.toFloatArray(pv_array, 0, length, data, 0);
+        value = new ArrayFloat(data);
+    }
+
+    @Override
+    public List<ArrayDimensionDisplay> getDimensionDisplay()
+    {
+        return ValueUtil.defaultArrayDisplay(this);
+    }
+
+    @Override
+    public ListInt getSizes()
+    {
+        return new ArrayInt(value.size());
+    }
+
+    @Override
+    public ListFloat getData()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return VTypeToString.toString(this);
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForInt.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForInt.java
@@ -24,7 +24,7 @@ class VTypeForInt extends VTypeTimeAlarmDisplayBase implements VInt
     public VTypeForInt(final PVStructure struct)
     {
         super(struct);
-        value = PVStructureHelper.convert.toInt((PVScalar) struct.getSubField("value"));
+        value = PVStructureHelper.convert.toInt(struct.getSubField(PVScalar.class, "value"));
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForIntArray.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForIntArray.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.List;
+
+import org.epics.pvdata.pv.PVScalarArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.util.array.ArrayInt;
+import org.epics.util.array.ListInt;
+import org.epics.vtype.ArrayDimensionDisplay;
+import org.epics.vtype.VIntArray;
+import org.epics.vtype.VType;
+import org.epics.vtype.VTypeToString;
+import org.epics.vtype.ValueUtil;
+
+/** Hold/decode data of {@link PVStructure} in {@link VType}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class VTypeForIntArray extends VTypeTimeAlarmDisplayBase implements VIntArray
+{
+    final private ListInt value;
+
+    public VTypeForIntArray(final PVStructure struct)
+    {
+        super(struct);
+        final PVScalarArray pv_array = struct.getSubField(PVScalarArray.class, "value");
+        final int length = pv_array.getLength();
+        final int[] data = new int[length];
+        PVStructureHelper.convert.toIntArray(pv_array, 0, length, data, 0);
+        value = new ArrayInt(data);
+    }
+
+    @Override
+    public List<ArrayDimensionDisplay> getDimensionDisplay()
+    {
+        return ValueUtil.defaultArrayDisplay(this);
+    }
+
+    @Override
+    public ListInt getSizes()
+    {
+        return new ArrayInt(value.size());
+    }
+
+    @Override
+    public ListInt getData()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return VTypeToString.toString(this);
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForLong.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForLong.java
@@ -24,7 +24,7 @@ class VTypeForLong extends VTypeTimeAlarmDisplayBase implements VLong
     public VTypeForLong(final PVStructure struct)
     {
         super(struct);
-        value = PVStructureHelper.convert.toLong((PVScalar) struct.getSubField("value"));
+        value = PVStructureHelper.convert.toLong(struct.getSubField(PVScalar.class, "value"));
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForLongArray.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForLongArray.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.List;
+
+import org.epics.pvdata.pv.PVScalarArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.util.array.ArrayInt;
+import org.epics.util.array.ArrayLong;
+import org.epics.util.array.ListInt;
+import org.epics.util.array.ListLong;
+import org.epics.vtype.ArrayDimensionDisplay;
+import org.epics.vtype.VLongArray;
+import org.epics.vtype.VType;
+import org.epics.vtype.VTypeToString;
+import org.epics.vtype.ValueUtil;
+
+/** Hold/decode data of {@link PVStructure} in {@link VType}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class VTypeForLongArray extends VTypeTimeAlarmDisplayBase implements VLongArray
+{
+    final private ListLong value;
+
+    public VTypeForLongArray(final PVStructure struct)
+    {
+        super(struct);
+        final PVScalarArray pv_array = struct.getSubField(PVScalarArray.class, "value");
+        final int length = pv_array.getLength();
+        final long[] data = new long[length];
+        PVStructureHelper.convert.toLongArray(pv_array, 0, length, data, 0);
+        value = new ArrayLong(data);
+    }
+
+    @Override
+    public List<ArrayDimensionDisplay> getDimensionDisplay()
+    {
+        return ValueUtil.defaultArrayDisplay(this);
+    }
+
+    @Override
+    public ListInt getSizes()
+    {
+        return new ArrayInt(value.size());
+    }
+
+    @Override
+    public ListLong getData()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return VTypeToString.toString(this);
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForShort.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForShort.java
@@ -24,7 +24,7 @@ class VTypeForShort extends VTypeTimeAlarmDisplayBase implements VShort
     public VTypeForShort(final PVStructure struct)
     {
         super(struct);
-        value = PVStructureHelper.convert.toShort((PVScalar) struct.getSubField("value"));
+        value = PVStructureHelper.convert.toShort(struct.getSubField(PVScalar.class, "value"));
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForShortArray.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForShortArray.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.List;
+
+import org.epics.pvdata.pv.PVScalarArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.util.array.ArrayInt;
+import org.epics.util.array.ArrayShort;
+import org.epics.util.array.ListInt;
+import org.epics.util.array.ListShort;
+import org.epics.vtype.ArrayDimensionDisplay;
+import org.epics.vtype.VShortArray;
+import org.epics.vtype.VType;
+import org.epics.vtype.VTypeToString;
+import org.epics.vtype.ValueUtil;
+
+/** Hold/decode data of {@link PVStructure} in {@link VType}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class VTypeForShortArray extends VTypeTimeAlarmDisplayBase implements VShortArray
+{
+    final private ListShort value;
+
+    public VTypeForShortArray(final PVStructure struct)
+    {
+        super(struct);
+        final PVScalarArray pv_array = struct.getSubField(PVScalarArray.class, "value");
+        final int length = pv_array.getLength();
+        final short[] data = new short[length];
+        PVStructureHelper.convert.toShortArray(pv_array, 0, length, data, 0);
+        value = new ArrayShort(data);
+    }
+
+    @Override
+    public List<ArrayDimensionDisplay> getDimensionDisplay()
+    {
+        return ValueUtil.defaultArrayDisplay(this);
+    }
+
+    @Override
+    public ListInt getSizes()
+    {
+        return new ArrayInt(value.size());
+    }
+
+    @Override
+    public ListShort getData()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return VTypeToString.toString(this);
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForString.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForString.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.vtype.pv.pva;
 
+import org.epics.pvdata.pv.PVString;
 import org.epics.pvdata.pv.PVStructure;
 import org.epics.vtype.VString;
 import org.epics.vtype.VType;
@@ -23,7 +24,7 @@ class VTypeForString extends VTypeTimeAlarmBase implements VString
     public VTypeForString(final PVStructure struct)
     {
         super(struct);
-        value = struct.getStringField("value").get();
+        value = struct.getSubField(PVString.class, "value").get();
     }
 
     @Override

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForStringArray.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeForStringArray.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.pva;
+
+import java.util.List;
+
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.util.array.ArrayInt;
+import org.epics.util.array.ListInt;
+import org.epics.vtype.VStringArray;
+import org.epics.vtype.VType;
+import org.epics.vtype.VTypeToString;
+
+/** Hold/decode data of {@link PVStructure} in {@link VType}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+class VTypeForStringArray extends VTypeTimeAlarmDisplayBase implements VStringArray
+{
+    final private List<String> value;
+
+    public VTypeForStringArray(final PVStructure struct) throws Exception
+    {
+        super(struct);
+        value = PVStructureHelper.getStrings(struct, "value");
+    }
+
+    @Override
+    public ListInt getSizes()
+    {
+        return new ArrayInt(value.size());
+    }
+
+    @Override
+    public List<String> getData()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return VTypeToString.toString(this);
+    }
+}

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmBase.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmBase.java
@@ -69,8 +69,8 @@ class VTypeTimeAlarmBase implements Time, Alarm
         }
         else
         {
-            severity = AlarmSeverity.UNDEFINED;
-            message = AlarmStatus.UNDEFINED.name();
+            severity = AlarmSeverity.NONE;
+            message = AlarmStatus.NONE.name();
         }
     }
 

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmBase.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmBase.java
@@ -35,16 +35,16 @@ class VTypeTimeAlarmBase implements Time, Alarm
     VTypeTimeAlarmBase(final PVStructure struct)
     {
         // Decode time_t timeStamp
-        final PVStructure time = struct.getStructureField("timeStamp");
+        final PVStructure time = struct.getSubField(PVStructure.class, "timeStamp");
         if (time != null)
         {
-            final PVLong sec = time.getLongField("secondsPastEpoch");
-            final PVInt nano = time.getIntField("nanoSeconds");
+            final PVLong sec = time.getSubField(PVLong.class, "secondsPastEpoch");
+            final PVInt nano = time.getSubField(PVInt.class, "nanoSeconds");
             if (sec == null || nano == null)
                 timestamp = NO_TIME;
             else
                 timestamp = Timestamp.of(sec.get(), nano.get());
-            final PVInt user = time.getIntField("userTag");
+            final PVInt user = time.getSubField(PVInt.class, "userTag");
             usertag = user == null ? NO_USERTAG : user.get();
         }
         else
@@ -54,15 +54,15 @@ class VTypeTimeAlarmBase implements Time, Alarm
         }
 
         // Decode alarm_t alarm
-        final PVStructure alarm = struct.getStructureField("alarm");
+        final PVStructure alarm = struct.getSubField(PVStructure.class, "alarm");
         if (alarm != null)
         {
-            PVInt code = alarm.getIntField("severity");
+            PVInt code = alarm.getSubField(PVInt.class, "severity");
             severity = code == null
                 ? AlarmSeverity.UNDEFINED
                 : AlarmSeverity.values()[code.get()];
 
-            code = alarm.getIntField("status");
+            code = alarm.getSubField(PVInt.class, "status");
             message = code == null
                 ? AlarmStatus.UNDEFINED.name()
                 : AlarmStatus.values()[code.get()].name();

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmBase.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmBase.java
@@ -26,7 +26,9 @@ import org.epics.vtype.VType;
 class VTypeTimeAlarmBase implements Time, Alarm
 {
     final private static Timestamp NO_TIME = Timestamp.of(0, 0);
+    final private static Integer NO_USERTAG = Integer.valueOf(0);
     final private Timestamp timestamp;
+    final private Integer usertag;
     final private AlarmSeverity severity;
     final private String message;
 
@@ -42,9 +44,14 @@ class VTypeTimeAlarmBase implements Time, Alarm
                 timestamp = NO_TIME;
             else
                 timestamp = Timestamp.of(sec.get(), nano.get());
+            final PVInt user = time.getIntField("userTag");
+            usertag = user == null ? NO_USERTAG : user.get();
         }
         else
+        {
             timestamp = NO_TIME;
+            usertag = NO_USERTAG;
+        }
 
         // Decode alarm_t alarm
         final PVStructure alarm = struct.getStructureField("alarm");
@@ -78,8 +85,7 @@ class VTypeTimeAlarmBase implements Time, Alarm
     @Override
     public Integer getTimeUserTag()
     {
-        // TODO Auto-generated method stub
-        return null;
+        return usertag;
     }
 
     // Time

--- a/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmDisplayBase.java
+++ b/applications/plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/VTypeTimeAlarmDisplayBase.java
@@ -111,13 +111,13 @@ class VTypeTimeAlarmDisplayBase extends VTypeTimeAlarmBase implements Display
         super(struct);
 
         // Decode display_t display
-        PVStructure section = struct.getStructureField("display");
+        PVStructure section = struct.getSubField(PVStructure.class, "display");
         if (section != null)
         {
-            PVString str = section.getStringField("units");
+            PVString str = section.getSubField(PVString.class, "units");
             units = str == null ? noDisplay.getUnits() : str.get();
 
-            str = section.getStringField("format");
+            str = section.getSubField(PVString.class, "format");
             format = str == null
                 ? noDisplay.getFormat()
                 : createNumberFormat(str.get());
@@ -134,7 +134,7 @@ class VTypeTimeAlarmDisplayBase extends VTypeTimeAlarmBase implements Display
         }
 
         // Decode control_t control
-        section = struct.getStructureField("control");
+        section = struct.getSubField(PVStructure.class, "control");
         if (section != null)
         {
             control_low = PVStructureHelper.getDoubleValue(section, "limitLow", noDisplay.getLowerCtrlLimit());
@@ -147,7 +147,7 @@ class VTypeTimeAlarmDisplayBase extends VTypeTimeAlarmBase implements Display
         }
 
         // Decode valueAlarm_t valueAlarm
-        section = struct.getStructureField("control");
+        section = struct.getSubField(PVStructure.class, "control");
         if (section != null)
         {
             alarm_low = PVStructureHelper.getDoubleValue(section, "lowAlarmLimit", noDisplay.getLowerAlarmLimit());


### PR DESCRIPTION
Updates vtype.pv to the current release of EPICS V4, meaning it no longer uses 

org.epics.pvdata, org.epics.pvaccess

but instead requires

org.epics.pvDataJava, org.epics.pvAccessJava

pvmanager.pva has already been updated, so this doesn't add a new dependency but instead removes a dependency on outdated V4 plugins.

Then it fixes #898, i.e. implements access to structure elements via

  pva://channel/structure/substruct/element

or

  pva://channel?request=field(structure/substruct/element)
