### PR TITLE
Bug fix: Connector between linking containers is not correctly loaded 

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
@@ -7,23 +7,13 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.widgets.model;
 
-import java.util.LinkedList;
-import java.util.List;
 
-import org.csstudio.opibuilder.OPIBuilderPlugin;
 import org.csstudio.opibuilder.editparts.AbstractBaseEditPart;
-import org.csstudio.opibuilder.model.AbstractContainerModel;
-import org.csstudio.opibuilder.model.AbstractWidgetModel;
-import org.csstudio.opibuilder.model.DisplayModel;
+import org.csstudio.opibuilder.model.AbstractLinkingContainerModel;
 import org.csstudio.opibuilder.properties.BooleanProperty;
-import org.csstudio.opibuilder.properties.FilePathProperty;
-import org.csstudio.opibuilder.properties.StringProperty;
 import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
-import org.csstudio.opibuilder.util.ResourceUtil;
 import org.csstudio.opibuilder.visualparts.BorderStyle;
 import org.csstudio.opibuilder.widgets.editparts.LinkingContainerEditpart;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.gef.GraphicalViewer;
 
@@ -31,25 +21,13 @@ import org.eclipse.gef.GraphicalViewer;
  * @author Xihui Chen
  *
  */
-public class LinkingContainerModel extends AbstractContainerModel {
+public class LinkingContainerModel extends AbstractLinkingContainerModel {
 
 	/**
 	 * The ID of this widget model.
 	 */
 	public static final String ID = "org.csstudio.opibuilder.widgets.linkingContainer"; //$NON-NLS-1$	
-	
-	/**
-	 * The ID of the resource property.
-	 */
-	public static final String PROP_OPI_FILE = "opi_file"; //$NON-NLS-1$
 
-	/**
-	 * The name of the group container widget in the OPI file, which
-	 * will be loaded if it is specified. If it is not specified, the whole
-	 * OPI file will be loaded.
-	 */
-	public static final String PROP_GROUP_NAME = "group_name"; //$NON-NLS-1$
-	
 	/**
 	 * The ID of the auto zoom property.
 	 */
@@ -73,11 +51,6 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	 */
 	private Dimension childrenGeoSize = null;
 	
-	/**
-	 * The display Scale options of the embedded OPI.
-	 */
-	private DisplayModel displayModel = null;
-	
 	public LinkingContainerModel() {
 		setSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
 		setBorderStyle(BorderStyle.LOWERED);
@@ -86,13 +59,6 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	@Override
 	protected void configureProperties() {
 		
-		addProperty(new FilePathProperty(PROP_OPI_FILE, "OPI File",
-				WidgetPropertyCategory.Behavior, new Path(""), //$NON-NLS-1$
-				new String[] { OPIBuilderPlugin.OPI_FILE_EXTENSION}));
-		
-		addProperty(new StringProperty(PROP_GROUP_NAME, "Group Name",
-				WidgetPropertyCategory.Behavior, "")); //$NON-NLS-1$
-		
 		addProperty(new BooleanProperty(PROP_ZOOMTOFITALL, "Zoom to Fit", WidgetPropertyCategory.Display, true));
 		addProperty(new BooleanProperty(PROP_AUTO_SIZE, "Auto Size", WidgetPropertyCategory.Display, false));
 	}
@@ -100,22 +66,6 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	@Override
 	public String getTypeID() {
 		return ID;
-	}
-
-	/**
-	 * Return the target resource.
-	 * 
-	 * @return The target resource.
-	 */
-	public IPath getOPIFilePath() {
-		IPath absolutePath = (IPath) getProperty(PROP_OPI_FILE).getPropertyValue();
-		if(absolutePath != null && !absolutePath.isEmpty() && !absolutePath.isAbsolute())
-			absolutePath = ResourceUtil.buildAbsolutePath(this, absolutePath);
-		return absolutePath;
-	}
-	
-	public void setOPIFilePath(String path){
-		setPropertyValue(PROP_OPI_FILE, new Path(path));
 	}
 
 	/**
@@ -128,18 +78,6 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	
 	public boolean isAutoSize() {
 		return (Boolean) getProperty(PROP_AUTO_SIZE).getPropertyValue();
-	}
-	
-	public String getGroupName(){
-		return (String)getPropertyValue(PROP_GROUP_NAME);
-	}
-	
-	
-	@Override
-	public List<AbstractWidgetModel> getChildren() {
-		//Linking container should have "no" children. 
-		//Its children should be dynamically loaded from opi file.
-		return new LinkedList<AbstractWidgetModel>();
 	}
 	
 	@Override
@@ -174,19 +112,19 @@ public class LinkingContainerModel extends AbstractContainerModel {
 		double newWidthRatio = size.width/(double)getOriginSize().width;
 		double newHeightRatio = size.height/(double)getOriginSize().height;
 		boolean allowScale = true;
-		if(displayModel != null){
-			allowScale = displayModel.getDisplayScaleData().isAutoScaleWidgets();
+		if(getDisplayModel() != null){
+			allowScale = getDisplayModel().getDisplayScaleData().isAutoScaleWidgets();
 			if(allowScale){
-				int minWidth = displayModel.getDisplayScaleData()
+				int minWidth = getDisplayModel().getDisplayScaleData()
 						.getMinimumWidth();
 
 				if (minWidth < 0) {
-					minWidth = displayModel.getWidth();
+					minWidth = getDisplayModel().getWidth();
 				}
-				int minHeight = displayModel.getDisplayScaleData()
+				int minHeight = getDisplayModel().getDisplayScaleData()
 						.getMinimumHeight();
 				if (minHeight < 0) {
-					minHeight = displayModel.getHeight();
+					minHeight = getDisplayModel().getHeight();
 				}
 				if (getWidth() * newWidthRatio < minWidth)
 					newWidthRatio = minWidth / (double) getOriginSize().width;
@@ -211,19 +149,5 @@ public class LinkingContainerModel extends AbstractContainerModel {
 	
 	public void setChildrenGeoSize(Dimension childrenGeoSize) {
 		this.childrenGeoSize = childrenGeoSize;
-	}
-	
-	/**Set the display model of the loaded opi.
-	 * @param displayModel
-	 */
-	public void setDisplayModel(DisplayModel displayModel) {
-		this.displayModel = displayModel;
-	}
-	
-	/**
-	 * @return display model of the loaded opi. null if no opi has been loaded.
-	 */
-	public DisplayModel getDisplayModel() {
-		return displayModel;
 	}
 }

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/OPIWidgetsTransfer.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/OPIWidgetsTransfer.java
@@ -88,7 +88,7 @@ public class OPIWidgetsTransfer extends ByteArrayTransfer {
 			return null;
 		try {		
 			DisplayModel displayModel = 
-					(DisplayModel) XMLUtil.XMLStringToWidget(new String(bytes, "UTF-8")); //$NON-NLS-1$
+					(DisplayModel) XMLUtil.fillWidgetsFromXMLString(new String(bytes, "UTF-8"), null); //$NON-NLS-1$
 			List<AbstractWidgetModel> widgets = displayModel.getChildren();
 			return widgets;
 		} catch (Exception e) {

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/commands/WidgetCreateCommand.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/commands/WidgetCreateCommand.java
@@ -14,6 +14,7 @@ import org.csstudio.opibuilder.model.AbstractContainerModel;
 import org.csstudio.opibuilder.model.AbstractLayoutModel;
 import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.csstudio.opibuilder.model.ConnectionModel;
+import org.csstudio.opibuilder.persistence.XMLUtil;
 import org.csstudio.opibuilder.util.SchemaService;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -157,6 +158,13 @@ public class WidgetCreateCommand extends Command {
 		}
 		container.addChild(index, newWidget);
 		container.selectWidget(newWidget, append);
+		if(newWidget instanceof AbstractContainerModel) {
+			try {
+				XMLUtil.fillLinkingContainers((AbstractContainerModel)newWidget);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
 	}
 
 	@Override

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractLinkingContainerEditpart.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractLinkingContainerEditpart.java
@@ -1,0 +1,8 @@
+package org.csstudio.opibuilder.editparts;
+
+/**The editpart for {@link AbstractLinkingContainerModel}
+ * @author 
+ */
+public abstract class AbstractLinkingContainerEditpart extends AbstractContainerEditpart {	
+
+}

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/WidgetConnectionEditPart.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/WidgetConnectionEditPart.java
@@ -171,7 +171,7 @@ public class WidgetConnectionEditPart extends AbstractConnectionEditPart {
 
 	@Override
 	protected void createEditPolicies() {
-		if (getExecutionMode() == ExecutionMode.EDIT_MODE) {
+		if (getExecutionMode() == ExecutionMode.EDIT_MODE && !getWidgetModel().isLoadedFromLinkedOpi()) {
 			// Selection handle edit policy.
 			// Makes the connection show a feedback, when selected by the user.
 			installEditPolicy(EditPolicy.CONNECTION_ENDPOINTS_ROLE,

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractLinkingContainerModel.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractLinkingContainerModel.java
@@ -1,0 +1,79 @@
+package org.csstudio.opibuilder.model;
+
+import org.csstudio.opibuilder.OPIBuilderPlugin;
+import org.csstudio.opibuilder.properties.FilePathProperty;
+import org.csstudio.opibuilder.properties.StringProperty;
+import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
+import org.csstudio.opibuilder.util.ResourceUtil;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+
+/**The abstract base model for LinkingContainer widgets.
+ */
+public abstract class AbstractLinkingContainerModel extends AbstractContainerModel {
+	
+	/**
+	 * The ID of the resource property.
+	 */
+	public static final String PROP_OPI_FILE = "opi_file"; //$NON-NLS-1$
+	
+	/**
+	 * The name of the group container widget in the OPI file, which
+	 * will be loaded if it is specified. If it is not specified, the whole
+	 * OPI file will be loaded.
+	 */
+	public static final String PROP_GROUP_NAME = "group_name"; //$NON-NLS-1$
+	
+
+	
+	/**
+	 * The display Scale options of the embedded OPI.
+	 */
+	private DisplayModel displayModel = null;
+	
+	@Override
+	protected void configureBaseProperties() {
+		super.configureBaseProperties();
+		
+		addProperty(new FilePathProperty(PROP_OPI_FILE, "OPI File",
+				WidgetPropertyCategory.Behavior, new Path(""), //$NON-NLS-1$
+				new String[] { OPIBuilderPlugin.OPI_FILE_EXTENSION}));
+		
+		addProperty(new StringProperty(PROP_GROUP_NAME, "Group Name",
+				WidgetPropertyCategory.Behavior, "")); //$NON-NLS-1$
+	}
+	
+	public String getGroupName(){
+		return (String)getPropertyValue(PROP_GROUP_NAME);
+	}
+	
+	/**
+	 * Return the target resource.
+	 * 
+	 * @return The target resource.
+	 */
+	public IPath getOPIFilePath() {
+		IPath absolutePath = (IPath) getProperty(PROP_OPI_FILE).getPropertyValue();
+		if(absolutePath != null && !absolutePath.isEmpty() && !absolutePath.isAbsolute())
+			absolutePath = ResourceUtil.buildAbsolutePath(this, absolutePath);
+		return absolutePath;
+	}
+	
+	public void setOPIFilePath(String path){
+		setPropertyValue(PROP_OPI_FILE, new Path(path));
+	}
+
+	/**Set the display model of the loaded opi.
+	 * @param displayModel
+	 */
+	public void setDisplayModel(DisplayModel displayModel) {
+		this.displayModel = displayModel;
+	}
+	
+	/**
+	 * @return display model of the loaded opi. null if no opi has been loaded.
+	 */
+	public DisplayModel getDisplayModel() {
+		return displayModel;
+	}
+}

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
@@ -335,4 +335,5 @@ public class DisplayModel extends AbstractContainerModel {
 	public void setFrameRate(double rate) {
 		setPropertyValue(PROP_FRAME_RATE, rate);
 	}
+	
 }


### PR DESCRIPTION
Changes:

ConnectionModel.java
- Add src_path, tgt_path property to ConnectionModel so it can
distinguish two widgets which is included in two different
LinkingContainer but have same WID.
- Add loadedFromLinkedOpi attribute to prevent some connection inside
LinkingContainer from being saved to .opi file.

XMLUtil.java
- Change the order of procedure of converting XML element to widget so
it can correctly load connection between widgets loaded in
LinkingContainer.
- Add utility methods :stringToXML, inputStreamToXML.
- Add ability to detect loops in LinkingContainer and loaded .ooi files.

AbstractLinkingContainerModel.java,
AbstractLinkingContainerEditPart.java
- Put LinkingContainer up from org.csstudio.opibuilder.widgets to
org.csstudio.opibuilder so those classes in org.csstudio.opibuilder can
handle LinkingContainer Models/EditPart separately from ordinal
Container Model/EditPart.