### PR TITLE
Bug963

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Alarm Notification Application
 Bundle-SymbolicName: org.csstudio.alarm.beast.notifier;singleton:=true
-Bundle-Version: 3.3.2.qualifier
+Bundle-Version: 4.0.3.qualifier
 Bundle-Vendor: Fred Arnaud <frederic.arnaud@iter.org> - ITER
 Bundle-Description: BEAST Alarm Notification
 Require-Bundle: org.junit;bundle-version="4.8.2",
@@ -15,7 +15,7 @@ Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.security,
  org.epics.util,
  org.epics.vtype
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.csstudio.alarm.beast.notifier,
  org.csstudio.alarm.beast.notifier.actions,
  org.csstudio.alarm.beast.notifier.model,

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/plugin_customization.ini
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/plugin_customization.ini
@@ -2,7 +2,7 @@
 org.csstudio.alarm.beast/root_component=Annunciator
 
 # Alarm System RDB Connection
-org.csstudio.alarm.beast/rdb_url=jdbc:mysql://localhost/alarm
+org.csstudio.alarm.beast/rdb_url=jdbc:mysql://localhost/ALARM
 org.csstudio.alarm.beast/rdb_user=alarm
 org.csstudio.alarm.beast/rdb_password=$alarm
 org.csstudio.alarm.beast/rdb_schema=ALARM

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/plugin_customization.ini
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/plugin_customization.ini
@@ -29,7 +29,9 @@ org.csstudio.email/smtp_sender=alarm-notifier@home.org
 
 # Automated actions thresholds
 org.csstudio.alarm.beast.notifier/timer_threshold=100
-org.csstudio.alarm.beast.notifier/thread_threshold=100
+
+# Notify only on alarms that have a higher severity than the previous?
+org.csstudio.alarm.beast.notifier/notify_escalating_alarms_only=false
 
 #
 # IDE sometimes adds stuff below this line...

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/plugin_customization.ini
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/plugin_customization.ini
@@ -30,7 +30,8 @@ org.csstudio.email/smtp_sender=alarm-notifier@home.org
 # Automated actions thresholds
 org.csstudio.alarm.beast.notifier/timer_threshold=100
 
-# Notify only on alarms that have a higher severity than the previous?
+# Notify only on alarms that have a higher severity?
+# See preferences.ini for details
 org.csstudio.alarm.beast.notifier/notify_escalating_alarms_only=false
 
 #

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.alarm.beast.notifier</artifactId>
-  <version>3.3.2-SNAPSHOT</version>
+  <version>4.0.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/preferences.ini
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/preferences.ini
@@ -9,7 +9,20 @@ timer_threshold=100
 # Log level of plugins listed in Application class
 verbose_log.level=WARNING
 
-# Notify only on alarms that have a higher severity than the previous
-# state of the PV? Skip notifications for 'OK' and acknowledged alarms?
-# Default (false): Do send updates for 'OK' and ack' 
+# Notify only on alarms that have a higher severity,
+# skipping follow-up notifications for 'OK' and acknowledged alarms?
+#
+# Comparison of time lines
+# ------------------------
+#
+# In any case we start with
+# 1) Alarm PV triggers, delay expires -> notification
+#
+# Original behavior, notify_escalating_alarms_only = false
+# 2.a) Acknowledged -> Another notification "ack"
+# 2.b) Alarm PV OK, then acknowledged -> Another "OK" plus "ack" notification
+#
+# New behavior, notify_escalating_alarms_only = true
+# 2.a) Acknowledged -> Nothing
+# 2.b) Alarm PV OK, then acknowledged -> Nothing
 notify_escalating_alarms_only=false

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/preferences.ini
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/preferences.ini
@@ -8,3 +8,8 @@ timer_threshold=100
 
 # Log level of plugins listed in Application class
 verbose_log.level=WARNING
+
+# Notify only on alarms that have a higher severity than the previous
+# state of the PV? Skip notifications for 'OK' and acknowledged alarms?
+# Default (false): Do send updates for 'OK' and ack' 
+notify_escalating_alarms_only=false

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Activator.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Activator.java
@@ -9,6 +9,7 @@ package org.csstudio.alarm.beast.notifier;
 
 import java.util.logging.Logger;
 
+@SuppressWarnings("nls")
 public class Activator {
 
 	/** Plugin ID defined in MANIFEST.MF */

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/AlarmHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/AlarmHandler.java
@@ -20,10 +20,11 @@ import org.csstudio.alarm.beast.notifier.model.IAutomatedAction;
 /**
  * Manager of an automated action scheduled task.. Handle alarm update
  * management.
- * 
+ *
  * @author Fred Arnaud (Sopra Group)
- * 
+ *
  */
+@SuppressWarnings("nls")
 public class AlarmHandler {
 
 	/** Unique action identifier */
@@ -58,7 +59,7 @@ public class AlarmHandler {
 
 	/**
 	 * Update current status & priority
-	 * 
+	 *
 	 * @param pv, snapshot of the pv on which an alarm event was raised.
 	 */
 	public void updateAlarms(PVSnapshot pv) {
@@ -107,7 +108,7 @@ public class AlarmHandler {
 						this.reason = buildReason();
 					}
 				}
-				if (!(this.status.equals(EActionStatus.NO_DELAY) 
+				if (!(this.status.equals(EActionStatus.NO_DELAY)
 						|| this.status.equals(EActionStatus.CANCELED_NO_DELAY))) {
 					boolean allCanceled = true;
 					for (PVAlarmHandler ah : pvs.values())
@@ -125,7 +126,7 @@ public class AlarmHandler {
 		}
 	}
 
-	private String buildReason() {
+    private String buildReason() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(Messages.Reason_SubActionsCanceled);
 		sb.append(":\n");

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/AlarmNotifier.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/AlarmNotifier.java
@@ -34,86 +34,86 @@ import org.csstudio.logging.JMSLogMessage;
  */
 @SuppressWarnings("nls")
 public class AlarmNotifier {
-	
+
     private boolean debug = false;
 
-	/** Name of alarm tree root element */
-	final String rootName = Preferences.getAlarmTreeRoot();
+    /** Name of alarm tree root element */
+    final String rootName = Preferences.getAlarmTreeRoot();
 
-	/** Alarm model handler */
-	final private IAlarmRDBHandler rdb;
+    /** Alarm model handler */
+    final private IAlarmRDBHandler rdb;
 
-	/** Automated actions factory */
-	final private AutomatedActionFactory factory;
+    /** Automated actions factory */
+    final private AutomatedActionFactory factory;
 
-	/** Queue which handles pending actions */
-	final private WorkQueue workQueue;
+    /** Queue which handles pending actions */
+    final private WorkQueue workQueue;
 
-	private boolean maintenanceMode = false;
+    private boolean maintenanceMode = false;
 
-	public AlarmNotifier(final String root_name,
-			final IAlarmRDBHandler rdbHandler,
-			final AutomatedActionFactory factory, final int timer_threshold)
-			throws Exception {
-		this.rdb = rdbHandler;
-		this.factory = factory;
-		this.workQueue = new WorkQueue(timer_threshold, 60000); // 60s
-	}
+    public AlarmNotifier(final String root_name,
+            final IAlarmRDBHandler rdbHandler,
+            final AutomatedActionFactory factory, final int timer_threshold)
+            throws Exception {
+        this.rdb = rdbHandler;
+        this.factory = factory;
+        this.workQueue = new WorkQueue(timer_threshold, 60000); // 60s
+    }
 
-	/** @return Name of configuration root element */
-	public String getRootName() {
-		return rootName;
-	}
+    /** @return Name of configuration root element */
+    public String getRootName() {
+        return rootName;
+    }
 
-	/** Connect to JMS */
+    /** Connect to JMS */
     public void start() {
-		Activator.getLogger().log(Level.INFO, "Alarm Notifier started");
-	}
+        Activator.getLogger().log(Level.INFO, "Alarm Notifier started");
+    }
 
-	/** Release all resources */
-	public void stop() {
-		rdb.close();
-		workQueue.flush();
-		Activator.getLogger().log(Level.INFO, "Alarm Notifier stopped");
-	}
+    /** Release all resources */
+    public void stop() {
+        rdb.close();
+        workQueue.flush();
+        Activator.getLogger().log(Level.INFO, "Alarm Notifier stopped");
+    }
 
-	/**
-	 * Read info about {@link AlarmTreeItem} from model.
-	 *
-	 * @param path, path of the item
-	 * @return ItemInfo
-	 */
-	public ItemInfo getItemInfo(String path) {
-		AlarmTreeItem item = rdb.findItem(path);
-		return ItemInfo.fromItem(item);
-	}
+    /**
+     * Read info about {@link AlarmTreeItem} from model.
+     *
+     * @param path, path of the item
+     * @return ItemInfo
+     */
+    public ItemInfo getItemInfo(String path) {
+        AlarmTreeItem item = rdb.findItem(path);
+        return ItemInfo.fromItem(item);
+    }
 
-	/**
-	 * Start automated action for the given PV and its parents.
-	 *
-	 * @param pvItem
-	 */
-	public synchronized void handleAlarmUpdate(final AlarmTreePV pvItem) {
-	    final PVSnapshot snapshot = PVSnapshot.fromPVItem(pvItem);
-	    final AlarmNotifierHistory history = AlarmNotifierHistory.getInstance();
+    /**
+     * Start automated action for the given PV and its parents.
+     *
+     * @param pvItem
+     */
+    public synchronized void handleAlarmUpdate(final AlarmTreePV pvItem) {
+        final PVSnapshot snapshot = PVSnapshot.fromPVItem(pvItem);
+        final AlarmNotifierHistory history = AlarmNotifierHistory.getInstance();
         if (!pvItem.isEnabled()) {
             // Ignore PV, it's disabled
             history.clear(snapshot);
             return;
         }
-		// Avoid to send 'fake' alarms when the PV is re-enabled for example
-		if (snapshot.getValue() != null && snapshot.getValue().isEmpty())
-			return;
-		// Configuration update results in an alarm update with no changes
-		final PVHistoryEntry pv_history = history.getPV(snapshot.getPath());
-		if (pv_history == null
-				&& snapshot.getSeverity().equals(SeverityLevel.OK))
-			return;
-		if (pv_history != null
-				&& snapshot.getSeverity().equals(pv_history.getSeverity())
-				&& snapshot.getCurrentSeverity().equals(pv_history.getCurrentSeverity()))
-			return;
-		// Process automated actions of PV, recursing up to root
+        // Avoid to send 'fake' alarms when the PV is re-enabled for example
+        if (snapshot.getValue() != null && snapshot.getValue().isEmpty())
+            return;
+        // Configuration update results in an alarm update with no changes
+        final PVHistoryEntry pv_history = history.getPV(snapshot.getPath());
+        if (pv_history == null
+                && snapshot.getSeverity().equals(SeverityLevel.OK))
+            return;
+        if (pv_history != null
+                && snapshot.getSeverity().equals(pv_history.getSeverity())
+                && snapshot.getCurrentSeverity().equals(pv_history.getCurrentSeverity()))
+            return;
+        // Process automated actions of PV, recursing up to root
         for (AlarmTreeItem item = pvItem;
              item != null  &&  !item.getPosition().equals(AlarmTreePosition.Root);
              item = item.getParent()) {
@@ -121,102 +121,102 @@ public class AlarmNotifier {
                 handleAutomatedAction(snapshot, item, aa);
         }
         history.addSnapshot(snapshot);
-	}
+    }
 
-	private void handleAutomatedAction(PVSnapshot snapshot,
-			AlarmTreeItem aaItem, AADataStructure aa) {
-		final ActionID naID = NotifierUtils.getActionID(aaItem, aa);
-		AlarmHandler actionTask = workQueue.find(naID);
-		if (actionTask != null) {
-			// Update only if action is scheduled and not yet executed
-			actionTask.updateAlarms(snapshot);
-			if (actionTask.getStatus().equals(EActionStatus.NO_DELAY)) {
-				workQueue.interrupt(actionTask);
-				if (!maintenanceMode
-						|| (maintenanceMode && actionTask.getPriority().equals(
-								EActionPriority.IMPORTANT))) {
-					actionTask.setStatus(EActionStatus.FORCED);
-					workQueue.schedule(actionTask, true);
-				}
-			} else if (actionTask.getStatus().equals(
-					EActionStatus.CANCELED_NO_DELAY)) {
-				workQueue.interrupt(actionTask);
-				if (debug) AlarmNotifierHistory.getInstance().addAction(actionTask);
-			}
-			// Pending action updated => no need to create a new one
-			return;
-		}
-		final ItemInfo info = ItemInfo.fromItem(aaItem);
-		// No automated action if PV disabled
-		if (info.isPV() && !info.isEnabled())
-			return;
-		final IAutomatedAction newAction = factory.getNotificationAction(aaItem, aa);
-		if (newAction == null)
-			return;
-		final AlarmHandler newTask = new AlarmHandler(naID, info, newAction, aa.getDelay());
-		newTask.updateAlarms(snapshot);
-		if (newTask.getStatus().equals(EActionStatus.CANCELED)
-				|| newTask.getStatus().equals(EActionStatus.CANCELED_NO_DELAY)) {
-			// Do not schedule canceled actions
-			if (debug) AlarmNotifierHistory.getInstance().addAction(newTask);
-			return;
-		}
-		if (!maintenanceMode
-				|| (maintenanceMode && newTask.getPriority().equals(
-						EActionPriority.IMPORTANT))) {
-			if (newTask.getStatus().equals(EActionStatus.NO_DELAY)) {
-				newTask.setStatus(EActionStatus.FORCED);
-				workQueue.schedule(newTask, true);
-			} else {
-				workQueue.schedule(newTask, false);
-			}
-		}
-	}
+    private void handleAutomatedAction(PVSnapshot snapshot,
+            AlarmTreeItem aaItem, AADataStructure aa) {
+        final ActionID naID = NotifierUtils.getActionID(aaItem, aa);
+        AlarmHandler actionTask = workQueue.find(naID);
+        if (actionTask != null) {
+            // Update only if action is scheduled and not yet executed
+            actionTask.updateAlarms(snapshot);
+            if (actionTask.getStatus().equals(EActionStatus.NO_DELAY)) {
+                workQueue.interrupt(actionTask);
+                if (!maintenanceMode
+                        || (maintenanceMode && actionTask.getPriority().equals(
+                                EActionPriority.IMPORTANT))) {
+                    actionTask.setStatus(EActionStatus.FORCED);
+                    workQueue.schedule(actionTask, true);
+                }
+            } else if (actionTask.getStatus().equals(
+                    EActionStatus.CANCELED_NO_DELAY)) {
+                workQueue.interrupt(actionTask);
+                if (debug) AlarmNotifierHistory.getInstance().addAction(actionTask);
+            }
+            // Pending action updated => no need to create a new one
+            return;
+        }
+        final ItemInfo info = ItemInfo.fromItem(aaItem);
+        // No automated action if PV disabled
+        if (info.isPV() && !info.isEnabled())
+            return;
+        final IAutomatedAction newAction = factory.getNotificationAction(aaItem, aa);
+        if (newAction == null)
+            return;
+        final AlarmHandler newTask = new AlarmHandler(naID, info, newAction, aa.getDelay());
+        newTask.updateAlarms(snapshot);
+        if (newTask.getStatus().equals(EActionStatus.CANCELED)
+                || newTask.getStatus().equals(EActionStatus.CANCELED_NO_DELAY)) {
+            // Do not schedule canceled actions
+            if (debug) AlarmNotifierHistory.getInstance().addAction(newTask);
+            return;
+        }
+        if (!maintenanceMode
+                || (maintenanceMode && newTask.getPriority().equals(
+                        EActionPriority.IMPORTANT))) {
+            if (newTask.getStatus().equals(EActionStatus.NO_DELAY)) {
+                newTask.setStatus(EActionStatus.FORCED);
+                workQueue.schedule(newTask, true);
+            } else {
+                workQueue.schedule(newTask, false);
+            }
+        }
+    }
 
-	/**
-	 * Cancel all current running automated actions when a new configuration is
-	 * set.
-	 */
-	public void handleNewAlarmConfiguration() {
-		workQueue.interruptAll();
-		Activator.getLogger().config("New alarm configuration loaded, pending actions interrupted");
-	}
+    /**
+     * Cancel all current running automated actions when a new configuration is
+     * set.
+     */
+    public void handleNewAlarmConfiguration() {
+        workQueue.interruptAll();
+        Activator.getLogger().config("New alarm configuration loaded, pending actions interrupted");
+    }
 
-	/**
-	 * Cancel all current running automated actions when maintenance mode is set
-	 * to <code>true</code>
-	 */
-	public void handleModeUpdate(boolean maintenance_mode) {
-		this.maintenanceMode = maintenance_mode;
-		AlarmNotifierHistory.getInstance().clearAll();
-		if (maintenance_mode)
-			workQueue.interruptAll();
-		Activator.getLogger().config("Maintenance mode "
-						+ (maintenance_mode ? "activated, pending actions interrupted"
-								: "deactivated") + ", history cleaned");
-	}
+    /**
+     * Cancel all current running automated actions when maintenance mode is set
+     * to <code>true</code>
+     */
+    public void handleModeUpdate(boolean maintenance_mode) {
+        this.maintenanceMode = maintenance_mode;
+        AlarmNotifierHistory.getInstance().clearAll();
+        if (maintenance_mode)
+            workQueue.interruptAll();
+        Activator.getLogger().config("Maintenance mode "
+                        + (maintenance_mode ? "activated, pending actions interrupted"
+                                : "deactivated") + ", history cleaned");
+    }
 
-	/** Dump to stdout */
-	public void dump() {
-		System.out.println("== Alarm Notifier Snapshot ==");
+    /** Dump to stdout */
+    public void dump() {
+        System.out.println("== Alarm Notifier Snapshot ==");
 
-		// Log memory usage in MB
-		final double free = Runtime.getRuntime().freeMemory() / (1024.0 * 1024.0);
-		final double total = Runtime.getRuntime().totalMemory() / (1024.0 * 1024.0);
-		final double max = Runtime.getRuntime().maxMemory() / (1024.0 * 1024.0);
-		final DateFormat format = new SimpleDateFormat(JMSLogMessage.DATE_FORMAT);
-		System.out.format("%s == Alarm Notifier Memory: Max %.2f MB, Free %.2f MB (%.1f %%), total %.2f MB (%.1f %%)\n",
-						format.format(new Date()), max, free, 100.0 * free / max, total, 100.0 * total / max);
+        // Log memory usage in MB
+        final double free = Runtime.getRuntime().freeMemory() / (1024.0 * 1024.0);
+        final double total = Runtime.getRuntime().totalMemory() / (1024.0 * 1024.0);
+        final double max = Runtime.getRuntime().maxMemory() / (1024.0 * 1024.0);
+        final DateFormat format = new SimpleDateFormat(JMSLogMessage.DATE_FORMAT);
+        System.out.format("%s == Alarm Notifier Memory: Max %.2f MB, Free %.2f MB (%.1f %%), total %.2f MB (%.1f %%)\n",
+                        format.format(new Date()), max, free, 100.0 * free / max, total, 100.0 * total / max);
 
-		workQueue.dump();
-	}
+        workQueue.dump();
+    }
 
-	public WorkQueue getWorkQueue() {
-		return workQueue;
-	}
+    public WorkQueue getWorkQueue() {
+        return workQueue;
+    }
 
-	public void setDebug(boolean debug) {
-		this.debug = debug;
-	}
+    public void setDebug(boolean debug) {
+        this.debug = debug;
+    }
 
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/AlarmNotifier.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/AlarmNotifier.java
@@ -120,7 +120,14 @@ public class AlarmNotifier {
             for (AADataStructure aa : item.getAutomatedActions())
                 handleAutomatedAction(snapshot, item, aa);
         }
-        history.addSnapshot(snapshot);
+
+        // When only notifying on escalation, and the current
+        // severity is OK, forget that this happened.
+        // Otherwise remember so that we can notify with NO_DELAY
+        // as the PV re-enters an alarm
+        if (PVAlarmHandler.notify_escalating_alarms_only == false  ||
+            snapshot.getCurrentSeverity() != SeverityLevel.OK)
+            history.addSnapshot(snapshot);
     }
 
     private void handleAutomatedAction(PVSnapshot snapshot,

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Application.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Application.java
@@ -37,7 +37,10 @@ public class Application implements IApplication {
 	private static final String[] VERBOSE_PACKAGES = new String[] {
 			"com.sun.jersey.core.spi.component",
 			"com.sun.jersey.core.spi.component.ProviderServices",
-			"com.sun.jersey.spi.service.ServiceFinder" };
+			"com.sun.jersey.spi.service.ServiceFinder",
+			"org.apache.activemq",
+			"com.sun.mail"
+	};
 	private final List<Logger> strongRefLoggers = new ArrayList<>();
 
 	final public static String APPLICATION_NAME = "AlarmNotifier";

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Application.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Application.java
@@ -36,83 +36,83 @@ import org.eclipse.equinox.app.IApplicationContext;
 public class Application implements IApplication {
 
     private static final String[] VERBOSE_PACKAGES = new String[] {
-			"com.sun.jersey.core.spi.component",
-			"com.sun.jersey.core.spi.component.ProviderServices",
-			"com.sun.jersey.spi.service.ServiceFinder",
-			"org.apache.activemq",
-			// "com.sun" disables com.sun.mail.smtp.SMTPTransport.
-			// Should also disable "com.sun.activation.registries.LogSupport",
-			// but doesn't ?!
-			"com.sun",
-			"javax.mail"
-	};
-	private final List<Logger> strongRefLoggers = new ArrayList<>();
+            "com.sun.jersey.core.spi.component",
+            "com.sun.jersey.core.spi.component.ProviderServices",
+            "com.sun.jersey.spi.service.ServiceFinder",
+            "org.apache.activemq",
+            // "com.sun" disables com.sun.mail.smtp.SMTPTransport.
+            // Should also disable "com.sun.activation.registries.LogSupport",
+            // but doesn't ?!
+            "com.sun",
+            "javax.mail"
+    };
+    private final List<Logger> strongRefLoggers = new ArrayList<>();
 
-	final public static String APPLICATION_NAME = "AlarmNotifier";
-	private boolean run = true;
+    final public static String APPLICATION_NAME = "AlarmNotifier";
+    private boolean run = true;
 
     /** {@inheritDoc} */
     @Override
-	public Object start(final IApplicationContext context) throws Exception
-	{
+    public Object start(final IApplicationContext context) throws Exception
+    {
         // Initialize logging
         LogConfigurator.configureFromPreferences();
 
         // Adjust log level of verbose packages
-		Level verboseLogLevel = org.csstudio.alarm.beast.notifier.Preferences.getVerboseLogLevel();
-		for (String verbosePackage : VERBOSE_PACKAGES) {
-			Logger logger = Logger.getLogger(verbosePackage);
-			logger.setLevel(verboseLogLevel);
-			for (Handler handler : logger.getHandlers()) {
-				handler.setLevel(verboseLogLevel);
-			}
-			//keep strong references so log manager doesn't release and recreate the loggers with default level
-			strongRefLoggers.add(logger);
-		}
+        Level verboseLogLevel = org.csstudio.alarm.beast.notifier.Preferences.getVerboseLogLevel();
+        for (String verbosePackage : VERBOSE_PACKAGES) {
+            Logger logger = Logger.getLogger(verbosePackage);
+            logger.setLevel(verboseLogLevel);
+            for (Handler handler : logger.getHandlers()) {
+                handler.setLevel(verboseLogLevel);
+            }
+            //keep strong references so log manager doesn't release and recreate the loggers with default level
+            strongRefLoggers.add(logger);
+        }
 
-		// Display configuration info
+        // Display configuration info
         final String version = (String) context.getBrandingBundle().getHeaders().get("Bundle-Version");
         final String app_info = context.getBrandingName() + " " + version;
 
-    	// Create parser for arguments and run it.
+        // Create parser for arguments and run it.
         final String args[] = (String []) context.getArguments().get("application.args");
 
         final ArgParser parser = new ArgParser();
         final BooleanOption help_opt = new BooleanOption(parser, "-help", "Display help");
         final BooleanOption version_opt = new BooleanOption(parser, "-version", "Display version info");
         final StringOption config_name = new StringOption(parser,
-    		"-root", "Alarm Configuration root", Preferences.getAlarmTreeRoot());
-		final StringOption set_password = new StringOption(parser,
-				"-set_password", "plugin/key=value", "Set secure preferences", null);
-		parser.addEclipseParameters();
-		try {
-			parser.parse(args);
-		} catch (final Exception ex) {
-			System.out.println(ex.getMessage() + "\n" + parser.getHelp());
-			return IApplication.EXIT_OK;
-		}
-		if (help_opt.get()) {
-			System.out.println(app_info + "\n\n" + parser.getHelp());
-			return IApplication.EXIT_OK;
-		}
-		if (version_opt.get()) {
-			System.out.println(app_info);
-			return IApplication.EXIT_OK;
-		}
-		final String option = set_password.get();
-		if (option != null) { // Split "plugin/key=value"
-			final String pref, value;
-			final int sep = option.indexOf("=");
-			if (sep >= 0) {
-				pref = option.substring(0, sep);
-				value = option.substring(sep + 1);
-			} else {
-				pref = option;
-				value = PasswordInput.readPassword("Value for " + pref + ":");
-			}
-			SecurePreferences.set(pref, value);
-			return IApplication.EXIT_OK;
-		}
+            "-root", "Alarm Configuration root", Preferences.getAlarmTreeRoot());
+        final StringOption set_password = new StringOption(parser,
+                "-set_password", "plugin/key=value", "Set secure preferences", null);
+        parser.addEclipseParameters();
+        try {
+            parser.parse(args);
+        } catch (final Exception ex) {
+            System.out.println(ex.getMessage() + "\n" + parser.getHelp());
+            return IApplication.EXIT_OK;
+        }
+        if (help_opt.get()) {
+            System.out.println(app_info + "\n\n" + parser.getHelp());
+            return IApplication.EXIT_OK;
+        }
+        if (version_opt.get()) {
+            System.out.println(app_info);
+            return IApplication.EXIT_OK;
+        }
+        final String option = set_password.get();
+        if (option != null) { // Split "plugin/key=value"
+            final String pref, value;
+            final int sep = option.indexOf("=");
+            if (sep >= 0) {
+                pref = option.substring(0, sep);
+                value = option.substring(sep + 1);
+            } else {
+                pref = option;
+                value = PasswordInput.readPassword("Value for " + pref + ":");
+            }
+            SecurePreferences.set(pref, value);
+            return IApplication.EXIT_OK;
+        }
 
         Activator.getLogger().info(app_info + " started for '" + config_name.get() + "' configuration");
         System.out.println(app_info);
@@ -125,37 +125,37 @@ public class Application implements IApplication {
         System.out.println("Notifier timer threshold: " + timer_threshold);
         System.out.println("Notifie only escalating alarms: " + PVAlarmHandler.notify_escalating_alarms_only);
 
-		try {
-			List<IApplicationListener> listeners = NotifierUtils.getListeners();
-			if (listeners != null)
-				for (IApplicationListener l : listeners)
-					l.applicationStarted(context);
-			AutomatedActionFactory factory = AutomatedActionFactory.getInstance();
-			factory.init(NotifierUtils.getActions());
-			final IAlarmRDBHandler rdbHandler = new AlarmRDBHandler(config_name.get());
-			final AlarmNotifier alarm_notifier = new AlarmNotifier(
-					config_name.get(), rdbHandler, factory, timer_threshold);
-			rdbHandler.init(alarm_notifier);
-			alarm_notifier.start();
-			while (run) {
-				Thread.sleep(500);
-			}
-			alarm_notifier.stop();
-		} catch (Throwable ex) {
-			Activator.getLogger().log(Level.SEVERE,
-					"Exception during Alarm Notifier starting", ex);
-			return Integer.valueOf(-1);
-		}
-		return IApplication.EXIT_OK;
+        try {
+            List<IApplicationListener> listeners = NotifierUtils.getListeners();
+            if (listeners != null)
+                for (IApplicationListener l : listeners)
+                    l.applicationStarted(context);
+            AutomatedActionFactory factory = AutomatedActionFactory.getInstance();
+            factory.init(NotifierUtils.getActions());
+            final IAlarmRDBHandler rdbHandler = new AlarmRDBHandler(config_name.get());
+            final AlarmNotifier alarm_notifier = new AlarmNotifier(
+                    config_name.get(), rdbHandler, factory, timer_threshold);
+            rdbHandler.init(alarm_notifier);
+            alarm_notifier.start();
+            while (run) {
+                Thread.sleep(500);
+            }
+            alarm_notifier.stop();
+        } catch (Throwable ex) {
+            Activator.getLogger().log(Level.SEVERE,
+                    "Exception during Alarm Notifier starting", ex);
+            return Integer.valueOf(-1);
+        }
+        return IApplication.EXIT_OK;
     }
 
-	/**
-	 * From the Equinox console, calling 'stopApp' will invoke this method
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void stop() {
-		run = false;
-	}
+    /**
+     * From the Equinox console, calling 'stopApp' will invoke this method
+     * {@inheritDoc}
+     */
+    @Override
+    public void stop() {
+        run = false;
+    }
 
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/EActionPriority.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/EActionPriority.java
@@ -13,7 +13,7 @@ package org.csstudio.alarm.beast.notifier;
  *
  */
 public enum EActionPriority {
-	
+
 	/** OK/NO_ALARM/normal/good */
     OK(Messages.Priority_OK, 0),
 
@@ -25,10 +25,10 @@ public enum EActionPriority {
 
     /** Major issue */
     MAJOR(Messages.Priority_MAJOR, 2);
-    
+
 	final private String display_name;
     final private int priority;
-	
+
 	EActionPriority(final String display_name, final int priority) {
 		this.display_name = display_name;
 		this.priority = priority;
@@ -42,7 +42,8 @@ public enum EActionPriority {
 		return priority;
 	}
 
-	@Override
+	@SuppressWarnings("nls")
+    @Override
 	public String toString() {
 		return "EActionPriority " + name() + " (" + display_name + ",  "
 				+ ordinal() + ")";

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/ItemInfo.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/ItemInfo.java
@@ -18,15 +18,16 @@ import org.csstudio.alarm.beast.client.AlarmTreePV;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class ItemInfo {
-	
+
 	final int id;
 	final private String name, path, description;
 	final private boolean enabled, isPV, latching;
-	
-	private static Pattern IMPPattern = Pattern.compile("^\\ *\\*?\\!.*");
 
-	public static ItemInfo fromItem(final AlarmTreeItem item) 
+    private static Pattern IMPPattern = Pattern.compile("^\\ *\\*?\\!.*");
+
+	public static ItemInfo fromItem(final AlarmTreeItem item)
     {
 		final int id = item.getID();
 		final String name = item.getName();
@@ -41,7 +42,7 @@ public class ItemInfo {
 			return new ItemInfo(id, name, path, null, false, false, false);
 		}
     }
-	
+
 	public ItemInfo(final int id,
 			final String name,
 			final String path,
@@ -52,13 +53,13 @@ public class ItemInfo {
     {
         this.id = id;
         this.name = name;
-        this.path = path; 
+        this.path = path;
         this.description = description;
         this.isPV = isPV;
         this.enabled = enabled;
         this.latching = latching;
     }
-	
+
 	public boolean isImportant() {
 		if (description == null || "".equals(description))
 			return false;
@@ -89,5 +90,5 @@ public class ItemInfo {
 	public boolean isLatching() {
 		return latching;
 	}
-	
+
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Messages.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Messages.java
@@ -31,6 +31,7 @@ public class Messages extends NLS {
 	public static String Status_FAILED;
 
 	public static String Reason_Recovered;
+    public static String Reason_RecoveredFmt;
 	public static String Reason_Acknowledged;
 	public static String Reason_NoDelay;
 	public static String Reason_SubActionsCanceled;

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVAlarmHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVAlarmHandler.java
@@ -54,9 +54,9 @@ public class PVAlarmHandler {
     }
 
     private void validate() {
-        PVSnapshot current_snapshot = getCurrent();
-        PVHistoryEntry pv_history = AlarmNotifierHistory.getInstance().getPV(
-                current_snapshot.getPath());
+        final PVSnapshot current_snapshot = getCurrent();
+        final AlarmNotifierHistory history = AlarmNotifierHistory.getInstance();
+        final PVHistoryEntry pv_history = history.getPV(current_snapshot.getPath());
 
         if (notify_escalating_alarms_only)
         {   // Cancel alarms that are not escalating the severity
@@ -66,12 +66,14 @@ public class PVAlarmHandler {
             {
                 this.status = EActionStatus.CANCELED;
                 this.reason = Messages.Reason_Acknowledged;
+                history.clear(current_snapshot);
                 return;
             }
             else if (! current.isActive()) // For now really same as current == OK
             {
                  this.status = EActionStatus.CANCELED;
                  this.reason = NLS.bind(Messages.Reason_RecoveredFmt, latched.name(), current.name());
+                 history.clear(current_snapshot);
                  return;
             }
         }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVAlarmHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVAlarmHandler.java
@@ -26,37 +26,37 @@ import org.eclipse.osgi.util.NLS;
 public class PVAlarmHandler {
     final public static boolean notify_escalating_alarms_only = org.csstudio.alarm.beast.notifier.Preferences.getNotifyEscalatingAlarmsOnly();
 
-	private List<PVSnapshot> snapshots;
-	private EActionStatus status = EActionStatus.PENDING;
-	private String reason = Messages.Empty;
-	private boolean acknowledged = false;
+    private List<PVSnapshot> snapshots;
+    private EActionStatus status = EActionStatus.PENDING;
+    private String reason = Messages.Empty;
+    private boolean acknowledged = false;
 
-	public PVAlarmHandler() {
-		this.snapshots = new LinkedList<PVSnapshot>();
-	}
+    public PVAlarmHandler() {
+        this.snapshots = new LinkedList<PVSnapshot>();
+    }
 
-	public void update(PVSnapshot snapshot) {
-		if (getCurrent() != null) {
-			SeverityLevel previous_severity = getCurrent().getSeverity();
-			if (unACK(previous_severity, snapshot.getSeverity()))
-				this.acknowledged = false;
-		}
-		if (!acknowledged && snapshot.isAcknowledge())
-			this.acknowledged = true;
-		snapshots.add(snapshot);
-		validate();
-	}
+    public void update(PVSnapshot snapshot) {
+        if (getCurrent() != null) {
+            SeverityLevel previous_severity = getCurrent().getSeverity();
+            if (unACK(previous_severity, snapshot.getSeverity()))
+                this.acknowledged = false;
+        }
+        if (!acknowledged && snapshot.isAcknowledge())
+            this.acknowledged = true;
+        snapshots.add(snapshot);
+        validate();
+    }
 
-	public PVSnapshot getCurrent() {
-		if (snapshots.isEmpty())
-			return null;
-		return snapshots.get(snapshots.size() - 1);
-	}
+    public PVSnapshot getCurrent() {
+        if (snapshots.isEmpty())
+            return null;
+        return snapshots.get(snapshots.size() - 1);
+    }
 
-	private void validate() {
-		PVSnapshot current_snapshot = getCurrent();
-		PVHistoryEntry pv_history = AlarmNotifierHistory.getInstance().getPV(
-				current_snapshot.getPath());
+    private void validate() {
+        PVSnapshot current_snapshot = getCurrent();
+        PVHistoryEntry pv_history = AlarmNotifierHistory.getInstance().getPV(
+                current_snapshot.getPath());
 
         if (notify_escalating_alarms_only)
         {   // Cancel alarms that are not escalating the severity
@@ -76,101 +76,101 @@ public class PVAlarmHandler {
             }
         }
 
-		if (snapshots.size() == 1) {
-			if (pv_history == null) {
-				if (current_snapshot.getSeverity().equals(SeverityLevel.OK)) {
-					// Configuration update results in an alarm update with no changes => CANCEL
-					this.status = EActionStatus.CANCELED;
-					this.reason = Messages.Reason_NoAlarmRaised;
-					return;
-				}
-				// If no history entry exists, it is the first alarm update => WAIT
-				this.status = EActionStatus.PENDING;
-				this.reason = Messages.Empty;
-			} else {
-				if (current_snapshot.getSeverity().equals(pv_history.getSeverity())
-						&& current_snapshot.getCurrentSeverity().equals(pv_history.getCurrentSeverity())) {
-					// Configuration update results in an alarm update with no changes => CANCEL
-					this.status = EActionStatus.CANCELED;
-					this.reason = Messages.Reason_NoAlarmRaised;
-					return;
-				}
-				// If an history entry exists, PV was already under alarm
-				if (pv_history.isAcknowledged()) {
-					if (unACK(pv_history.getSeverity(), current_snapshot.getSeverity())) {
-						// Un-acknowledged alarm state change after the delay of previous ACK => NO DELAY
-						this.status = EActionStatus.NO_DELAY;
-						this.reason = Messages.Reason_NoDelay;
-					} else {
-						// Acknowledged alarm state change with lower/higher or OK priority => CANCEL
-						this.status = EActionStatus.CANCELED;
-						this.reason = Messages.Reason_Acknowledged;
-					}
-				} else {
-					if (pv_history.hasRecovredWithinDelay()
-							&& current_snapshot.isAcknowledge()) {
-						// Acknowledge after alarm state change and recover within delay => CANCEL
-						this.status = EActionStatus.CANCELED;
-						this.reason = Messages.Reason_Recovered;
-					} else {
-						// Alarm acknowledged after delay of last action => NO DELAY
-						// Un-acknowledged alarm state change => NO DELAY
-						this.status = EActionStatus.NO_DELAY;
-						this.reason = Messages.Reason_NoDelay;
-					}
-				}
-			}
-		} else {
-			if (!current_snapshot.isUnderAlarm()) {
-				// Alarm raised & recovered within the delay => CANCEL
-				this.status = EActionStatus.CANCELED;
-				this.reason = Messages.Reason_Recovered;
-			} else {
-				if (acknowledged) {
-					// Alarm raised & acknowledged within the delay => CANCEL NO DELAY
-					this.status = EActionStatus.CANCELED_NO_DELAY;
-					this.reason = Messages.Reason_Acknowledged;
-				} else {
-					PVSnapshot previous_snapshot = snapshots.get(snapshots.size() - 2);
-					if (pv_history != null
-							&& pv_history.isAcknowledged()
-							&& !unACK(previous_snapshot.getSeverity(), current_snapshot.getSeverity())) {
-						// Acknowledged alarm state change with lower/higher or OK priority => CANCEL NO DELAY
-						this.status = EActionStatus.CANCELED_NO_DELAY;
-						this.reason = Messages.Reason_Acknowledged;
-					} else {
-						// Default: we wait for the delay
-						this.status = EActionStatus.PENDING;
-						this.reason = Messages.Empty;
-					}
-				}
-			}
-		}
-		// TODO: if a update occurs before the previous one has finished
-		// processing, history is null...
-		if (pv_history != null) {
-			if (snapshots.size() == 1) pv_history.setRecovredWithinDelay(false);
-			else pv_history.setRecovredWithinDelay(!current_snapshot.isUnderAlarm());
-		}
-	}
+        if (snapshots.size() == 1) {
+            if (pv_history == null) {
+                if (current_snapshot.getSeverity().equals(SeverityLevel.OK)) {
+                    // Configuration update results in an alarm update with no changes => CANCEL
+                    this.status = EActionStatus.CANCELED;
+                    this.reason = Messages.Reason_NoAlarmRaised;
+                    return;
+                }
+                // If no history entry exists, it is the first alarm update => WAIT
+                this.status = EActionStatus.PENDING;
+                this.reason = Messages.Empty;
+            } else {
+                if (current_snapshot.getSeverity().equals(pv_history.getSeverity())
+                        && current_snapshot.getCurrentSeverity().equals(pv_history.getCurrentSeverity())) {
+                    // Configuration update results in an alarm update with no changes => CANCEL
+                    this.status = EActionStatus.CANCELED;
+                    this.reason = Messages.Reason_NoAlarmRaised;
+                    return;
+                }
+                // If an history entry exists, PV was already under alarm
+                if (pv_history.isAcknowledged()) {
+                    if (unACK(pv_history.getSeverity(), current_snapshot.getSeverity())) {
+                        // Un-acknowledged alarm state change after the delay of previous ACK => NO DELAY
+                        this.status = EActionStatus.NO_DELAY;
+                        this.reason = Messages.Reason_NoDelay;
+                    } else {
+                        // Acknowledged alarm state change with lower/higher or OK priority => CANCEL
+                        this.status = EActionStatus.CANCELED;
+                        this.reason = Messages.Reason_Acknowledged;
+                    }
+                } else {
+                    if (pv_history.hasRecovredWithinDelay()
+                            && current_snapshot.isAcknowledge()) {
+                        // Acknowledge after alarm state change and recover within delay => CANCEL
+                        this.status = EActionStatus.CANCELED;
+                        this.reason = Messages.Reason_Recovered;
+                    } else {
+                        // Alarm acknowledged after delay of last action => NO DELAY
+                        // Un-acknowledged alarm state change => NO DELAY
+                        this.status = EActionStatus.NO_DELAY;
+                        this.reason = Messages.Reason_NoDelay;
+                    }
+                }
+            }
+        } else {
+            if (!current_snapshot.isUnderAlarm()) {
+                // Alarm raised & recovered within the delay => CANCEL
+                this.status = EActionStatus.CANCELED;
+                this.reason = Messages.Reason_Recovered;
+            } else {
+                if (acknowledged) {
+                    // Alarm raised & acknowledged within the delay => CANCEL NO DELAY
+                    this.status = EActionStatus.CANCELED_NO_DELAY;
+                    this.reason = Messages.Reason_Acknowledged;
+                } else {
+                    PVSnapshot previous_snapshot = snapshots.get(snapshots.size() - 2);
+                    if (pv_history != null
+                            && pv_history.isAcknowledged()
+                            && !unACK(previous_snapshot.getSeverity(), current_snapshot.getSeverity())) {
+                        // Acknowledged alarm state change with lower/higher or OK priority => CANCEL NO DELAY
+                        this.status = EActionStatus.CANCELED_NO_DELAY;
+                        this.reason = Messages.Reason_Acknowledged;
+                    } else {
+                        // Default: we wait for the delay
+                        this.status = EActionStatus.PENDING;
+                        this.reason = Messages.Empty;
+                    }
+                }
+            }
+        }
+        // TODO: if a update occurs before the previous one has finished
+        // processing, history is null...
+        if (pv_history != null) {
+            if (snapshots.size() == 1) pv_history.setRecovredWithinDelay(false);
+            else pv_history.setRecovredWithinDelay(!current_snapshot.isUnderAlarm());
+        }
+    }
 
-	/** @param previous Previous severity
-	 *  @param current Current severity
-	 *  @return Is current the un-acked version of the previous {@link SeverityLevel}?
-	 */
-	private boolean unACK(final SeverityLevel previous, final SeverityLevel current)
-	{
-	    return current.isActive()  == true   &&
-		       previous.isActive() == false  &&
-			   previous.name().startsWith(current.name());
-	}
+    /** @param previous Previous severity
+     *  @param current Current severity
+     *  @return Is current the un-acked version of the previous {@link SeverityLevel}?
+     */
+    private boolean unACK(final SeverityLevel previous, final SeverityLevel current)
+    {
+        return current.isActive()  == true   &&
+               previous.isActive() == false  &&
+               previous.name().startsWith(current.name());
+    }
 
-	public EActionStatus getStatus() {
-		return status;
-	}
+    public EActionStatus getStatus() {
+        return status;
+    }
 
-	public String getReason() {
-		return reason;
-	}
+    public String getReason() {
+        return reason;
+    }
 
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVSnapshot.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVSnapshot.java
@@ -21,28 +21,29 @@ import org.epics.util.time.Timestamp;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class PVSnapshot implements Comparable<PVSnapshot> {
 
 	/** Parser for received time stamp */
     final protected static SimpleDateFormat date_format = new SimpleDateFormat(JMSLogMessage.DATE_FORMAT);
-    
+
     /** Pattern for important priority */
     final protected static Pattern IMPPattern = Pattern.compile("^\\ *\\*?\\!.*");
-	
+
 	final int id;
 	final private String name, path, parentPath, description;
 	final private boolean enabled, latching;
-	
+
     final private SeverityLevel current_severity, severity;
     final private String current_message, message, value;
     final private Timestamp timestamp;
-	
+
     /**
      * Create {@link PVSnapshot} from an {@link AlarmTreePV}
      * @param pv
      * @return
      */
-	public static PVSnapshot fromPVItem(final AlarmTreePV pv) 
+	public static PVSnapshot fromPVItem(final AlarmTreePV pv)
 	{
 		final int id = pv.getID();
 		final String name = pv.getName();
@@ -58,12 +59,12 @@ public class PVSnapshot implements Comparable<PVSnapshot> {
 		final String current_message = pv.getCurrentMessage();
 		final String value = pv.getValue();
 		final Timestamp timestamp = pv.getTimestamp();
-		
+
 		return new PVSnapshot(id, name, path, parentPath, description, enabled, latching,
 				current_severity, current_message, severity, status, value,
 				timestamp);
 	}
-    
+
     public PVSnapshot(final int id,
 			final String name,
 			final String path,
@@ -73,7 +74,7 @@ public class PVSnapshot implements Comparable<PVSnapshot> {
             final boolean latching,
             final SeverityLevel current_severity,
             final String current_message,
-            final SeverityLevel severity, 
+            final SeverityLevel severity,
             final String message,
             final String value,
             final Timestamp timestamp)
@@ -92,7 +93,7 @@ public class PVSnapshot implements Comparable<PVSnapshot> {
 		this.value = value;
 		this.timestamp = timestamp;
     }
-    
+
     /** Return <code>true</code> if PV has an important priority defined in description */
     public boolean isImportant() {
 		if (description == null || "".equals(description))
@@ -102,7 +103,7 @@ public class PVSnapshot implements Comparable<PVSnapshot> {
 			return true;
 		return false;
 	}
-    
+
 	/** Return <code>true</code> if the alarm severity is NOT OK */
 	public boolean isUnderAlarm() {
 		return !this.current_severity.equals(SeverityLevel.OK);

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVSummary.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/PVSummary.java
@@ -18,6 +18,7 @@ import org.eclipse.osgi.util.NLS;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class PVSummary {
 
 	private String name, description;
@@ -105,31 +106,31 @@ public class PVSummary {
 		builder.append("PV: ");
 		builder.append(name);
 		builder.append(" - ");
-		
+
 		builder.append("Description: ");
 		builder.append(getSummary());
 		builder.append(" - ");
-		
+
 		builder.append("Alarm Time: ");
 		builder.append(timestamp);
 		builder.append(" - ");
-		
+
 		builder.append("Current Severity: ");
 		builder.append(current_severity);
 		builder.append(" - ");
-		
+
 		builder.append("Current Status: ");
 		builder.append(current_message);
 		builder.append(" - ");
-		
+
 		builder.append("Alarm Severity: ");
 		builder.append(severity);
 		builder.append(" - ");
-		
+
 		builder.append("Alarm Status: ");
 		builder.append(message);
 		builder.append(" - ");
-		
+
 		builder.append("Alarm Value: ");
 		builder.append(value);
 		return builder.toString();

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Preferences.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/Preferences.java
@@ -16,10 +16,13 @@ import org.eclipse.core.runtime.preferences.IPreferencesService;
  *  <p>
  *  See preferences.ini for explanation of supported preferences.
  *  @author Fred Arnaud (Sopra Group)
+ *  @author Xinyu Wu - notify only on escalating alarms
  */
+@SuppressWarnings("nls")
 public class Preferences {
-	final public static String TIMER_THRESHOLD = "timer_threshold";
-	final public static String VERBOSE_LOG_LEVEL = "verbose_log.level";
+    final public static String TIMER_THRESHOLD = "timer_threshold";
+    final public static String VERBOSE_LOG_LEVEL = "verbose_log.level";
+    final public static String NOTIFY_ESCALATING_ALARMS_ONLY = "notify_escalating_alarms_only";
 
 	/**
 	 * @param setting Preference identifier
@@ -60,7 +63,13 @@ public class Preferences {
 					"Illegal console log level '" + levelStr + "'");
 			return Level.WARNING;
 		}
-
 	}
 
+	/** @return NOTIFY_ESCALATING_ALARMS_ONLY for automated actions */
+	public static boolean getNotifyEscalatingAlarmsOnly() {
+	    final IPreferencesService service = Platform.getPreferencesService();
+	    if (service == null)
+	        return false; // default
+	    return service.getBoolean(Activator.ID, NOTIFY_ESCALATING_ALARMS_ONLY, false, null);
+	}
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/WorkQueue.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/WorkQueue.java
@@ -25,10 +25,11 @@ import org.csstudio.alarm.beast.notifier.util.OverflowManager;
  * Automated actions work queue. Each action is scheduled in a timer and then
  * executed in a stand-alone thread. A scheduled task is executed only if its
  * status is OK.
- * 
+ *
  * @author Fred Arnaud (Sopra Group)
- * 
+ *
  */
+@SuppressWarnings("nls")
 public class WorkQueue {
 
 	private class ScheduledActionTask extends TimerTask {

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/actions/AbstractMailActionImpl.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/actions/AbstractMailActionImpl.java
@@ -19,20 +19,21 @@ import org.csstudio.alarm.beast.notifier.model.IAutomatedAction;
 import org.csstudio.email.JavaxMailSender;
 import org.eclipse.osgi.util.NLS;
 
+@SuppressWarnings("nls")
 public abstract class AbstractMailActionImpl implements IAutomatedAction {
-	
+
 	/** Information from {@link AlarmTreeItem} providing the automated action */
 	protected ItemInfo item;
-	
+
 	protected List<PVSnapshot> pvs;
-	
+
 	protected boolean manuallyExecuted = false;
 
 	protected JavaxMailSender mailSender;
 
 	final private static Pattern NLSPattern = Pattern.compile("\\{\\ *\\d+\\ *\\}");
     final private static Pattern PrefixPattern = Pattern.compile("^\\*(.*)$");
-    
+
     protected String buildSubject() {
 		String subject = mailSender.getSubject().trim();
 		StringBuilder builder = new StringBuilder();
@@ -80,7 +81,7 @@ public abstract class AbstractMailActionImpl implements IAutomatedAction {
 		}
 		return builder.toString();
 	}
-	
+
 	protected String buildBody() {
 		String body = mailSender.getBody().trim();
 		StringBuilder builder = new StringBuilder();
@@ -112,7 +113,7 @@ public abstract class AbstractMailActionImpl implements IAutomatedAction {
 		}
 		return builder.toString();
 	}
-	
+
 	// Handle NLS
 	private String fillNLS(final String message) {
 		Matcher nlsMatcher = NLSPattern.matcher(message);
@@ -129,7 +130,7 @@ public abstract class AbstractMailActionImpl implements IAutomatedAction {
 		}
 		return filledMessage;
 	}
-	
+
 	// Build a summary of underlying alarms
 	private String buildAlarmCount() {
 		StringBuilder builder = new StringBuilder();

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/actions/CommandActionImpl.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/actions/CommandActionImpl.java
@@ -28,6 +28,7 @@ import org.csstudio.java.string.StringSplitter;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class CommandActionImpl implements IAutomatedAction {
 
 	/** Command to run. Format depends on OS */
@@ -88,7 +89,7 @@ public class CommandActionImpl implements IAutomatedAction {
 			execCmd(dir, expanded_command, wait);
 		} else execCmd(dir, command, wait);
 	}
-	
+
 	public void execCmd(String dir_name, String command, int wait) {
 		// Execute command in a certain directory
 		final File dir = new File(dir_name);
@@ -138,13 +139,13 @@ public class CommandActionImpl implements IAutomatedAction {
 		state = CommandState.FINISHED_ERROR;
 		error(exit_code, stderr.getText());
 	}
-	
+
 	private void error(final int exit_code, final String stderr) {
 		Activator.getLogger().log(Level.WARNING,
 						"Failed to execute command: {0}, exit code: {1}, stderr: {2}",
 						new Object[] { command, exit_code, stderr });
 	}
-	
+
 	/** @return Command state */
 	public CommandState getCommandState() {
 		return state;

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/actions/SmsActionImpl.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/actions/SmsActionImpl.java
@@ -23,6 +23,7 @@ import org.csstudio.email.JavaxMailSender;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class SmsActionImpl extends AbstractMailActionImpl {
 
 	/** {@inheritDoc} */
@@ -57,7 +58,7 @@ public class SmsActionImpl extends AbstractMailActionImpl {
 		mailSender.setBody(buildBody());
 		mailSender.send();
 	}
-	
+
 	public void dump() {
 		System.out.println("SmsActionImpl [\n\tto= " + mailSender.getTo()
 				+ "\n\tsubject= " + mailSender.getSubject() + "\n]");

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/history/AlarmNotifierHistory.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/history/AlarmNotifierHistory.java
@@ -17,13 +17,13 @@ import org.csstudio.alarm.beast.notifier.PVSnapshot;
 
 /**
  * Handles history of previously executed automated actions & alarm updates.
- * 
+ *
  * @author Fred Arnaud (Sopra Group) - ITER
- * 
+ *
  */
 public class AlarmNotifierHistory {
 
-	private static AlarmNotifierHistory instance;
+	private static AlarmNotifierHistory instance = new AlarmNotifierHistory();
 
 	private final Map<ActionID, ActionHistoryEntry> actions;
 	// map PV path (unique) => PVHistoryEntry
@@ -35,8 +35,6 @@ public class AlarmNotifierHistory {
 	}
 
 	public static AlarmNotifierHistory getInstance() {
-		if (instance == null)
-			instance = new AlarmNotifierHistory();
 		return instance;
 	}
 

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/history/PVHistoryEntry.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/history/PVHistoryEntry.java
@@ -12,9 +12,9 @@ import org.csstudio.alarm.beast.notifier.PVSnapshot;
 
 /**
  * History entry of an alarm update identified by its {@link PVSnapshot}.
- * 
+ *
  * @author Fred Arnaud (Sopra Group) - ITER
- * 
+ *
  */
 public class PVHistoryEntry {
 
@@ -36,10 +36,11 @@ public class PVHistoryEntry {
 	}
 
 	public void update(PVSnapshot snapshot) {
-		if (this.severity != null
-				&& this.severity.name().endsWith("ACK")
-				&& this.severity.name().startsWith(snapshot.getSeverity().name())
-				&& !snapshot.getSeverity().name().endsWith("ACK"))
+	    // Does this un-acknowledge a previous acknowledgement?
+		if (severity != null                  &&
+		    snapshot.getSeverity().isActive() &&
+		    severity.isActive() == false      &&
+		    severity.name().startsWith(snapshot.getSeverity().name()) )
 			this.acknowledged = false;
 		if (!acknowledged && snapshot.isAcknowledge())
 			this.acknowledged = true;
@@ -75,11 +76,11 @@ public class PVHistoryEntry {
 		this.recovredWithinDelay = recovredWithinDelay;
 	}
 
-	@Override
+	@SuppressWarnings("nls")
+    @Override
 	public String toString() {
 		return "PVHistoryEntry [currentSeverity=" + currentSeverity
 				+ ", severity=" + severity + ", acknowledged=" + acknowledged
 				+ "]";
 	}
-
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/messages.properties
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/messages.properties
@@ -10,6 +10,7 @@ Status_CANCELED=CANCELED
 Status_CANCELED_NO_DELAY=CANCELED_NO_DELAY
 Status_FAILED=FAILED
 Reason_Recovered=the alarm has recovered
+Reason_RecoveredFmt=recovered from {0} to {1}
 Reason_Acknowledged=the alarm has been acknowledged
 Reason_NoDelay=the action has to be executed without delay
 Reason_SubActionsCanceled=all sub-actions have been canceled

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/model/IApplicationListener.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/model/IApplicationListener.java
@@ -11,10 +11,11 @@ import org.eclipse.equinox.app.IApplicationContext;
 
 /**
  * Listener called when application is started.
- * 
+ *
  * @author Fred Arnaud (Sopra Group) - ITER
- * 
+ *
  */
+@SuppressWarnings("nls")
 public interface IApplicationListener {
 
 	/** ID of the extension point, defined in plugin.xml */

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/rdb/AlarmRDBHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/rdb/AlarmRDBHandler.java
@@ -21,37 +21,42 @@ import org.csstudio.alarm.beast.ui.clientmodel.AlarmClientModel;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class AlarmRDBHandler implements IAlarmRDBHandler {
 
     /** Server for which we communicate */
     private AlarmNotifier notifier;
-    
+
     /** Alarm model */
     final private AlarmClientModel model;
-    
-    
+
+
 	public AlarmRDBHandler(final String root) throws Exception {
 		model = AlarmClientModel.getInstance(root);
 		model.addListener(this);
 	}
 
 	/** Initialize wrapper with AlarmNotifier */
-	public void init(final AlarmNotifier notifier) {
+	@Override
+    public void init(final AlarmNotifier notifier) {
 		this.notifier = notifier;
 	}
 
 	/** Find item by path */
-	public AlarmTreeItem findItem(String path) {
+	@Override
+    public AlarmTreeItem findItem(String path) {
 		return model.getConfigTree().getItemByPath(path);
 	}
 
 	/** @return Current alarm tree */
-	public TreeItem getAlarmTree() {
+	@Override
+    public TreeItem getAlarmTree() {
 		return model.getConfigTree();
 	}
-	
+
 	/** Must be called to release resources */
-	public void close() {
+	@Override
+    public void close() {
 		model.release();
 	}
 
@@ -77,5 +82,5 @@ public class AlarmRDBHandler implements IAlarmRDBHandler {
 			return;
 		notifier.handleAlarmUpdate(pv);
 	}
-	
+
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/AbstractCommandHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/AbstractCommandHandler.java
@@ -13,11 +13,12 @@ import java.util.regex.Pattern;
 import org.csstudio.alarm.beast.notifier.model.IActionHandler;
 
 /** Common behavior for mail commands handlers */
+@SuppressWarnings("nls")
 public abstract class AbstractCommandHandler implements IActionHandler {
 
 	protected final static String DELIMITERS = ",;";
 	final protected static Pattern NLSPattern = Pattern.compile("\\{\\ *[01]\\ *\\}");
-	
+
 	protected enum ParamType {
 		To("to", 0), Cc("cc", 1), Cci("cci", 2), Bcc("bcc", 3), Subject("subject", 4), Body("body", 5);
 
@@ -48,21 +49,22 @@ public abstract class AbstractCommandHandler implements IActionHandler {
 			return null;
 		}
 	}
-	
+
 	private final String scheme;
 	private final String details;
-	
+
 	public AbstractCommandHandler(String details, String scheme) {
 		this.details = details;
 		this.scheme = scheme;
 	}
-	
-	public void parse() throws Exception {
+
+	@Override
+    public void parse() throws Exception {
 		parseDataType(details, null);
 	}
 
 	protected abstract void handleParameter(String data, ParamType type) throws Exception;
-	
+
 	// Recursive method to retrieve pattern parameters
 	private void parseDataType(String data, ParamType type) throws Exception {
 		if (data == null || "".equals(data))
@@ -84,7 +86,7 @@ public abstract class AbstractCommandHandler implements IActionHandler {
 		// no pattern found => final data
 		if (!found) handleParameter(data, type);
 	}
-	
+
 	protected void validateNSF(String data) throws Exception {
 		String dataCopy = new String(data);
 		int beginIndex = 0, endIndex = 0;

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/CSVParser.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/CSVParser.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("nls")
 public class CSVParser {
 
     private final char separator;

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/EMailCommandHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/EMailCommandHandler.java
@@ -19,21 +19,23 @@ import org.csstudio.email.EmailUtils;
 /**
  * Handler for EMail command:
  * Parse {@link AADataStructure} details to extract information.
- * Exemple: 
+ * Exemple:
  *     mailto:rf_support@iter.org;rf_operator@iter.org?cc=rf.ro@iter.org&subject=RF Source 1 in error&body=Major Alarm raised
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class EMailCommandHandler extends AbstractCommandHandler {
-	
+
 	private List<String> to, cc, cci;
 	private String subject, body;
-	
+
 	public EMailCommandHandler(String details) {
 		super(details, "mailto");
 	}
-	
-	protected void handleParameter(String data, ParamType type) throws Exception {
+
+	@Override
+    protected void handleParameter(String data, ParamType type) throws Exception {
 		if (type == null || data == null) return;
 		switch (type) {
 		case To:
@@ -56,7 +58,7 @@ public class EMailCommandHandler extends AbstractCommandHandler {
 			break;
 		}
 	}
-	
+
 	private List<String> extractEmailAdresses(String data) throws Exception {
 		final Pattern emailPattern = Pattern.compile(EmailUtils.EMAIL_REG_EXP);
 		StringTokenizer st = new StringTokenizer(data, DELIMITERS);
@@ -74,10 +76,10 @@ public class EMailCommandHandler extends AbstractCommandHandler {
 	/** @return <code>true</code> if the EMail command define a recipient, a subject and a body */
 	public boolean isComplete() {
 		return ((getTo() != null && !getTo().isEmpty())
-				&& (getSubject() != null && !"".equals(getSubject().trim())) 
+				&& (getSubject() != null && !"".equals(getSubject().trim()))
 				&& (getBody() != null && !"".equals(getBody().trim())));
 	}
-	
+
 	public List<String> getTo() {
 		return to;
 	}

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/EMailCommandValidator.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/EMailCommandValidator.java
@@ -16,21 +16,24 @@ import org.csstudio.alarm.beast.notifier.model.IActionValidator;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class EMailCommandValidator implements IActionValidator {
 
 	private String details;
 	private EMailCommandHandler handler;
-	
-	public void init(String details) {
+
+	@Override
+    public void init(String details) {
 		this.details = details == null ? null : details.trim();
 		handler = new EMailCommandHandler(details);
 	}
-	
+
 	/** @return handler for EMail command */
-	public EMailCommandHandler getHandler() {
+	@Override
+    public EMailCommandHandler getHandler() {
 		return handler;
 	}
-	
+
 	@Override
 	public boolean validate() throws Exception {
 		if (details == null || "".equals(details)) {
@@ -42,5 +45,5 @@ public class EMailCommandValidator implements IActionValidator {
 		}
 		return true;
 	}
-	
+
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/NotifierUtils.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/NotifierUtils.java
@@ -35,11 +35,12 @@ import org.epics.util.time.Timestamp;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class NotifierUtils {
-	
+
 	/** Pattern for automated action command scheme */
     final private static Pattern SchemePattern = Pattern.compile("^([_A-Za-z0-9]+):.*");
-	
+
 	/**
 	 * Read automated action extension points from plugin.xml.
 	 * @return Map<String, IAutomatedAction>, extension points referenced by their scheme.
@@ -99,7 +100,7 @@ public class NotifierUtils {
         return new AlarmUpdateInfo(name, current_severity, current_message,
                 severity, status, value, timestamp);
     }
-	
+
 	/**
 	 * Perform a validation on automated action details.
 	 * @param details

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/PhoneUtils.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/PhoneUtils.java
@@ -12,10 +12,11 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@SuppressWarnings("nls")
 public class PhoneUtils {
-	
+
 	final public static Pattern PhonePattern = Pattern.compile("(\\+?[0-9\\(\\)\\/\\-\\.\\ ]+)");
-	
+
 	public static List<String> parse(String data) throws Exception {
 		List<String> phoneNumbers = new ArrayList<String>();
 		Matcher m = PhonePattern.matcher(data);

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/SmsCommandHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/SmsCommandHandler.java
@@ -17,21 +17,23 @@ import org.csstudio.alarm.beast.client.AADataStructure;
 /**
  * Handler for SMS command:
  * Parse {@link AADataStructure} details to extract information.
- * Exemple: 
+ * Exemple:
  *     sms:+33 6 03 74 36 61?body={0} Alarm raised - Water below {1} m3
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class SmsCommandHandler extends AbstractCommandHandler {
 
 	private List<String> to;
 	private String body;
-	
+
 	public SmsCommandHandler(String details) {
 		super(details, "sms");
 	}
-	
-	protected void handleParameter(String data, ParamType type) throws Exception {
+
+	@Override
+    protected void handleParameter(String data, ParamType type) throws Exception {
 		if (type == null || data == null) return;
 		switch (type) {
 		case To:
@@ -45,7 +47,7 @@ public class SmsCommandHandler extends AbstractCommandHandler {
 			break;
 		}
 	}
-	
+
 	private List<String> extractSMSNumbers(String data) throws Exception {
 		StringTokenizer st = new StringTokenizer(data, DELIMITERS);
 		List<String> smsList = new ArrayList<String>();
@@ -58,7 +60,7 @@ public class SmsCommandHandler extends AbstractCommandHandler {
 		}
 		return smsList;
 	}
-	
+
 	public List<String> getTo() {
 		return to;
 	}

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/SmsCommandValidator.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.notifier/src/org/csstudio/alarm/beast/notifier/util/SmsCommandValidator.java
@@ -16,18 +16,21 @@ import org.csstudio.alarm.beast.notifier.model.IActionValidator;
  * @author Fred Arnaud (Sopra Group)
  *
  */
+@SuppressWarnings("nls")
 public class SmsCommandValidator implements IActionValidator {
 
 	private String details;
 	private SmsCommandHandler handler;
 
-	public void init(String details) {
+	@Override
+    public void init(String details) {
 		this.details = details == null ? null : details.trim();
 		handler = new SmsCommandHandler(details);
 	}
 
 	/** @return handler for SMS command */
-	public SmsCommandHandler getHandler() {
+	@Override
+    public SmsCommandHandler getHandler() {
 		return handler;
 	}
 

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/ChangeLog.html
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/ChangeLog.html
@@ -13,6 +13,13 @@ by all other alarm system tools.
 Revisions before 3.1.0 refer to the associated SNS CSS update.
 </p>
 
+<h2>4.0.3 - 2015-02-18</h2>
+<ul>
+  <li>Notifier option 'notify_escalating_alarms_only' to suppress 'Ack' and 'OK'
+      follow-ups on already executed notifications.
+  </li>
+</ul>
+
 <h2>4.0.2 - 2015-02-16</h2>
 <ul>
   <li>Alarm GUI context menu entries to enable/disable alarms for a PV

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Shared Alarm Components
 Bundle-SymbolicName: org.csstudio.alarm.beast;singleton:=true
-Bundle-Version: 4.0.2.qualifier
+Bundle-Version: 4.0.3.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen - SNS
 Bundle-Description: BEAST library: Alarm model, ...
 Require-Bundle: org.junit;bundle-version="4.8.2",

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.alarm.beast</artifactId>
-  <version>4.0.2-SNAPSHOT</version>
+  <version>4.0.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Adds notifier option 'notify_escalating_alarms_only' to suppress 'Ack' and 'OK' follow-ups on already executed notifications.

Fixes #963 and handles all from #953 that would apply to 'master'.