### PR TITLE
Opi validation tool

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.validation/.classpath
+++ b/applications/plugins/org.csstudio.opibuilder.validation/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/applications/plugins/org.csstudio.opibuilder.validation/.project
+++ b/applications/plugins/org.csstudio.opibuilder.validation/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.csstudio.opibuilder.validation</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/applications/plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
@@ -1,0 +1,19 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: OPI Validation
+Bundle-SymbolicName: org.csstudio.opibuilder.validation;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: ITER
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.csstudio.opibuilder;bundle-version="4.0.0",
+ org.eclipse.ui.views;bundle-version="3.7.0",
+ org.eclipse.wst.validation;bundle-version="1.2.501",
+ org.eclipse.ui.ide;bundle-version="3.10.1",
+ org.csstudio.ui.util;bundle-version="3.2.0",
+ org.eclipse.core.runtime;bundle-version="3.10.0",
+ org.eclipse.core.resources;bundle-version="3.9.1",
+ org.eclipse.ui;bundle-version="3.106.0"
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.csstudio.opibuilder.validation.Activator
+Import-Package: org.w3c.dom;version="3.0.0",
+ org.w3c.dom.events;version="3.0.0"

--- a/applications/plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OPI Validation
 Bundle-SymbolicName: org.csstudio.opibuilder.validation;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: ITER
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.csstudio.opibuilder;bundle-version="4.0.0",
@@ -12,7 +12,8 @@ Require-Bundle: org.csstudio.opibuilder;bundle-version="4.0.0",
  org.csstudio.ui.util;bundle-version="3.2.0",
  org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.resources;bundle-version="3.9.1",
- org.eclipse.ui;bundle-version="3.106.0"
+ org.eclipse.ui;bundle-version="3.106.0",
+ org.jdom;bundle-version="1.1.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.csstudio.opibuilder.validation.Activator
 Import-Package: org.w3c.dom;version="3.0.0",

--- a/applications/plugins/org.csstudio.opibuilder.validation/build.properties
+++ b/applications/plugins/org.csstudio.opibuilder.validation/build.properties
@@ -1,0 +1,7 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml,\
+               preferences.ini,\
+               rules.def

--- a/applications/plugins/org.csstudio.opibuilder.validation/plugin.xml
+++ b/applications/plugins/org.csstudio.opibuilder.validation/plugin.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         id="opi"
+         name="OPI Validator"
+         point="org.eclipse.wst.validation.validatorV2">
+      <validator
+            build="true"
+            class="org.csstudio.opibuilder.validation.core.Validator"
+            manual="true"
+            markerId="org.csstudio.opibuilder.validation.opiValidationProblem">
+         <include>
+            <rules>
+               <fileext
+                     caseSensitive="false"
+                     ext="opi">
+               </fileext>
+            </rules>
+         </include>
+      </validator>
+   </extension>
+   <extension
+         id="opiValidationProblem"
+         name="OPI Validation Problem"
+         point="org.eclipse.core.resources.markers">
+         <super type="org.eclipse.wst.validation.problemmarker"/>
+         <persistent value="false"/>
+         <attribute
+               name="validationFailure">
+         </attribute>
+   </extension>
+   <extension
+         id="opiLoadingError"
+         name="OPI Loading Error"
+         point="org.eclipse.core.resources.markers">
+      <super
+            type="org.eclipse.wst.validation.problemmarker">
+      </super>
+      <persistent
+            value="false">
+      </persistent>
+   </extension>
+   <extension
+         point="org.eclipse.ui.ide.markerResolution">
+      <markerResolutionGenerator
+            class="org.csstudio.opibuilder.validation.core.QuickFixer"
+            markerType="org.csstudio.opibuilder.validation.opiValidationProblem">
+      </markerResolutionGenerator>
+   </extension>
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            category="ValidationPreferencePage"
+            class="org.csstudio.opibuilder.validation.ui.PreferencesPage"
+            id="org.csstudio.opibuilder.validation.opiValidationPreference"
+            name="Opi Validation">
+      </page>
+   </extension>
+   
+
+</plugin>

--- a/applications/plugins/org.csstudio.opibuilder.validation/pom.xml
+++ b/applications/plugins/org.csstudio.opibuilder.validation/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.opibuilder.validation</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/plugins/org.csstudio.opibuilder.validation/pom.xml
+++ b/applications/plugins/org.csstudio.opibuilder.validation/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.csstudio</groupId>
+    <artifactId>applications-plugins</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <groupId>org.csstudio</groupId>
+  <artifactId>org.csstudio.opibuilder.validation</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/applications/plugins/org.csstudio.opibuilder.validation/preferences.ini
+++ b/applications/plugins/org.csstudio.opibuilder.validation/preferences.ini
@@ -1,0 +1,4 @@
+showBackupDialog=true
+showSummary=true
+doBackup=true
+rulesFile=rules.def

--- a/applications/plugins/org.csstudio.opibuilder.validation/preferences.ini
+++ b/applications/plugins/org.csstudio.opibuilder.validation/preferences.ini
@@ -2,3 +2,4 @@ showBackupDialog=true
 showSummary=true
 doBackup=true
 rulesFile=rules.def
+nestMarkers=true

--- a/applications/plugins/org.csstudio.opibuilder.validation/preferences.ini
+++ b/applications/plugins/org.csstudio.opibuilder.validation/preferences.ini
@@ -1,5 +1,19 @@
+# Show a question dialog, which asks if a backup file should be created before quick fix is applied. 
 showBackupDialog=true
+
+# Show the summary dialog at the end of each validation
 showSummary=true
+
+# Make backup of a quick fixed file (applicable only when showBackupDialog is false)
 doBackup=true
+
+# The path to the file that defines the rules 
 rulesFile=rules.def
+
+# Indicates if the sub validation markers (action, script, rule) should appear nested below
+# their parents (in the problems view) or if they should be stand alone like all other markers
 nestMarkers=true
+
+# Indicates if validation markers (for the whole workspace) should be cleared every time when 
+# a new validation job is started
+clearMarkers=true

--- a/applications/plugins/org.csstudio.opibuilder.validation/rules.def
+++ b/applications/plugins/org.csstudio.opibuilder.validation/rules.def
@@ -16,6 +16,13 @@
 #! pv_name property is obligatory writable
 #! pv_name=WRITE
 
+#! You can also use regular expressions to define the properties. If you have a numbered property, 
+#! such as trace_0_trace_color, trace_1_trace_color, you can specify the name of the property
+#! using regular expression:   
+#! trace_[0-9]+_trace_color=RO
+#! Or properties that ends with name
+#! [a-zA-Z0-9_]*name=RO
+
 border_color=RO
 pv_name=WRITE
 ActionButton.font=RO

--- a/applications/plugins/org.csstudio.opibuilder.validation/rules.def
+++ b/applications/plugins/org.csstudio.opibuilder.validation/rules.def
@@ -1,0 +1,23 @@
+# The file lists all properties of all widgets that should obey specific rules.
+# If a certain property is listed in this file the validator will check if the 
+# OPI file follows this rule with respect to the schema OPI. Each property
+# can be either read only (RO), readable/writable (RW), or obligatory writable (WRITE).
+# Read only properties should have the same values as defined by the OPI schema, 
+# readable/writable properties can have any value, obligatory writable properties
+# must have a value, which is not null or empty. 
+# If the property is not listed here it is automatically assumed to be writable. If 
+# there is a property that is related to a specific widget it has priority 
+# over a general property.
+
+#! Example
+#! border_width will be read-only for all widgets, except for the polyline, for which it is writable
+#! border_width=RO
+#! polyline.border_width=RW
+#! pv_name property is obligatory writable
+#! pv_name=WRITE
+
+border_color=RO
+pv_name=WRITE
+ActionButton.font=RO
+border_width=RO
+polyline.border_width=RW

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/Activator.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/Activator.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation;
+
+import java.io.File;
+import java.net.URL;
+
+import org.csstudio.opibuilder.OPIBuilderPlugin;
+import org.csstudio.opibuilder.util.ResourceUtil;
+import org.csstudio.ui.util.CustomMediaFactory;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.osgi.service.datalocation.Location;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * 
+ * <code>Activator</code> handles the lifecycle of this plugin.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class Activator extends AbstractUIPlugin {
+
+    /** The ID of this plugin */
+    public static final String ID = "org.csstudio.opibuilder.validation";
+    
+    /** Preference if backup of the file should be made before quick fix is applied */
+    public static final String PREF_DO_BACKUP = "doBackup";
+    /** Preference if user should be asked if she wants to make backup of the quick fixed file */
+    public static final String PREF_SHOW_BACKUP_DIALOG = "showBackupDialog";
+    /** Preference if the validation summary should be displayed after each validation */
+    public static final String PREF_SHOW_SUMMARY = "showSummary";
+    /** Preference the name of the file that provides the rules */
+    public static final String PREF_RULES_FILE = "rulesFile";
+    
+    private static Activator instance; 
+    
+    private Image quickFixImage;
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+     */
+    @Override
+    public void start(BundleContext context) throws Exception {        
+        instance = this;
+        super.start(context);
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+     */
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        instance = null;
+        if (quickFixImage != null) {
+            quickFixImage.dispose();
+        }
+        super.stop(context);
+    }
+    
+    /**
+     * Constructs and returns the shared image used by the quick fix dialog.
+     * 
+     * @return the shared quick fix image
+     */
+    public Image getQuickFixImage() {
+        if (quickFixImage == null) {
+            quickFixImage = CustomMediaFactory.getInstance().getImageDescriptorFromPlugin(
+                    OPIBuilderPlugin.PLUGIN_ID, "icons/edit.gif").createImage();
+        }
+        return quickFixImage;
+    }
+    
+    /**
+     * @return the shared instance of this activator
+     */
+    public static Activator getInstance() {
+        return instance;
+    }
+    
+    /**
+     * @return true if the backup of the files should be created or false otherwise
+     */
+    public boolean isDoBackup() {
+        return getPreferenceStore().getBoolean(PREF_DO_BACKUP);
+    }
+    
+    /**
+     * @return true if the dialog to ask for backup should be shown or false otherwise
+     */
+    public boolean isShowBackupDialog() {
+        return getPreferenceStore().getBoolean(PREF_SHOW_BACKUP_DIALOG);
+    }
+    
+    /**
+     * @return true if the summary dialog should be displayed at the end of validation
+     */
+    public boolean isShowSummaryDialog() {
+        return getPreferenceStore().getBoolean(PREF_SHOW_SUMMARY);
+    }
+    
+    /**
+     * @return the path to the file that contains the rules settings
+     */
+    public IPath getRulesFile() {
+        String s = getPreferenceStore().getString(PREF_RULES_FILE);
+        if (s == null || s.trim().isEmpty()) {
+            return null;
+        }
+        return getExistFileInRepoAndSearchPath(s);
+    }
+    
+    private static IPath getExistFileInRepoAndSearchPath(String pathString){
+        IPath originPath = ResourceUtil.getPathFromString(pathString);
+        if(originPath == null) {
+            return null;
+        } else if (originPath.toFile().exists()) {
+            return originPath;
+        } else {
+            Location loc = Platform.getInstanceLocation();
+            URL url = loc.getURL();
+            File workspaceLocation = new File(url.getFile());
+            File file = new File(workspaceLocation, pathString);
+            if (file.exists()) {
+                return ResourceUtil.getPathFromString(file.getAbsolutePath());
+            }
+        }
+        return null;
+        
+    }
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/Activator.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/Activator.java
@@ -42,6 +42,8 @@ public class Activator extends AbstractUIPlugin {
     public static final String PREF_RULES_FILE = "rulesFile";
     /** Preference if the markers in the problem view should be nested */
     public static final String PREF_NEST_MARKERS = "nestMarkers";
+    /** Preference if all workspace makers should be cleared at the start of each validation */
+    public static final String PREF_CLEAR_MARKERS = "clearMarkers";
     
     private static Activator instance; 
     
@@ -127,6 +129,13 @@ public class Activator extends AbstractUIPlugin {
      */
     public boolean isNestMarkers() {
         return getPreferenceStore().getBoolean(PREF_NEST_MARKERS);
+    }
+    
+    /**
+     * @return true if all markers are cleared before each validation run
+     */
+    public boolean isClearMarkers() {
+        return getPreferenceStore().getBoolean(PREF_CLEAR_MARKERS);
     }
     
     private static IPath getExistFileInRepoAndSearchPath(String pathString){

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/Activator.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/Activator.java
@@ -40,6 +40,8 @@ public class Activator extends AbstractUIPlugin {
     public static final String PREF_SHOW_SUMMARY = "showSummary";
     /** Preference the name of the file that provides the rules */
     public static final String PREF_RULES_FILE = "rulesFile";
+    /** Preference if the markers in the problem view should be nested */
+    public static final String PREF_NEST_MARKERS = "nestMarkers";
     
     private static Activator instance; 
     
@@ -118,6 +120,13 @@ public class Activator extends AbstractUIPlugin {
             return null;
         }
         return getExistFileInRepoAndSearchPath(s);
+    }
+    
+    /**
+     * @return true if the markers in the problems view should be nested or false otherwise
+     */
+    public boolean isNestMarkers() {
+        return getPreferenceStore().getBoolean(PREF_NEST_MARKERS);
     }
     
     private static IPath getExistFileInRepoAndSearchPath(String pathString){

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/QuickFixer.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/QuickFixer.java
@@ -1,0 +1,243 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.csstudio.opibuilder.validation.Activator;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobFunction;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IMarkerResolution;
+import org.eclipse.ui.IMarkerResolutionGenerator2;
+import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
+import org.eclipse.wst.validation.internal.ValType;
+import org.eclipse.wst.validation.internal.ValidationRunner;
+
+/**
+ * 
+ * <code>QuickFixer</code> is a resolution implementation that fixes the OPI validation failures, by replacing the
+ * actual value with the expected value. It only works for the markers which represent a read-only validation failure.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+@SuppressWarnings("restriction")
+public class QuickFixer implements IMarkerResolutionGenerator2 {
+    
+    private static final Logger LOGGER = Logger.getLogger(QuickFixer.class.getName());
+
+    private static class Resolution extends WorkbenchMarkerResolution {
+        
+        private final IMarker marker;
+        
+        Resolution(IMarker marker) {
+            this.marker = marker;
+        }
+
+        /*
+         * (non-Javadoc)
+         * @see org.eclipse.ui.IMarkerResolution2#getDescription()
+         */
+        @Override
+        public String getDescription() {
+            //not used anyway
+            return getLabel();
+        }
+
+        /*
+         * (non-Javadoc)
+         * @see org.eclipse.ui.IMarkerResolution2#getImage()
+         */
+        @Override
+        public Image getImage() {
+            return Activator.getInstance().getQuickFixImage();
+        }
+
+        /*
+         * (non-Javadoc)
+         * @see org.eclipse.ui.IMarkerResolution#getLabel()
+         */
+        @Override
+        public String getLabel() {
+          return "Change the value of the property to the expected value and save OPI. OPIs might be backed up during the process.";
+        }
+
+        /*
+         * (non-Javadoc)
+         * @see org.eclipse.ui.IMarkerResolution#run(org.eclipse.core.resources.IMarker)
+         */
+        @Override
+        public void run(IMarker marker) {
+            throw new UnsupportedOperationException("Run with a single marker should never be called.");
+        }
+        
+        /*
+         * (non-Javadoc)
+         * @see org.eclipse.ui.views.markers.WorkbenchMarkerResolution#run(org.eclipse.core.resources.IMarker[], org.eclipse.core.runtime.IProgressMonitor)
+         */
+        @Override
+        public void run(IMarker[] markers, IProgressMonitor monitor) {
+            final boolean doBackup;
+            if (Activator.getInstance().isShowBackupDialog()) {
+                doBackup = MessageDialog.openQuestion(Display.getCurrent().getActiveShell(), "Backup",
+                    "Would you like to make a backup of the OPI files before changing them?");
+            } else {
+                doBackup = Activator.getInstance().isDoBackup();
+            }
+            
+            Job job = Job.create("OPI Validation Quick Fix", new IJobFunction() {
+                
+                @Override
+                public IStatus run(IProgressMonitor monitor) {
+                    try {
+                        Map<IPath, List<ValidationFailure>> toFix = new HashMap<>();
+                        ValidationFailure f;
+                        List<ValidationFailure> list;
+                        //sort all failures by paths, so that each file is edited only once
+                        for (int i = 0; i < markers.length; i++) {
+                            f = (ValidationFailure)markers[i].getAttribute(Validator.ATTR_VALIDATION_FAILURE);
+                            list = toFix.get(f.getPath());
+                            if (list == null) {
+                                list = new ArrayList<>();
+                                toFix.put(f.getPath(), list);
+                            }
+                            list.add(f); 
+                        }
+                        monitor.beginTask("OPI Validation Quick Fix", toFix.size() + 3);
+                        monitor.worked(1);
+                        
+                        //if requested to do backup, copy all quick-fixed files to <file>~
+                        if (doBackup) {
+                            for (IPath path : toFix.keySet()) {
+                                String bck = path.toFile().getAbsolutePath();
+                                bck = bck + "~";
+                                File backup = new File(bck);
+                                Files.copy(path.toFile().toPath(), backup.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                            }
+                        }
+                        monitor.worked(1);
+                        for (List<ValidationFailure> l : toFix.values()) {
+                            //one call per file
+                            SchemaVerifier.fixOPIFailure(l.toArray(new ValidationFailure[l.size()]));
+                            monitor.worked(1);
+                        }
+                        for (IMarker m : markers) {
+                            //refresh all changed files
+                            m.getResource().refreshLocal(0, new NullProgressMonitor());
+                        }
+                        //revalidated all changed files to get rid of the fixed validations
+                        revalidate(markers, monitor);
+                        monitor.done();
+                        return Status.OK_STATUS;
+                    } catch (CoreException | IOException e) {
+                        LOGGER.log(Level.WARNING, "Unexpected error trying to quick fix the OPIs.", e);
+                        Display.getDefault().asyncExec(() -> 
+                            MessageDialog.openError(Display.getDefault().getActiveShell(), "Error Fixing OPI Problem", 
+                                    "There was an unexpected error while trying to quick fix the OPI: " + e.getMessage()));
+                        return new Status(IStatus.ERROR,Activator.ID,
+                                "There was an unexpected error while trying to quick fix the OPIs.",e);
+                    }
+                }
+            });
+            
+            job.schedule();
+        }
+        
+        /**
+         * Revalidated all opis defined by the given markers. This method is called after successful quick fix.
+         * 
+         * @param markers the markers that define the OPI files that will be validated
+         * @param monitor the monitor to report progress to
+         * @throws CoreException if resource could not be extracted from the marker
+         */
+        private void revalidate(IMarker[] markers, IProgressMonitor monitor) throws CoreException {
+            Map<IProject, Set<IResource>> map = new HashMap<>();
+            IProject p;
+            for (IMarker m : markers) {
+                p = m.getResource().getProject();
+                Set<IResource> set = map.get(p);
+                if (set == null) {
+                    set = new HashSet<>();
+                    map.put(p, set);
+                }
+                set.add(m.getResource());
+            }
+            
+            ValidationRunner.validate(map, ValType.Manual, monitor, true);
+        }
+
+        /*
+         * (non-Javadoc)
+         * @see org.eclipse.ui.views.markers.WorkbenchMarkerResolution#findOtherMarkers(org.eclipse.core.resources.IMarker[])
+         */
+        @Override
+        public IMarker[] findOtherMarkers(IMarker[] markers) {
+            List<IMarker> list = new ArrayList<>();
+            try {
+                for (IMarker marker : markers) {
+                    if (marker == this.marker) continue;
+                    if (!Validator.MARKER_PROBLEM.equals(marker.getType())) continue;
+                    if (((ValidationFailure)marker.getAttribute(Validator.ATTR_VALIDATION_FAILURE)).getRule() != ValidationRule.RO) continue;
+                    
+                    list.add(marker);
+                }
+            } catch (CoreException e) {
+                
+            }
+            return list.toArray(new IMarker[list.size()]);
+        }
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.ui.IMarkerResolutionGenerator#getResolutions(org.eclipse.core.resources.IMarker)
+     */
+    @Override
+    public IMarkerResolution[] getResolutions(IMarker marker) {
+        return new IMarkerResolution[]{new Resolution(marker)};
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.ui.IMarkerResolutionGenerator2#hasResolutions(org.eclipse.core.resources.IMarker)
+     */
+    @Override
+    public boolean hasResolutions(IMarker marker) {
+        try {
+            //only read-only markers have resolutions
+            return ((ValidationFailure)marker.getAttribute(Validator.ATTR_VALIDATION_FAILURE))
+                    .getRule() == ValidationRule.RO;
+        } catch (CoreException e) {
+            return false;
+        }
+    }
+
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/QuickFixer.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/QuickFixer.java
@@ -190,8 +190,14 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
                 }
                 set.add(m.getResource());
             }
-            
-            ValidationRunner.validate(map, ValType.Manual, monitor, true);
+            boolean isClearMarkers = Activator.getInstance().isClearMarkers();
+            try {
+                //in case of revalidation after quick fix, do not clear the markers
+                Activator.getInstance().getPreferenceStore().setValue(Activator.PREF_CLEAR_MARKERS, false);
+                ValidationRunner.validate(map, ValType.Manual, monitor, true);
+            } finally {
+                Activator.getInstance().getPreferenceStore().setValue(Activator.PREF_CLEAR_MARKERS, isClearMarkers);
+            }
         }
 
         /*

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/SchemaFixer.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/SchemaFixer.java
@@ -1,0 +1,321 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import org.csstudio.opibuilder.model.AbstractContainerModel;
+import org.csstudio.opibuilder.model.AbstractWidgetModel;
+import org.csstudio.opibuilder.model.DisplayModel;
+import org.csstudio.opibuilder.persistence.XMLUtil;
+import org.csstudio.opibuilder.script.RuleData;
+import org.csstudio.opibuilder.script.RulesInput;
+import org.csstudio.opibuilder.script.ScriptData;
+import org.csstudio.opibuilder.script.ScriptsInput;
+import org.csstudio.opibuilder.util.ResourceUtil;
+import org.csstudio.opibuilder.widgetActions.AbstractWidgetAction;
+import org.csstudio.opibuilder.widgetActions.ActionsInput;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.swt.widgets.Display;
+
+public class SchemaFixer {
+
+    /**
+     * Fix the given validation failures. All failures are expected to belong to the same OPI file. The fix replaces
+     * the actual value of the validated property with the expected value.
+     * 
+     * @param failureToFix the validation failures to fix
+     * @throws IOException if there was an exception in reading the OPI
+     * @throws IllegalArgumentException if the failures do not belong to the same OPI
+     */
+    public static void fixOPIFailure(ValidationFailure[] failureToFix) throws IOException, IllegalArgumentException {
+        if (failureToFix.length == 0) return;
+        IPath path = failureToFix[0].getPath();
+        for (ValidationFailure f : failureToFix) {
+            if (!f.getPath().equals(path)) {
+                throw new IllegalArgumentException("All validation failures must belong to the same path.");
+            } else if (!f.isFixable()) {
+                throw new IllegalArgumentException("Validation failure '" + f + "' is not fixable.");
+            }
+            
+        }
+        DisplayModel displayModel = null;
+        try (InputStream inputStream = ResourceUtil.pathToInputStream(path, false)) {
+            displayModel = new DisplayModel(failureToFix[0].getPath());
+            XMLUtil.fillDisplayModelFromInputStream(inputStream, displayModel, Display.getDefault());
+        } catch (Exception e) {
+            throw new IOException("Could not read the opi " + path.toOSString() +".",e);
+        }
+        
+        for (ValidationFailure f : failureToFix) {
+            fixFailure:
+            if (f instanceof SubValidationFailure) {
+                //this is a sub failure in action, script or rule
+                if (((SubValidationFailure)f).isFixed()) return;
+                //if the parent is being fixed, do not fix this one, it will be fixed by the parent
+                ValidationFailure parent = ((SubValidationFailure) f).getParent();
+                for (ValidationFailure ff : failureToFix) {
+                    if (ff == parent) {
+                        break fixFailure;
+                    }
+                }
+                
+                //fix the sub validation failure
+                AbstractWidgetModel model = findWidget(displayModel, parent, true);
+                if (model == null) {
+                    continue;
+                }
+                fixSubValidation((SubValidationFailure)f,model);
+            } else {
+                AbstractWidgetModel model = findWidget(displayModel, f, true);
+                if (model == null) {
+                    continue;
+                }
+                if (f.getRule() == ValidationRule.RO) {
+                    model.setPropertyValue(f.getProperty(), f.getExpectedValue());
+                } else if (f.getRule() == ValidationRule.WRITE) {
+                    //the only writable and fixable properties are actions, scripts and rules
+                    //in this case add the missing ones to the model
+                    Object value = model.getPropertyValue(f.getProperty());
+                    addToValue(value, f.getExpectedValue());
+                }
+                if (f.hasSubFailures()) {
+                    SubValidationFailure[] subs = f.getSubFailures();
+                    for (SubValidationFailure s : subs) {
+                        s.setFixed(true);
+                    }
+                }
+            }
+        }
+        
+        try (FileOutputStream output = new FileOutputStream(path.toFile())) {
+            XMLUtil.widgetToOutputStream(displayModel, output, true);
+        }        
+    }
+    
+    /**
+     * For actions, rules and scripts we need to add the missing elements.
+     * 
+     * @param destination the destination
+     * @param expected the expected value
+     */
+    private static void addToValue(Object destination, Object expected) {
+        if (destination instanceof RulesInput) {
+            List<RuleData> existing = ((RulesInput)destination).getRuleDataList();
+            List<RuleData> needToBe = ((RulesInput)expected).getRuleDataList();
+            addMissing(existing, needToBe, (r1,r2) -> Utilities.areRulesIdentical(r1, r2));
+        } else if (destination instanceof ActionsInput) {
+            List<AbstractWidgetAction> existing = ((ActionsInput)destination).getActionsList();
+            List<AbstractWidgetAction> needToBe = ((ActionsInput)expected).getActionsList();
+            addMissing(existing, needToBe, (a1,a2) -> Utilities.areActionsIdentical(a1, a2));
+        } else if (destination instanceof ScriptsInput) {
+            List<ScriptData> existing = ((ScriptsInput)destination).getScriptList();
+            List<ScriptData> needToBe = ((ScriptsInput)expected).getScriptList();
+            addMissing(existing, needToBe, (s1,s2) -> Utilities.areScriptsIdentical(s1, s2));
+        }
+    }
+    
+    /**
+     * Add elements from needToBe to destination if they are not already present there.
+     * 
+     * @param destination the list that should contain the element
+     * @param needToBe the list of elements that should be present in the destination
+     * @param comparator the comparator to compare elements
+     */
+    private static <T> void addMissing(List<T> destination, List<T> needToBe, Comparator<T> comparator) {
+        for (T stuff : needToBe) {
+            findStuff: {
+                for (T d : destination) {
+                    if (comparator.compare(stuff, d) == 0) {
+                        break findStuff;
+                    }
+                }
+                destination.add(stuff);
+            }
+        }
+    }
+    
+    /**
+     * Finds the widget model that matches the validation failure.
+     * 
+     * @param parent the parent to look for the widget model in
+     * @param failure the failure to match
+     * @param useWuid if true the wuid of the model has to match the wuid of the failure
+     * @return the widget model if found, or null if match was not found
+     */
+    private static AbstractWidgetModel findWidget(AbstractContainerModel parent, ValidationFailure failure, 
+            boolean useWuid) {
+        String widgetType;
+        String widgetName;
+        boolean skipCheck = false;
+        for (AbstractWidgetModel model : parent.getChildren()) {
+            widgetType = model.getTypeID();
+            widgetName = model.getName();
+            skipCheck = false;
+            if (useWuid) {
+                if (!failure.getWUID().equals(model.getWUID())){
+                    skipCheck = true;
+                }
+            }
+            
+            if (!skipCheck && widgetType.equals(failure.getWidgetType()) && widgetName.equals(failure.getWidgetName())) {
+                Object obj = model.getPropertyValue(failure.getProperty());
+                if (equals(obj, failure.getActualValue())) {
+                    return model;
+                }
+            }
+            if (model instanceof AbstractContainerModel) {
+                AbstractWidgetModel result = findWidget((AbstractContainerModel)model, failure, useWuid);
+                if (result != null) return result;
+            }
+        }  
+        if (useWuid) {
+            return findWidget(parent, failure, false);
+        }
+        return null;
+    }
+    
+    /**
+     * Check if the objects are identical. In most cases this is simple equals call, except in the case of actions,
+     * scripts and rules. Ideally those would be compared with equals as well, but they have properties 
+     * that we do not want to compare here (e.g. widgetModel).
+     * 
+     * @param o1 
+     * @param o2
+     * @return true if the objects are identical or false otherwise
+     */
+    private static boolean equals(Object o1, Object o2) {
+        if (o1 instanceof ActionsInput && o2 instanceof ActionsInput) {
+            ActionsInput oi = (ActionsInput)o1;
+            ActionsInput mi = (ActionsInput)o2;
+            if (oi.isFirstActionHookedUpToWidget() != mi.isFirstActionHookedUpToWidget()) return false;
+            if (oi.isHookUpAllActionsToWidget() != mi.isHookUpAllActionsToWidget()) return false;
+            LinkedList<AbstractWidgetAction> olist = oi.getActionsList();
+            LinkedList<AbstractWidgetAction> mlist = mi.getActionsList();
+            for (AbstractWidgetAction a : olist) {
+                findAction: {
+                    for (AbstractWidgetAction b : mlist) {
+                        if (Utilities.areActionsIdentical(a, b) == 0) {
+                            break findAction;
+                        }
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } else if (o1 instanceof ScriptsInput && o2 instanceof ScriptsInput) {
+            ScriptsInput oi = (ScriptsInput)o1;
+            ScriptsInput mi = (ScriptsInput)o2;
+            List<ScriptData> olist = oi.getScriptList();
+            List<ScriptData> mlist = mi.getScriptList();
+            for (ScriptData a : olist) {
+                findScript: {
+                    for (ScriptData b : mlist) {
+                        if (Utilities.areScriptsIdentical(a, b) == 0) {
+                            break findScript;
+                        }
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } else if (o1 instanceof RulesInput && o2 instanceof RulesInput) {
+            RulesInput oi = (RulesInput)o1;
+            RulesInput mi = (RulesInput)o2;
+            List<RuleData> olist = oi.getRuleDataList();
+            List<RuleData> mlist = mi.getRuleDataList();
+            for (RuleData a : olist) {
+                findRule: {
+                    for (RuleData b : mlist) {
+                        if (Utilities.areRulesIdentical(a, b) == 0) {
+                            break findRule;
+                        }
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return Objects.equals(o1,o2);
+        }
+    }
+    
+    private static void fixSubValidation(SubValidationFailure failure, AbstractWidgetModel model) {
+        ValidationFailure parent = failure.getParent();
+        Object propValue = model.getPropertyValue(parent.getProperty());
+        ValidationRule rule = failure.getRule();
+        if (rule == ValidationRule.WRITE) {
+            //expected sub value is missing
+            Object toAdd = failure.getExpectedValue();
+            if (toAdd instanceof RuleData) {
+                ((RulesInput)propValue).getRuleDataList().add((RuleData)toAdd);
+            } else if (toAdd instanceof ScriptData) {
+                ((ScriptsInput)propValue).getScriptList().add((ScriptData)toAdd);
+            } else if (toAdd instanceof AbstractWidgetAction) {
+                ((ActionsInput)propValue).getActionsList().add((AbstractWidgetAction)toAdd);
+            }        
+        } else if (rule == ValidationRule.RO) {
+            if (failure.getActualValue() == null) {
+                //missing actual value, so add it
+                Object toAdd = failure.getExpectedValue();
+                if (toAdd instanceof RuleData) {
+                    ((RulesInput)propValue).getRuleDataList().add((RuleData)toAdd);
+                } else if (toAdd instanceof ScriptData) {
+                    ((ScriptsInput)propValue).getScriptList().add((ScriptData)toAdd);
+                } else if (toAdd instanceof AbstractWidgetAction) {
+                    ((ActionsInput)propValue).getActionsList().add((AbstractWidgetAction)toAdd);
+                }                
+            } else if (failure.getExpectedValue() == null) {
+                //there is an actual value, which should not be there
+                Object toRemove = failure.getActualValue();
+                if (toRemove instanceof RuleData) {
+                    RuleData r = (RuleData)toRemove;
+                    List<RuleData> list = ((RulesInput)propValue).getRuleDataList();
+                    for (int i = 0; i < list.size(); i++) {
+                        if (Utilities.areRulesIdentical(list.get(i),r) == 0) {
+                            list.remove(i);
+                            return;
+                        }
+                    }
+                } else if (toRemove instanceof ScriptData) {
+                    ScriptData r = (ScriptData)toRemove;
+                    List<ScriptData> list = ((ScriptsInput)propValue).getScriptList();
+                    for (int i = 0; i < list.size(); i++) {
+                        if (Utilities.areScriptsIdentical(list.get(i),r) == 0) {
+                            list.remove(i);
+                            return;
+                        }
+                    }
+                } else if (toRemove instanceof AbstractWidgetAction) {
+                    AbstractWidgetAction r = (AbstractWidgetAction)toRemove;
+                    List<AbstractWidgetAction> list = ((ActionsInput)propValue).getActionsList();
+                    for (int i = 0; i < list.size(); i++) {
+                        if (Utilities.areActionsIdentical(list.get(i),r) == 0) {
+                            list.remove(i);
+                            return;
+                        }
+                    }
+                }   
+            } else {
+                //can only happen in the action case
+                ActionsInput ai = (ActionsInput)propValue;
+                if (Utilities.PROP_ACTION_HOOK.equals(failure.getSubPropertyTag())) {
+                    ai.setHookUpFirstActionToWidget((Boolean)failure.getExpectedValue());
+                } else if (Utilities.PROP_ACTION_HOOK_ALL.equals(failure.getSubPropertyTag())) {
+                    ai.setHookUpAllActionsToWidget((Boolean)failure.getExpectedValue());
+                }
+            }
+        }
+    }
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/SchemaVerifier.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/SchemaVerifier.java
@@ -1,0 +1,663 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Stack;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.csstudio.opibuilder.model.AbstractContainerModel;
+import org.csstudio.opibuilder.model.AbstractWidgetModel;
+import org.csstudio.opibuilder.model.ConnectionModel;
+import org.csstudio.opibuilder.model.DisplayModel;
+import org.csstudio.opibuilder.persistence.XMLUtil;
+import org.csstudio.opibuilder.preferences.PreferencesHelper;
+import org.csstudio.opibuilder.util.MediaService;
+import org.csstudio.opibuilder.util.OPIColor;
+import org.csstudio.opibuilder.util.OPIFont;
+import org.csstudio.opibuilder.util.ResourceUtil;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.swt.widgets.Display;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.Attributes;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * 
+ * <code>SchemaVerifier</code> verifies if the given OPI or the OPIs located below the given path conform(s) to 
+ * the the schema defined by the opibuilder. The instructions how to verify individual properties are defined 
+ * in the rules definitions file.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class SchemaVerifier {
+            
+    private static final String LINE_NUMBER_KEY_NAME = "lineNumber";
+    private static final String TAG_NAME = "name";
+    
+    private List<ValidationFailure> validationFails = new ArrayList<>();
+    private IPath validatedPath;
+    private Map<String, AbstractWidgetModel> schema;
+    private OPIColor[] colors;
+    private OPIFont[] fonts;
+    
+    private int numberOfAnalyzedWidgets = 0;
+    private int numberOfWidgetsFailures = 0;
+    private int numberOfAnalyzedFiles = 0;
+    private int numberOfFilesFailures = 0;
+    private int numberOfROProperties = 0;
+    private int numberOfWRITEProperties = 0;
+    private int numberOfCriticalROFailures = 0;
+    private int numberOfMajorROFailures = 0;
+    private int numberOfWRITEFailures = 0;
+    
+    private IPath schemaPath;
+        
+    private final Map<String, ValidationRule> rules;
+    
+    /**
+     * Constructs a new schema verifier using the schema path defined in the preferences.
+     * 
+     * @param rules the validation rules to use (keys are the property names, values are the rules for that property)
+     */
+    public SchemaVerifier(Map<String,ValidationRule> rules) {
+        this(PreferencesHelper.getSchemaOPIPath(), rules);
+    }
+    
+    /**
+     * Construct a new SchemaVerifier.
+     * 
+     * @param pathToSchema the path to the OPI schema against which the opis will be validated
+     * @param rules the validation rules to use (keys are the property names, values are the rules for that property)
+     */
+    public SchemaVerifier(IPath pathToSchema, Map<String,ValidationRule> rules) {
+        if (pathToSchema == null) {
+            throw new IllegalArgumentException("There is no OPI schema defined.");
+        }
+        this.schemaPath = pathToSchema;
+        this.rules = new HashMap<String, ValidationRule>(rules);
+    }
+    
+    /**
+     * Returns the list of all validation failures since the last cleanup
+     * 
+     * @return the list of validation failures
+     */
+    public ValidationFailure[] getValidationFailures() {
+        return validationFails.toArray(new ValidationFailure[validationFails.size()]);
+    }
+    
+    /**
+     * Removes all validation failures and resets the counters.
+     */
+    public void clean() {
+        validationFails.clear();
+        numberOfAnalyzedWidgets = 0;
+        numberOfAnalyzedFiles = 0;
+        numberOfROProperties = 0;
+        numberOfWRITEProperties = 0;
+        numberOfCriticalROFailures = 0;
+        numberOfMajorROFailures = 0;
+        numberOfWRITEFailures = 0;
+        numberOfFilesFailures = 0;
+        numberOfWidgetsFailures = 0;
+    }
+    
+    /**
+     * @return number of analysed files since the last cleanup
+     */
+    public int getNumberOfAnalyzedFiles() {
+        return numberOfAnalyzedFiles;
+    }
+    
+    /**
+     * @return number of analysed widgets since the last cleanup
+     */
+    public int getNumberOfAnalyzedWidgets() {
+        return numberOfAnalyzedWidgets;
+    }
+    
+    /**
+     * @return number of obligatory write failures since the last cleanup
+     */
+    public int getNumberOfWRITEFailures() {
+        return numberOfWRITEFailures;
+    }
+    
+    /**
+     * @return number of analysed obligatory write properties since the last cleanup
+     */
+    public int getNumberOfWRITEProperties() {
+        return numberOfWRITEProperties;
+    }
+    
+    /**
+     * @return number of critical read only failures since the last cleanup
+     */
+    public int getNumberOfCriticalROFailures() {
+        return numberOfCriticalROFailures;
+    }
+    
+    /**
+     * @return number of major read only failures since the last cleanup
+     */
+    public int getNumberOfMajorROFailures() {
+        return numberOfMajorROFailures;
+    }    
+    
+    /**
+     * @return number of analysed read only properties since the last cleanup
+     */
+    public int getNumberOfROProperties() {
+        return numberOfROProperties;
+    }
+    
+    /**
+     * @return number of files with failures since the last cleanup
+     */
+    public int getNumberOfFilesFailures() {
+        return numberOfFilesFailures;
+    }
+    
+    /**
+     * @return number of widgets with failures since the last cleanup
+     */
+    public int getNumberOfWidgetsFailures() {
+        return numberOfWidgetsFailures;
+    }
+    
+    /**
+     * Validates the OPIs on the given path and returns the list of all validation failures. If the path is
+     * a directory all OPIs below that path are validated.
+     * 
+     * @param validatedPath the path the OPI or folder containing OPIs.
+     * @return the list of all validation failures
+     * @throws IOException if there was an error opening the OPI file or schema
+     * @throws IllegalStateException if the schema is not defined
+     */
+    public ValidationFailure[] validate(IPath validatedPath) throws IOException, IllegalStateException {
+        if (validatedPath == null) {
+            throw new IOException("Cannot access null path.");
+        }
+        if (schema == null) {
+            schema = loadSchema(schemaPath);
+            colors = MediaService.getInstance().getAllPredefinedColors();
+            fonts = MediaService.getInstance().getAllPredefinedFonts();
+        }
+        this.validatedPath = validatedPath;
+        
+        File file = this.validatedPath.toFile();
+        List<ValidationFailure> failures = new ArrayList<>();
+        if (file.isFile()) {
+            failures.addAll(check(this.validatedPath));
+        } else if (file.isDirectory()) {
+            List<File> opis = new ArrayList<>();
+            gatherOPIFiles(file, opis);
+            for (File f : opis) {
+                failures.addAll(check(new Path(f.getAbsolutePath())));
+            }
+        }
+        validationFails.addAll(failures);
+        return failures.toArray(new ValidationFailure[failures.size()]);
+    }
+    
+    /**
+     * Recursively scans the parent file for all files that have the extension opi.
+     * 
+     * @param parent the directory to scan
+     * @param opis the list into which the found opi files are stored
+     */
+    private static void gatherOPIFiles(File parent, List<File> opis) {
+        for (File f : parent.listFiles()) {
+            if (f.isDirectory()) {
+                gatherOPIFiles(parent, opis);
+            } else if (f.getAbsolutePath().toLowerCase().endsWith(".opi")) {
+                opis.add(f);
+            }
+        }
+    }
+    
+    /**
+     * Checks if the given OPI matches the schema definition. All detected validation failures are stored into
+     * {@link #validationFails} list.
+     *  
+     * @param opi the path to the OPI file
+     * @throws IOException if there was an error reading the OPI file
+     */
+    private List<ValidationFailure> check(IPath opi) throws IOException{
+        DisplayModel displayModel = null;
+        try (InputStream inputStream = ResourceUtil.pathToInputStream(opi, false)) {
+            displayModel = new DisplayModel(opi);
+            XMLUtil.fillDisplayModelFromInputStream(inputStream, displayModel, Display.getDefault());
+        } catch (Exception e) {
+            throw new IOException("Could not read the opi " + opi.toOSString() +".",e);
+        }
+        
+        numberOfAnalyzedFiles++;
+        List<ValidationFailure> failures = new ArrayList<>();
+        check(opi, displayModel, failures);    
+        findCoordinates(failures.toArray(new ValidationFailure[failures.size()]), opi);
+        if (!failures.isEmpty()) {
+            numberOfFilesFailures++;
+        }
+        return failures;
+    }
+    
+
+    /**
+     * Scans the OPI given by path to find the occurrences of the failures. If they are found it stores the line and 
+     * column number into the failure object. All failures are expected to belong to the same OPI.
+     * 
+     * @param failures the list of failures, which are to be found in the file (should belong to the same path)
+     * @param path the path to scan
+     * @throws IOException if there was an error opening the file
+     */
+    private void findCoordinates(ValidationFailure[] failures, IPath path) throws IOException {
+        //It is slightly inefficient that we read the whole file once again, because we already read
+        //it when the failures were created. However, the scanning of a file doesn't take that long 
+        //that this should worry anyone 
+        if (failures.length == 0) return;
+        for (ValidationFailure f : failures) {
+            if (!path.equals(f.getPath())) {
+                throw new IllegalArgumentException("All validation failures should belong to the same path. " 
+                        + f.getPath() + " is not the same as " + path);
+            }
+        }
+        try (InputStream stream = ResourceUtil.pathToInputStream(path, false)) {
+            Document document = readXMLWithLineNumbers(stream);
+            NodeList widgetNodes = document.getElementsByTagName(XMLUtil.XMLTAG_WIDGET);
+            NodeList displayNodes = document.getElementsByTagName(XMLUtil.XMLTAG_DISPLAY);
+            NodeList connectionNodes = document.getElementsByTagName(XMLUtil.XMLTAG_CONNECTION);
+            //gather all widgets, displays, and connectors in the same array
+            Node[] widgets = new Node[widgetNodes.getLength() + displayNodes.getLength() + connectionNodes.getLength()];
+            int displays = displayNodes.getLength();
+            int widgetCount = widgetNodes.getLength();
+            for (int i = 0; i < displays; i++) {
+                widgets[i] = displayNodes.item(i);
+            }
+            for (int i = 0; i < widgetCount; i++) {
+                widgets[displays + i] = widgetNodes.item(i);
+            }
+            for (int i = 0; i < connectionNodes.getLength(); i++) {
+                widgets[displays + widgetCount + i] = connectionNodes.item(i);
+            }
+            
+            for (int m = 0; m < failures.length; m++) {
+                String type = failures[m].getWidgetType();
+                String name = failures[m].getWidgetName();
+                //for every failure find the widget that match the widget typeId 
+                for (int i = 0; i < widgets.length; i++) {
+                    findProperty:
+                    if (type.equals(widgets[i].getAttributes().getNamedItem(XMLUtil.XMLATTR_TYPEID).getTextContent())) {
+                        //find the node describing the property, but only if the name of the widget matches the one in the failure
+                        Node node = findNode(widgets[i],name,failures[m].getProperty());
+                        if (node == null && failures[m].getRule() == ValidationRule.WRITE) {
+                            //if no such property is find and the property has a write rule, it is not defined in the XML, so mark the widget itself 
+                            node = widgets[i];
+                        } 
+                        
+                        if (node != null) {
+                            int line = (Integer)node.getUserData(LINE_NUMBER_KEY_NAME);
+                            //the widgets may have identical names, so check that we didn't have this line in any of the previous failures
+                            for (int n = 0; n < m; n++) {
+                                if (failures[n].getLineNumber() == line) {
+                                    //if the line is duplicated, continue with the next widget
+                                    break findProperty;
+                                }
+                            }
+                            //otherwise continue with the next failure
+                            failures[m].setLineNumber(line);
+                            break;
+                        }
+                    }                    
+                }
+            }
+        } catch (Exception e) {
+            throw new IOException("Unable to load opi '" + path + "'.");
+        }
+    }
+    
+    /**
+     * Returns the child node of the given node, which has the tag name identical to property. The node is only
+     * returned if there is a child node with the tag name that has the value identical to the given name.
+     *  
+     * @param node the parent node to search its children
+     * @param name the value of the name tag, which needs to match
+     * @param property the tag of the node that is returned
+     * @return the node if found or null otherwise
+     */
+    private static Node findNode(Node node, String name, String property) {
+        NodeList nodes = node.getChildNodes();
+        Node n;
+        Node retVal = null;
+        boolean isCorrect = false;
+        for (int i = 0; i < nodes.getLength(); i++) {
+            n = nodes.item(i);
+            if (TAG_NAME.equals(n.getNodeName())) {
+                isCorrect = name.equals(n.getTextContent());
+                if (retVal != null) {
+                    return retVal;
+                }
+            } else if (property.equals(n.getNodeName())) {
+                retVal = n;
+                if (isCorrect) {
+                    return retVal;
+                }
+            }
+        }
+        return null;
+    }
+        
+    /**
+     * Checks the container model and its children if they match the definitions in the schema.
+     * All detected validation failures are stored into the failures list.
+     * 
+     * @param pathToFile the path to the file that owns the model
+     * @param containerModel the container model to check against the schema
+     * @param failures the list into which all validation failures are stored
+     */
+    private void check(IPath pathToFile, AbstractContainerModel containerModel, List<ValidationFailure> failures) {
+        AbstractWidgetModel original;
+        Object orgVal, modelVal;
+        String widgetType;
+        ValidationRule rule;
+        int startingFailures = failures.size();
+        for (AbstractWidgetModel model : containerModel.getChildren()) {
+            numberOfAnalyzedWidgets++;
+            widgetType = model.getTypeID();
+            original = schema.get(widgetType);
+            Set<String> properties = model.getAllPropertyIDs() ;
+            for (String p : properties) {
+                rule = getRuleForProperty(p, widgetType);
+                if (rule == ValidationRule.RW) {
+                    //nothing to do in the case of read/write properties
+                    continue;
+                } else if (rule == ValidationRule.RO) {
+                    //read-only properties must have identical values, otherwise it is a failure
+                    numberOfROProperties++;
+                    modelVal = model.getPropertyValue(p);
+                    orgVal = original.getPropertyValue(p);
+                    if (!Objects.equals(modelVal, orgVal)) {
+                        //the failure is always critical, except for fonts and colors if a predefined value was used
+                        boolean critical = !isPropertyDefined(modelVal);
+                        failures.add(new ValidationFailure(pathToFile, widgetType, 
+                            model.getName(), p, orgVal, modelVal, rule, critical));
+                        if (critical) {
+                            numberOfCriticalROFailures++;
+                        } else {
+                            numberOfMajorROFailures++;
+                        }
+                    }
+                } else if (rule == ValidationRule.WRITE) {
+                    //write properties must be different and non null
+                    numberOfWRITEProperties++;
+                    modelVal = model.getPropertyValue(p);
+                    orgVal = original.getPropertyValue(p);
+                    if (Objects.equals(modelVal, orgVal) || modelVal == null) {
+                        failures.add(new ValidationFailure(pathToFile, widgetType, 
+                            model.getName(), p, orgVal, modelVal, rule, false));
+                        numberOfWRITEFailures++;
+                    }
+                }
+            }
+            
+            if (model instanceof AbstractContainerModel) {
+                check(pathToFile, (AbstractContainerModel)model, failures);
+            }
+        }  
+        if (failures.size() != startingFailures) {
+            numberOfWidgetsFailures++;
+        }
+    }
+    
+    /**
+     * Checks the property matches one of the predefined colors or fonts. If yes it returns true otherwise it returns false.
+     * 
+     * @param modelVal the property value to check
+     * @return true if a match was found or false otherwise
+     */
+    private boolean isPropertyDefined(Object modelVal) {
+        if (modelVal instanceof OPIColor) {
+            for (OPIColor c : colors) {
+                if (c.equals(modelVal)) return true;
+            }
+        } else if (modelVal instanceof OPIFont) {
+            for (OPIFont c : fonts) {
+                if (c.equals(modelVal)) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Loads the validation rule from the rules map. First the rule for the property of the specified widget 
+     * (as widget.property) is being loaded. If it is defined it is returned. If it does not exist the widget
+     * is trimmed of any prefixes (e.g. org.csstudio.opibuilder.widgets) and the property for the trimmed
+     * widget is loaded. If it exist it is returned otherwise a general property rule definition is searched 
+     * for. If none is found the property is of read/write type. 
+     * 
+     * @param property the name of the property
+     * @param widget the type of the widget
+     * @return the rule for the property
+     */
+    private ValidationRule getRuleForProperty(String property, String widget) {
+        String prop = widget + "." + property;
+        ValidationRule value = rules.get(prop);
+        if (value == null) {
+            //try with abbreviated widget - omit org.csstudio.opibuilder.widgets
+            prop = widget.substring(widget.lastIndexOf('.')+1) + "." + property;
+            value = rules.get(prop);
+        }
+        if (value == null ) {
+            value = rules.get(property);
+        }
+        if (value == null) {
+            return ValidationRule.RW;
+        } else {
+            return value;
+        }        
+    }
+        
+    /**
+     * Loads the schema from the given path and stores data into a map, where the keys are the widget IDs and
+     * the values are the widget models.
+     * 
+     * @param path the path to the schema
+     * @return a map containing all elements defined in the schema
+     * @throws IOException if there was an error reading the schema
+     */
+    private static Map<String,AbstractWidgetModel> loadSchema(IPath path) throws IOException {
+        try (InputStream inputStream = ResourceUtil.pathToInputStream(path, false)) {
+            DisplayModel displayModel = new DisplayModel(path);
+            XMLUtil.fillDisplayModelFromInputStream(inputStream, displayModel, Display.getDefault());
+    
+            Map<String, AbstractWidgetModel> map = new HashMap<>();
+            map.put(displayModel.getTypeID(), displayModel);
+            loadModelFromContainer(displayModel,map);
+            if (!displayModel.getConnectionList().isEmpty()) {
+                map.put(ConnectionModel.ID, displayModel.getConnectionList().get(0));
+            }
+            return map;
+        } catch (Exception e) {
+            throw new IOException("Unable to load the OPI from " + path.toOSString() + ".",e);
+        }
+    }
+
+    private static void loadModelFromContainer(AbstractContainerModel containerModel,
+            Map<String, AbstractWidgetModel> map) {
+        for (AbstractWidgetModel model : containerModel.getChildren()) {
+            if (!map.containsKey(model.getTypeID())) {
+                map.put(model.getTypeID(), model);
+            }
+            if (model instanceof AbstractContainerModel) {
+                loadModelFromContainer((AbstractContainerModel) model, map);
+            }
+        }
+    }
+    
+    /**
+     * Fix the given validation failures. All failures are expected to belong to the same OPI file. The fix replaces
+     * the actual value of the validated property with the expected value.
+     * 
+     * @param failureToFix the validation failures to fix
+     * @throws IOException if there was an exception in reading the OPI
+     * @throws IllegalArgumentException if the failures do not belong to the same OPI
+     */
+    public static void fixOPIFailure(ValidationFailure[] failureToFix) throws IOException, IllegalArgumentException {
+        if (failureToFix.length == 0) return;
+        IPath path = failureToFix[0].getPath();
+        for (ValidationFailure f : failureToFix) {
+            if (!f.getPath().equals(path)) {
+                throw new IllegalArgumentException("All validation failures must belong to the same path.");
+            }
+        }
+        DisplayModel displayModel = null;
+        try (InputStream inputStream = ResourceUtil.pathToInputStream(path, false)) {
+            displayModel = new DisplayModel(failureToFix[0].getPath());
+            XMLUtil.fillDisplayModelFromInputStream(inputStream, displayModel, Display.getDefault());
+        } catch (Exception e) {
+            throw new IOException("Could not read the opi " + path.toOSString() +".",e);
+        }
+        
+        for (ValidationFailure f : failureToFix) {
+            AbstractWidgetModel model = findWidget(displayModel, f);
+            if (model == null) {
+                continue;
+            }
+            model.setPropertyValue(f.getProperty(), f.getExpectedValue());
+        }
+        
+        try (FileOutputStream output = new FileOutputStream(path.toFile())) {
+            XMLUtil.widgetToOutputStream(displayModel, output, true);
+        }        
+    }
+    
+   
+    /**
+     * Finds the widget model that matches the validation failure.
+     * 
+     * @param parent the parent to look for the widget model in
+     * @param failure the failure to match
+     * @return the widget model if found, or null if match was not found
+     */
+    private static AbstractWidgetModel findWidget(AbstractContainerModel parent, ValidationFailure failure) {
+        String widgetType;
+        String widgetName;
+        for (AbstractWidgetModel model : parent.getChildren()) {
+            widgetType = model.getTypeID();
+            widgetName = model.getName();
+            if (widgetType.equals(failure.getWidgetType()) && widgetName.equals(failure.getWidgetName())) {
+                Object obj = model.getPropertyValue(failure.getProperty());
+                if (obj.equals(failure.getActualValue())) {
+                    return model;
+                }
+            }
+            if (model instanceof AbstractContainerModel) {
+                AbstractWidgetModel result = findWidget((AbstractContainerModel)model, failure);
+                if (result != null) return result;
+            }
+        }  
+        return null;
+    }
+    
+
+    /**
+     * Creates a document that contains the line numbers of each node.
+     * 
+     * @param is the input stream
+     * @return the document
+     * 
+     * @throws IOException 
+     * @throws SAXException
+     */
+    private static Document readXMLWithLineNumbers(final InputStream is) throws IOException, SAXException {
+        final Document doc;
+        final SAXParser parser;
+        try {
+            SAXParserFactory factory = SAXParserFactory.newInstance();
+            parser = factory.newSAXParser();
+            DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
+            doc = docBuilder.newDocument();
+        } catch (final ParserConfigurationException e) {
+            throw new RuntimeException("Can't create SAX parser / DOM builder.", e);
+        }
+
+        Stack<Element> elementStack = new Stack<Element>();
+        StringBuilder textBuffer = new StringBuilder();
+        DefaultHandler handler = new DefaultHandler() {
+            private Locator locator;
+
+            @Override
+            public void setDocumentLocator(final Locator locator) {
+                this.locator = locator; 
+            }
+
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, 
+                    final Attributes attributes) throws SAXException {
+                addTextIfNeeded();
+                final Element el = doc.createElement(qName);
+                for (int i = 0; i < attributes.getLength(); i++) {
+                    el.setAttribute(attributes.getQName(i), attributes.getValue(i));
+                }
+                el.setUserData(LINE_NUMBER_KEY_NAME, Integer.valueOf(this.locator.getLineNumber()), null);
+                elementStack.push(el);
+            }
+
+            @Override
+            public void endElement(final String uri, final String localName, final String qName) {
+                addTextIfNeeded();
+                final Element closedEl = elementStack.pop();
+                if (elementStack.isEmpty()) { // Is this the root element?
+                    doc.appendChild(closedEl);
+                } else {
+                    elementStack.peek().appendChild(closedEl);
+                }
+            }
+
+            @Override
+            public void characters(final char ch[], final int start, final int length) throws SAXException {
+                textBuffer.append(ch, start, length);
+            }
+
+            private void addTextIfNeeded() {
+                if (textBuffer.length() > 0) {
+                    Element el = elementStack.peek();
+                    Node textNode = doc.createTextNode(textBuffer.toString());
+                    el.appendChild(textNode);
+                    textBuffer.delete(0, textBuffer.length());
+                }
+            }
+        };
+        parser.parse(is, handler);
+
+        return doc;
+    }
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/SubValidationFailure.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/SubValidationFailure.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import org.eclipse.core.runtime.IPath;
+
+/**
+ * 
+ * <code>SubValidationFailure</code> is a validation failure that was detected on a property, which is a subproperty
+ * of a widget's property, such as actions, scripts, or rules.  
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class SubValidationFailure extends ValidationFailure {
+
+    private ValidationFailure parent;
+    private final String subPropertyTag;
+    private final String subPropertyDesc;
+    private final String forcedMessage;
+    
+    private boolean isFixed = false;
+    
+    /**
+     * Constructs a new sub validation failure.
+     * 
+     * @param path the path to the file in which the failure was detected
+     * @param wuid the widget unique id that the failure was detected on
+     * @param widgetType the typeId of the widget
+     * @param widgetName the name of the widget
+     * @param property the name of the parent property
+     * @param subPropertyTag the tag of the subproperty 
+     * @param subPropertyDesc the descriptive string of the sub property (e.g. name, or type)
+     * @param expected the expected value of the property (from the schema)
+     * @param actual the actual value of the property (from the validated model)
+     * @param rule the rule that was violated
+     * @param isCritical true if this is a critical failure or false otherwise
+     * @param isFixable true if the failure can be quick fixed
+     */
+    public SubValidationFailure(IPath path, String wuid, String widgetType, String widgetName, String property, 
+            String subPropertyTag, String subPropertyDesc, Object expected, Object actual, ValidationRule rule, 
+            boolean isCritical, boolean isFixable, String forcedMessage) {
+        super(path, wuid, widgetType, widgetName, property, expected, actual, rule, isCritical, isFixable, forcedMessage);
+        this.subPropertyTag = subPropertyTag;
+        this.subPropertyDesc = subPropertyDesc;
+        this.forcedMessage = forcedMessage;
+    }
+    
+    /**
+     * @return the description of the sub property
+     */
+    public String getSubPropertyDesc() {
+        return subPropertyDesc;
+    }
+    
+    /**
+     * @return the xml tag of the sub property
+     */
+    public String getSubPropertyTag() {
+        return subPropertyTag;
+    }
+    
+    /**
+     * Set the parent validation failure. Only to be called from the {@link ValidationFailure}.
+     * 
+     * @param parent the parent
+     */
+    void setParent(ValidationFailure parent) {
+        this.parent = parent;
+    }
+    
+    /**
+     * @return the parent failure of this sub validation failure
+     */
+    public ValidationFailure getParent() {
+        return parent;
+    }
+    
+    void setFixed(boolean fixed) {
+        this.isFixed = fixed;
+    }
+    
+    boolean isFixed() {
+        return isFixed;
+    }
+    
+    
+
+    /*
+     * (non-Javadoc)
+     * @see org.csstudio.opibuilder.validation.core.ValidationFailure#getMessage()
+     */
+    @Override
+    public String getMessage() {
+        if (forcedMessage == null) {
+            if (getRule() == ValidationRule.RO) {
+                if (getActualValue() == null) {
+                    return new StringBuilder(parent.getProperty().length() + subPropertyDesc.length() + 40)
+                            .append(parent.getProperty()).append(": '").append(subPropertyDesc)
+                            .append("' expected to be defined, but was not").toString();
+                } else if (getExpectedValue() == null) {
+                    return new StringBuilder(parent.getProperty().length() + subPropertyDesc.length() + 26)
+                            .append(parent.getProperty()).append(": '").append(subPropertyDesc)
+                            .append("' should not be defined").toString();
+                } else {
+                    return new StringBuilder(parent.getProperty().length() + subPropertyDesc.length() + getExpected().length() 
+                            + getActual().length() + 29 ).append(parent.getProperty()).append(": '").append(subPropertyDesc)
+                            .append("': expected: '").append(getExpected()).append("' but was: '").append(getActual())
+                            .append('\'').toString();
+                }
+            } else if (getRule() == ValidationRule.WRITE) {
+                return new StringBuilder(parent.getProperty().length() + subPropertyDesc.length() + 40)
+                            .append(parent.getProperty()).append(": '").append(subPropertyDesc)
+                            .append("' expected to be defined, but was not").toString();
+            }
+        } else {
+            return new StringBuilder(parent.getProperty().length() + subPropertyDesc.length() 
+                    + forcedMessage.length() +6)
+                    .append(parent.getProperty()).append(": '").append(subPropertyDesc)
+                    .append("': ").append(forcedMessage).toString();
+        }
+        return super.getMessage();
+    }    
+    
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/Utilities.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/Utilities.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.csstudio.opibuilder.model.AbstractContainerModel;
+import org.csstudio.opibuilder.model.AbstractWidgetModel;
+import org.csstudio.opibuilder.model.ConnectionModel;
+import org.csstudio.opibuilder.model.DisplayModel;
+import org.csstudio.opibuilder.persistence.XMLUtil;
+import org.csstudio.opibuilder.script.Expression;
+import org.csstudio.opibuilder.script.PVTuple;
+import org.csstudio.opibuilder.script.RuleData;
+import org.csstudio.opibuilder.script.ScriptData;
+import org.csstudio.opibuilder.util.ResourceUtil;
+import org.csstudio.opibuilder.widgetActions.AbstractWidgetAction;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.swt.widgets.Display;
+
+/**
+ * 
+ * <code>Utilities</code> provides some static methods used during the validation or quick fixing the failures.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public final class Utilities {
+
+    static final String TAG_NAME = "name";
+    static final String PROP_ACTION_HOOK_ALL = "hook_all";
+    static final String PROP_ACTION_HOOK = "hook";
+    
+    public static String ruleMatchValueToMessage(int value) {
+        switch(value) {
+            case 1: return "PV name or trigger value does not match";
+            case 2: return "Expressions do not match";
+            case 3: return "Property ID does not match";
+            default: return null;
+        }
+    }
+    
+    public static String actionMatchValueToMessage(int value) {
+        if (value == 1) {
+            return "Action of the same type was found, but the properties values were different";
+        }
+        return null;
+    }
+    
+    public static String scriptMatchValueToMessage(int value) {
+        switch(value) {
+            case 1: return "PV name or trigger value does not match";
+            case 2: return "Stop execution value does not match";
+            case 3: return "Skip execution on first connection does not match";
+            case 4: return "Execute even if PVs are disconnected does not match";
+            case 5: return "Script text does not match";
+            default: return null;    
+        }
+    }
+    
+    /**
+     * Check if the rule definitions are identical. Rules are identical if they have the same name, property id,
+     * PV tuples and expressions.
+     * 
+     * @param original the original rule
+     * @param model the validated rule
+     * @return 0 if the rules are identical, 1 if tuples are different, 2 if expressions are different, 3 if
+     *          properties are different or 4 if names are different
+     */
+    public static int areRulesIdentical(RuleData original, RuleData model) {
+        if (!Objects.equals(original.getName(), model.getName())) return 4;
+        if (!Objects.equals(original.getPropId(),model.getPropId())) return 3;
+                
+        List<Expression> orgex = original.getExpressionList();
+        List<Expression> modex = original.getExpressionList();
+        if (orgex.size() != modex.size()) {
+            return 2;
+        }
+        //order of expressions is irrelevant
+        for (Expression oex : orgex) {
+            checkExpression: {
+                for (Expression mex : modex) {
+                    if (mex.getBooleanExpression().equals(oex.getBooleanExpression()) 
+                            && Objects.equals(oex.getValue(), mex.getValue())) {
+                        break checkExpression;
+                    }
+                }
+                return 2;
+            }
+        }
+        
+        List<PVTuple> orgpvs = original.getPVList();
+        List<PVTuple> mpvs = model.getPVList();
+        if (orgpvs.size() != mpvs.size()) {
+            return 1;
+        }
+        //order of pvs is important
+        for (int i = 0; i < orgpvs.size(); i++) {
+            PVTuple opt = orgpvs.get(i);
+            PVTuple mpt = mpvs.get(i);
+            if (!mpt.pvName.equals(opt.pvName) || mpt.trigger != opt.trigger) {
+                return 1; 
+            }
+        }
+        
+        return 0;
+    }
+    
+    /**
+     * Compare the widget actions and return 0 if the actions are identical, 1 if their
+     * properties are different or 2 if they are of different types.
+     * 
+     * @param original the original action
+     * @param model the validated action
+     * @return 0 if actions are identical, 1 if properties are different or 2 if action types are different
+     */
+    public static int areActionsIdentical(AbstractWidgetAction original, AbstractWidgetAction model) {
+        if (original.getActionType() != model.getActionType()) return 2;
+        for (String id : original.getAllPropertyIDs()) {
+            if (!Objects.equals(original.getPropertyValue(id),model.getPropertyValue(id))) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    
+    /**
+     * Checks if two scripts are identical, which means that all their fields are identical. If one of the properties
+     * from the original is different from the one in the mode a value greater than 0 is returned. The value depends
+     * on which property is different. 
+     * 
+     * @param original the original script
+     * @param model the validated script
+     * @return 0 if identical, or more than 0 if they are different
+     */
+    public static int areScriptsIdentical(ScriptData original, ScriptData model) {
+        if (original.getScriptType() != model.getScriptType()) return 9;
+        if (original.isEmbedded() != model.isEmbedded()) return 8;
+        if (!Objects.equals(original.getPath(),model.getPath())) return 7;
+        if (!Objects.equals(original.getScriptName(), model.getScriptName())) return 6;
+        if (!Objects.equals(original.getScriptText(), model.getScriptText())) return 5;
+        if (original.isCheckConnectivity() != model.isCheckConnectivity()) return 4;
+        if (original.isSkipPVsFirstConnection() != model.isSkipPVsFirstConnection()) return 3;
+        if (original.isStopExecuteOnError() != model.isStopExecuteOnError()) return 2;
+        
+        List<PVTuple> orgpvs = original.getPVList();
+        List<PVTuple> mpvs = model.getPVList();
+        if (orgpvs.size() != mpvs.size()) {
+            return 1;
+        }
+        //order of pvs is important
+        for (int i = 0; i < orgpvs.size(); i++) {
+            PVTuple opt = orgpvs.get(i);
+            PVTuple mpt = mpvs.get(i);
+            if (!mpt.pvName.equals(opt.pvName) || mpt.trigger != opt.trigger) {
+                return 1; 
+            }
+        }
+        
+        return 0;
+    }
+    
+    /**
+     * Loads the schema from the given path and stores data into a map, where the keys are the widget IDs and
+     * the values are the widget models.
+     * 
+     * @param path the path to the schema
+     * @return a map containing all elements defined in the schema
+     * @throws IOException if there was an error reading the schema
+     */
+    public static Map<String,AbstractWidgetModel> loadSchema(IPath path) throws IOException {
+        try (InputStream inputStream = ResourceUtil.pathToInputStream(path, false)) {
+            DisplayModel displayModel = new DisplayModel(path);
+            XMLUtil.fillDisplayModelFromInputStream(inputStream, displayModel, Display.getDefault());
+    
+            Map<String, AbstractWidgetModel> map = new HashMap<>();
+            map.put(displayModel.getTypeID(), displayModel);
+            loadModelFromContainer(displayModel,map);
+            if (!displayModel.getConnectionList().isEmpty()) {
+                map.put(ConnectionModel.ID, displayModel.getConnectionList().get(0));
+            }
+            return map;
+        } catch (Exception e) {
+            throw new IOException("Unable to load the OPI from " + path.toOSString() + ".",e);
+        }
+    }
+
+    private static void loadModelFromContainer(AbstractContainerModel containerModel,
+            Map<String, AbstractWidgetModel> map) {
+        for (AbstractWidgetModel model : containerModel.getChildren()) {
+            if (!map.containsKey(model.getTypeID())) {
+                map.put(model.getTypeID(), model);
+            }
+            if (model instanceof AbstractContainerModel) {
+                loadModelFromContainer((AbstractContainerModel) model, map);
+            }
+        }
+    }
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ValidationFailure.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ValidationFailure.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import org.eclipse.core.runtime.IPath;
+
+/**
+ * 
+ * <code>ValidationFailure</code> represents a single validation failure, which is a result of validating the OPI
+ * content against the schema.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class ValidationFailure {
+    
+    private final String widgetType;
+    private final String widgetName;
+    private final String property;
+    private final String expected;
+    private final String actual;
+    private final IPath path;
+    private final Object expectedValue;
+    private final Object actualValue;
+    private final ValidationRule rule;
+    private final boolean isCritical;
+    
+    private int lineNumber;
+    
+    /**
+     * Constructs a new validation failure.
+     * 
+     * @param path the path to the file, in which the failure originates
+     * @param widgetType the type of the widget
+     * @param widgetName the name of the widget
+     * @param property the property name which is failing
+     * @param expected the expected value of the property (schema value)
+     * @param actual the actual value of the property (validated opi value)
+     * @param rule the rule, which was violated
+     * @param isCritical defines if the failure is critical or not (failure is critical when a RO rule is violated
+     *          using a non-predefined value)
+     */
+    ValidationFailure(IPath path, String widgetType, String widgetName, 
+            String property, Object expected, Object actual, ValidationRule rule, boolean isCritical) {
+        this.widgetType = widgetType;
+        this.widgetName = widgetName;
+        this.property = property;
+        this.expectedValue = expected;
+        this.actualValue = actual;
+        this.expected = String.valueOf(expected);
+        this.actual = String.valueOf(actual);
+        this.path = path;
+        this.rule = rule;
+        this.isCritical = isCritical;
+    }
+    
+    /**
+     * Constructs the message describing this validation failure. The message is used for the contents of the marker.
+     * 
+     * @return the message describing the failure
+     */
+    public String getMessage() {
+        if (rule == ValidationRule.RO) {
+            return property + ": expected: '" + String.valueOf(expected) + "' but was: '" + String.valueOf(actual) + "'";
+        } else if (rule == ValidationRule.WRITE) {
+            return property + " is not set";
+        } else {
+            return "What could be wrong?";
+        }
+    }
+    
+    /**
+     * Constructs the location message containing the line number and widget name.
+     * 
+     * @return the location
+     */
+    public String getLocation() {
+        return "line " + lineNumber + " (Widget: " + widgetName + ")";
+    }
+    
+    /**
+     * @return the line number at which the failure was recorder
+     */
+    public int getLineNumber() {
+        return lineNumber;
+    }
+    
+    /**
+     * Sets the lin number at which this failure was recorded.
+     * 
+     * @param lineNumber the line number
+     */
+    void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    /**
+     * @return the widget typeId.
+     */
+    public String getWidgetType() {
+        return widgetType;
+    }
+
+    /**
+     * @return the widget name
+     */
+    public String getWidgetName() {
+        return widgetName;
+    }
+
+    /**
+     * @return the property name
+     */
+    public String getProperty() {
+        return property;
+    }
+
+    /**
+     * @return the expected property value transformed to string
+     */
+    public String getExpected() {
+        return expected;
+    }
+
+    /**
+     * @return the actual property value transformed to string
+     */
+    public String getActual() {
+        return actual;
+    }
+
+    /**
+     * @return the path to the file on which this failure occurred
+     */
+    public IPath getPath() {
+        return path;
+    }   
+    
+    /**
+     * @return the expected property value as a real property object
+     */
+    public Object getExpectedValue() {
+        return expectedValue;
+    }
+    
+    /**
+     * @return the actual property value as a real property object
+     */
+    public Object getActualValue() {
+        return actualValue;
+    }
+    
+    /**
+     * @return the violated validation rule
+     */
+    public ValidationRule getRule() {
+        return rule;
+    }
+    
+    /**
+     * @return true if this validation represents a critical failure (error) or false if not critical (warning)
+     */
+    public boolean isCritical() {
+        return isCritical;
+    }
+    
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ValidationRule.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ValidationRule.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+/**
+ * 
+ * <code>ValidationRule</code> defines the possible rules how to treat properties: read/write, read only, obligatory 
+ * write.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public enum ValidationRule {
+    RO, RW, WRITE
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/Validator.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/Validator.java
@@ -25,6 +25,8 @@ import org.csstudio.opibuilder.validation.ui.ResultsDialog;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.viewers.ITreeContentProvider;
@@ -146,6 +148,15 @@ public class Validator extends AbstractValidator {
     @Override
     public void validationStarting(IProject project, ValidationState state, IProgressMonitor monitor) {
         if (project == null) {
+            if (Activator.getInstance().isClearMarkers()) {
+                try {
+                    //cleanup all opi validation markers
+                    ResourcesPlugin.getWorkspace().getRoot().deleteMarkers(MARKER_PROBLEM, true, IProject.DEPTH_INFINITE);
+                    ResourcesPlugin.getWorkspace().getRoot().deleteMarkers(MARKER_ERROR, true, IProject.DEPTH_INFINITE);
+                } catch (CoreException e) {
+                    LOGGER.log(Level.WARNING, "Could not delete opi validation markers.",e);
+                }
+            }
             //bring the progress view to the top
             showView("org.eclipse.ui.views.ProgressView",false);
             //reload the rules, just in case they have been changed

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/Validator.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/Validator.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.csstudio.opibuilder.validation.Activator;
+import org.csstudio.opibuilder.validation.ui.ResultsDialog;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.wst.validation.AbstractValidator;
+import org.eclipse.wst.validation.ValidationResult;
+import org.eclipse.wst.validation.ValidationState;
+import org.eclipse.wst.validation.ValidatorMessage;
+
+/**
+ * 
+ * <code>Validator</code> implements the wst validation api for validating OPI files. 
+ * OPIs are validated by comparing their values to the ones defined in the OPI schema.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class Validator extends AbstractValidator {
+
+    private static final Logger LOGGER = Logger.getLogger(Validator.class.getName());
+    
+    /** Marker name for OPI validation failure */ 
+    public static final String MARKER_PROBLEM = Activator.ID + ".opiValidationProblem";
+    /** Marker name for OPI loading error */
+    public static final String MARKER_ERROR = Activator.ID + ".opiLoadingError";
+    /** The ID of the editor to open when the marker is double clicked */
+    private static final String DEFAULT_TEXT_EDITOR = "org.eclipse.ui.DefaultTextEditor";
+    /** The name of the marker attribute that contains the validation failure */
+    public static final String ATTR_VALIDATION_FAILURE = "validationFailure";
+    
+    private final SchemaVerifier verifier;
+
+    /**
+     * Construct the validator.
+     */
+    public Validator() {
+        IPath rulesFile = Activator.getInstance().getRulesFile();
+        Map<String, ValidationRule> rules = new HashMap<String, ValidationRule>();
+        if (rulesFile != null) {
+            Properties p = new Properties();
+            try (FileInputStream stream = new FileInputStream(rulesFile.toFile())) {
+                p.load(stream);
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Cannot read the rules definition file: " + rulesFile.toOSString(), e);
+            }
+            
+            for (Entry<Object,Object> e : p.entrySet()) {
+                rules.put((String)e.getKey(), ValidationRule.valueOf((String)e.getValue()));
+            }
+        }
+        verifier = new SchemaVerifier(rules);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.wst.validation.AbstractValidator#validate(org.eclipse.core.resources.IResource, int, org.eclipse.wst.validation.ValidationState, org.eclipse.core.runtime.IProgressMonitor)
+     */
+    @Override
+    public ValidationResult validate(IResource resource, int kind, ValidationState state, IProgressMonitor monitor) {
+        if (resource.getType() != IResource.FILE) {
+            return null;
+        }
+
+        if (monitor.isCanceled()) {
+            return null;
+        }
+        
+        ValidationResult result = new ValidationResult();
+        try {
+            ValidationFailure[] failures = verifier.validate(resource.getLocation());
+            for (ValidationFailure vf : failures) {
+                ValidatorMessage message = ValidatorMessage.create(vf.getMessage(), resource);
+                message.setType(MARKER_PROBLEM);
+                if (vf.getRule() == ValidationRule.RO) {
+                    if (vf.isCritical()) {
+                        message.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+                    } else {
+                        message.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+                    }
+                } else if (vf.getRule() == ValidationRule.WRITE) {
+                    message.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
+                }
+                message.setAttribute(IMarker.LOCATION, vf.getLocation());
+                message.setAttribute(IMarker.LINE_NUMBER, vf.getLineNumber());
+                message.setAttribute(ATTR_VALIDATION_FAILURE, vf);
+                message.setAttribute(IDE.EDITOR_ID_ATTR, DEFAULT_TEXT_EDITOR);
+                
+                result.add(message);
+            }
+        } catch (IOException e) {
+            ValidatorMessage message = ValidatorMessage.create(e.getMessage(), resource);
+            message.setType(MARKER_ERROR);
+            message.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+            message.setAttribute(IMarker.LOCATION, resource.getFullPath().toFile().getAbsolutePath());
+            result.add(message);
+        }
+
+        return result;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.wst.validation.AbstractValidator#validationStarting(org.eclipse.core.resources.IProject,
+     * org.eclipse.wst.validation.ValidationState, org.eclipse.core.runtime.IProgressMonitor)
+     */
+    @Override
+    public void validationStarting(IProject project, ValidationState state, IProgressMonitor monitor) {
+        verifier.clean();
+        if (project == null) {
+            showView("org.eclipse.ui.views.ProgressView");
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.wst.validation.AbstractValidator#validationFinishing(org.eclipse.core.resources.IProject,
+     * org.eclipse.wst.validation.ValidationState, org.eclipse.core.runtime.IProgressMonitor)
+     */
+    @Override
+    public void validationFinishing(IProject project, ValidationState state, IProgressMonitor monitor) {
+        if (project == null) {
+            //at the end bring the problems view to the top and if requested show the summary dialog
+            showView("org.eclipse.ui.views.ProblemView");
+            if (Activator.getInstance().isShowSummaryDialog()) {
+                Display.getDefault().asyncExec(() -> {
+                    IWorkbenchPage page = getPage();
+                    ResultsDialog dialog = new ResultsDialog(page.getWorkbenchWindow().getShell(),
+                            verifier.getNumberOfAnalyzedFiles(),
+                            verifier.getNumberOfFilesFailures(),
+                            verifier.getNumberOfAnalyzedWidgets(),
+                            verifier.getNumberOfWidgetsFailures(),
+                            verifier.getNumberOfROProperties(),
+                            verifier.getNumberOfCriticalROFailures(),
+                            verifier.getNumberOfMajorROFailures(),
+                            verifier.getNumberOfWRITEProperties(),
+                            verifier.getNumberOfWRITEFailures()
+                            );
+                    dialog.open();
+                });
+            }
+        }
+    }
+    
+    private void showView(String view) {
+        Display.getDefault().asyncExec(() -> {
+            try {
+                IWorkbenchPage page = getPage();
+                if (page != null) {
+                    page.showView(view);
+                }
+            } catch (PartInitException e) {
+            }
+        });
+    }
+    
+    private IWorkbenchPage getPage() {
+        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        if (window == null && PlatformUI.getWorkbench().getWorkbenchWindowCount() > 0) {
+            window = PlatformUI.getWorkbench().getWorkbenchWindows()[0];
+        }
+        if (window == null) {
+            return null;
+        }
+        IWorkbenchPage page = window.getActivePage();
+        if (page == null && window.getPages().length > 0) {
+            page = window.getPages()[0];
+        }
+        return page;
+    }
+
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/XMLParser.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/XMLParser.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core;
+
+import org.jdom.DefaultJDOMFactory;
+import org.jdom.Element;
+import org.jdom.Namespace;
+import org.jdom.input.SAXBuilder;
+import org.jdom.input.SAXHandler;
+
+/**
+ * 
+ * <code>XMLParser</code> provides a set of classes that parse an XML file and set the line number on each Element that
+ * was parsed.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class XMLParser {
+
+    /**
+     * 
+     * <code>LinedElement</code> is an element that also holds the line number at which it is located.
+     *
+     * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+     *
+     */
+    public static class LinedElement extends Element {
+
+        private static final long serialVersionUID = 1L;
+        private final int lineNumber;
+
+        public LinedElement(String name, Namespace namespace, int lineNumber) {
+            super(name, namespace);
+            this.lineNumber = lineNumber;
+        }
+
+        public int getLineNumber() {
+            return lineNumber;
+        }
+    }
+
+    private static class XMLLineBuilder extends SAXBuilder {
+
+        private LineFactory factory = new LineFactory();
+
+        public XMLLineBuilder() {
+            super();
+            setFactory(factory);
+        }
+
+        @Override
+        protected void configureContentHandler(SAXHandler contentHandler) {
+            super.configureContentHandler(contentHandler);
+            factory.setSAXHandler(contentHandler);
+        }
+
+    }
+
+    private static class LineFactory extends DefaultJDOMFactory {
+        private SAXHandler saxHandler;
+
+        public void setSAXHandler(SAXHandler sh) {
+            this.saxHandler = sh;
+        }
+
+        public Element element(String name) {
+            return this.element(name, (Namespace) null);
+        }
+
+        public Element element(String name, Namespace namespace) {
+            return new LinedElement(name, namespace, saxHandler.getDocumentLocator().getLineNumber());
+        }
+    }
+
+    /**
+     * @return a new builder that parses an XML and sets the line numbers on the elements
+     */
+    public static SAXBuilder createBuilder() {
+        return new XMLLineBuilder();
+    }
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ui/ContentProvider.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ui/ContentProvider.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core.ui;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.csstudio.opibuilder.validation.core.SubValidationFailure;
+import org.csstudio.opibuilder.validation.core.ValidationFailure;
+import org.csstudio.opibuilder.validation.core.Validator;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.Viewer;
+
+/**
+ * 
+ * <code>ContentProvider</code> is meant to replace the content provide of the problems view. 
+ * It provides elements in a 3-level tree like structure to be able to group the sub validation 
+ * failures below the parent failures.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class ContentProvider implements ITreeContentProvider {
+
+    private boolean filterOut = true;
+    private ITreeContentProvider original;
+    private Field markerField;
+    
+    private Map<ValidationFailure,Set<Object>> markersMap = new HashMap<>();
+    
+    
+    /**
+     * @param extendedMarkersView
+     */
+    public ContentProvider(ITreeContentProvider org) {
+        this.original = org;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.jface.viewers.IContentProvider#inputChanged(org.eclipse
+     * .jface.viewers.Viewer, java.lang.Object, java.lang.Object)
+     */
+    public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+        markersMap.clear();
+        original.inputChanged(viewer, oldInput, newInput);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.jface.viewers.IContentProvider#dispose()
+     */
+    public void dispose() {
+        original.dispose();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.jface.viewers.ITreeContentProvider#getChildren(java
+     * .lang.Object)
+     */
+    public Object[] getChildren(Object parentElement) {
+        ValidationFailure f = getValidationFailure(parentElement);
+        if (f != null && f.hasSubFailures()) {
+            Set<Object> list = markersMap.get(f);
+            if (list != null) {
+                return list.toArray(new Object[list.size()]);
+            }
+        }
+        return filterChildren(original.getChildren(parentElement));
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.jface.viewers.IStructuredContentProvider#getElements
+     * (java.lang.Object)
+     */
+    public Object[] getElements(Object inputElement) {
+        return filterElements(original.getElements(inputElement));
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.jface.viewers.ILazyTreeContentProvider#getParent(
+     * java.lang.Object)
+     */
+    public Object getParent(Object element) {
+        return original.getParent(element);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.jface.viewers.ITreeContentProvider#hasChildren(java
+     * .lang.Object)
+     */
+    public boolean hasChildren(Object element) {
+        ValidationFailure f = getValidationFailure(element);
+        if (f != null) return f.hasSubFailures();
+        if (original.hasChildren(element)) {
+            Object[] obj = filterChildren(original.getChildren(element));
+            return obj.length > 0;
+        }
+        return false;
+    }
+    
+    private ValidationFailure getValidationFailure(Object element) {
+        if ("MarkerEntry".equals(element.getClass().getSimpleName())) {
+            try {
+                if (markerField == null) {
+                    markerField = element.getClass().getDeclaredField("marker");
+                    markerField.setAccessible(true);
+                }
+                IMarker m = (IMarker)markerField.get(element);
+                return (ValidationFailure)m.getAttribute(Validator.ATTR_VALIDATION_FAILURE);
+            } catch (Exception e) {
+                //ignore
+            }
+        }
+        return null;
+    }
+    
+    private Object[] filterElements(Object[] categories) {
+        try {
+            List<Object> list = new ArrayList<>();
+            for (Object o : categories) {
+                if ("MarkerCategory".equals(o.getClass().getSimpleName())) {
+                    if (hasChildren(o)) {
+                        list.add(o);
+                    }
+                }
+            }
+            return filterOut ? list.toArray(new Object[list.size()]) : categories;
+        } catch (Exception e) {
+            //ignore
+        }
+        return categories;
+    }
+    
+    private Object[] filterChildren(Object[] markers) {
+        try {
+            List<Object> list = new ArrayList<>(markers.length); 
+            for (Object o : markers) {
+                if ("MarkerEntry".equals(o.getClass().getSimpleName())) {
+                    if (markerField == null) {
+                        markerField = o.getClass().getDeclaredField("marker");
+                        markerField.setAccessible(true);
+                    }
+                    IMarker m = (IMarker)markerField.get(o);
+                    ValidationFailure v = (ValidationFailure)m.getAttribute(Validator.ATTR_VALIDATION_FAILURE);
+                    if (v instanceof SubValidationFailure) {
+                        Set<Object> mlist = markersMap.get(((SubValidationFailure) v).getParent());
+                        if (mlist == null) {
+                            mlist = new HashSet<>();
+                            markersMap.put(((SubValidationFailure)v).getParent(), mlist);
+                        }
+                        mlist.add(o);
+                        continue;
+                    }
+                }
+                list.add(o);
+            }
+            return filterOut ? list.toArray(new Object[list.size()]) : markers;
+        } catch (Exception e) {
+            //ignore
+        }
+        return markers;
+    }
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ui/ContentProvider.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ui/ContentProvider.java
@@ -112,13 +112,15 @@ public class ContentProvider implements ITreeContentProvider {
      * .lang.Object)
      */
     public boolean hasChildren(Object element) {
-        ValidationFailure f = getValidationFailure(element);
-        if (f != null) return f.hasSubFailures();
-        if (original.hasChildren(element)) {
-            Object[] obj = filterChildren(original.getChildren(element));
-            return obj.length > 0;
-        }
-        return false;
+        if (Activator.getInstance().isNestMarkers()) {
+            ValidationFailure f = getValidationFailure(element);
+            if (f != null) return f.hasSubFailures();
+            if (original.hasChildren(element)) {
+                Object[] obj = filterChildren(original.getChildren(element));
+                return obj.length > 0;
+            }
+            return false;
+        } return original.hasChildren(element);
     }
     
     private ValidationFailure getValidationFailure(Object element) {

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ui/TreeViewerListener.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/core/ui/TreeViewerListener.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.core.ui;
+
+import org.eclipse.swt.events.TreeEvent;
+import org.eclipse.swt.events.TreeListener;
+
+/**
+ * 
+ * <code>TreeViewerListener</code> is an intercepter listener, which blocks the events that
+ * do not contain the MarkerCategory as the data item.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class TreeViewerListener implements TreeListener {
+    
+    private TreeListener delegate;
+    
+    /**
+     * Constructs a new listener that delegates the events to the given one.
+     * 
+     * @param delegate the listener to receive events from this listener
+     */
+    public TreeViewerListener(TreeListener delegate) {
+        this.delegate = delegate;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.swt.events.TreeListener#treeCollapsed(org.eclipse.swt.events.TreeEvent)
+     */
+    @Override
+    public void treeCollapsed(TreeEvent e) {
+        if ("MarkerCategory".equals(e.item.getData().getClass().getSimpleName())) {
+            delegate.treeCollapsed(e);
+        }
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.swt.events.TreeListener#treeExpanded(org.eclipse.swt.events.TreeEvent)
+     */
+    @Override
+    public void treeExpanded(TreeEvent e) {
+        if ("MarkerCategory".equals(e.item.getData().getClass().getSimpleName())) {
+            delegate.treeExpanded(e);
+        }
+    }
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
@@ -93,7 +93,7 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
         
         BooleanFieldEditor nestMarkers = new BooleanFieldEditor(Activator.PREF_NEST_MARKERS, 
                 "Nest markers in the Problems View?", parent);
-        nestMarkers.getLabelControl(parent).setToolTipText(
+        nestMarkers.getDescriptionControl(parent).setToolTipText(
                 "Display sub validation failures (action, script, rule) as children of their parent properties (actions, scripts, rules)");
         addField(nestMarkers);
     }

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
@@ -96,7 +96,11 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
         nestMarkers.getDescriptionControl(parent).setToolTipText(
                 "Display sub validation failures (action, script, rule) as children of their parent properties (actions, scripts, rules)");
         addField(nestMarkers);
-    }
-    
-    
+        
+        BooleanFieldEditor clearMarkers = new BooleanFieldEditor(Activator.PREF_CLEAR_MARKERS, 
+                "Clear old markers when validation starts?", parent);
+        clearMarkers.getDescriptionControl(parent).setToolTipText(
+                "Clear all validation markers on every new validation restart");
+        addField(clearMarkers);        
+    }    
 }

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
@@ -91,6 +91,11 @@ public class PreferencesPage extends FieldEditorPreferencePage implements IWorkb
                 "Show summary dialog after validation?", parent);
         addField(showSummary);
         
+        BooleanFieldEditor nestMarkers = new BooleanFieldEditor(Activator.PREF_NEST_MARKERS, 
+                "Nest markers in the Problems View?", parent);
+        nestMarkers.getLabelControl(parent).setToolTipText(
+                "Display sub validation failures (action, script, rule) as children of their parent properties (actions, scripts, rules)");
+        addField(nestMarkers);
     }
     
     

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/PreferencesPage.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.ui;
+
+import org.csstudio.opibuilder.preferences.WorkspaceFileFieldEditor;
+import org.csstudio.opibuilder.validation.Activator;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+/**
+ * 
+ * <code>PreferencesEditor</code> provides the preferences settings page for the OPI validation settings. 
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class PreferencesPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+    private BooleanFieldEditor makeBackup;
+    
+    /**
+     * Constructs a new preferences page.
+     */
+    public PreferencesPage() {
+        super(FieldEditorPreferencePage.GRID);
+        setPreferenceStore(Activator.getInstance().getPreferenceStore());
+        setMessage("OPI Validation Properties");
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
+     */
+    @Override
+    public void init(IWorkbench workbench) {
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.jface.preference.FieldEditorPreferencePage#createFieldEditors()
+     */
+    @Override
+    protected void createFieldEditors() {
+        final Composite parent = getFieldEditorParent();
+        
+        WorkspaceFileFieldEditor rules = new WorkspaceFileFieldEditor(Activator.PREF_RULES_FILE, 
+                    "Validation Rules: ", new String[]{"def"}, parent);
+        rules.getTextControl(parent).setToolTipText(
+                    "The file that defines the rules for validation of properties (read-only, write, read/write)");
+        addField(rules);
+        
+        BooleanFieldEditor askForBackup = new BooleanFieldEditor(Activator.PREF_SHOW_BACKUP_DIALOG,
+                "Ask to do backup before applying quick fix?", parent){
+            private Button button;
+            @Override
+            protected Button getChangeControl(Composite parent) {
+                if (button == null) {
+                    button = super.getChangeControl(parent);
+                    button.addSelectionListener(new SelectionListener() {
+                        @Override
+                        public void widgetSelected(SelectionEvent e) {
+                            makeBackup.setEnabled(!getBooleanValue(), parent);
+                        }
+                        @Override
+                        public void widgetDefaultSelected(SelectionEvent e) {
+                        }
+                    });
+                }
+                return button;
+            }  
+        };
+        addField(askForBackup);
+        
+        makeBackup = new BooleanFieldEditor(Activator.PREF_DO_BACKUP, 
+                "Do backup when applying quick fix?", parent);
+        makeBackup.setEnabled(!Activator.getInstance().isShowBackupDialog(), parent);
+        addField(makeBackup);
+        
+        BooleanFieldEditor showSummary = new BooleanFieldEditor(Activator.PREF_SHOW_SUMMARY, 
+                "Show summary dialog after validation?", parent);
+        addField(showSummary);
+        
+    }
+    
+    
+}

--- a/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/ResultsDialog.java
+++ b/applications/plugins/org.csstudio.opibuilder.validation/src/org/csstudio/opibuilder/validation/ui/ResultsDialog.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2015 ITER Organization.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.validation.ui;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * 
+ * <code>ResultsDialog</code> shows the summary of the validation - how many files, widgets, and properties were
+ * analyzed and how many of them failed validation.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public class ResultsDialog extends TitleAreaDialog {
+    
+    private static final String MESSAGE = "OPI Validation completed successfully.\n"
+            + "Below is the summary of the validation. Details can be found in the Problems View.";
+    private static final String TITLE = "OPI Validation Results";
+    
+    private final int noValidatedFiles;
+    private final int noFilesWithFailures;
+    private final int noValidatedWidgets;
+    private final int noWidgetsWithFailures;
+    private final int noValidatedROProperties;
+    private final int noROPropertiesWithCriticalFailures;
+    private final int noROPropertiesWithMajorFailures;
+    private final int noValidatedWRITEProperties;
+    private final int noWRITEPropertiesWithFailures;
+
+    private Font font;
+
+    /**
+     * Constructs a new dialog.
+     * 
+     * @param parentShell the parent shell
+     * @param noValidatedFiles number of validated files
+     * @param noFilesWithFailures number of files that did not pass the validation
+     * @param noValidatedWidgets number of validated widgets
+     * @param noWidgetsWithFailures number of widgets that did not pass the validation
+     * @param noValidatedROProperties number of validated read-only properties
+     * @param noROPropertiesWithCriticalFailures number of read-only properties that produced a critical validation failure
+     * @param noROPropertiesWithMajorFailures number of read-only properties that produced a major validation failure
+     * @param noValidatedWRITEProperties number of validated write properties
+     * @param noWRITEPropertiesWithFailures number of write properties that did not pass validation
+     */
+    public ResultsDialog(Shell parentShell, int noValidatedFiles, int noFilesWithFailures,
+            int noValidatedWidgets, int noWidgetsWithFailures, int noValidatedROProperties,
+            int noROPropertiesWithCriticalFailures, int noROPropertiesWithMajorFailures,
+            int noValidatedWRITEProperties, int noWRITEPropertiesWithFailures) {
+        super(parentShell);
+        this.noValidatedFiles = noValidatedFiles;
+        this.noFilesWithFailures = noFilesWithFailures;
+        this.noValidatedWidgets = noValidatedWidgets;
+        this.noWidgetsWithFailures = noWidgetsWithFailures;
+        this.noValidatedROProperties = noValidatedROProperties;
+        this.noROPropertiesWithCriticalFailures = noROPropertiesWithCriticalFailures;
+        this.noROPropertiesWithMajorFailures = noROPropertiesWithMajorFailures;
+        this.noValidatedWRITEProperties = noValidatedWRITEProperties;
+        this.noWRITEPropertiesWithFailures = noWRITEPropertiesWithFailures;
+        
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.jface.window.Window#configureShell(org.eclipse.swt.widgets.Shell)
+     */
+    @Override
+    protected void configureShell(Shell newShell) {
+        super.configureShell(newShell);
+        newShell.setText(TITLE);
+        newShell.addDisposeListener(new DisposeListener() {
+            @Override
+            public void widgetDisposed(DisposeEvent e) {
+                if (font != null) {
+                    font.dispose();
+                }
+            }
+        });
+        
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.jface.dialogs.TitleAreaDialog#createDialogArea(org.eclipse.swt.widgets.Composite)
+     */
+    @Override
+    protected Control createDialogArea(Composite parent) {
+        Composite c = (Composite)super.createDialogArea(parent);
+        setTitle(TITLE);
+        setMessage(MESSAGE);
+        GridLayout layout = (GridLayout)c.getLayout();
+        layout.verticalSpacing = 5;
+        layout.horizontalSpacing = 5;
+        layout.marginLeft = 5;
+        layout.marginRight = 5;
+        
+        Composite report = new Composite(parent, SWT.NONE);
+        GridData data = new GridData(GridData.HORIZONTAL_ALIGN_FILL, GridData.VERTICAL_ALIGN_FILL, true,true);
+        report.setLayoutData(data);
+        
+        GridLayout reportLayout = new GridLayout();
+        reportLayout.verticalSpacing = 3;
+        reportLayout.horizontalSpacing = 3;
+        reportLayout.marginLeft = 15;
+        report.setLayout(reportLayout);
+        
+        createReportContents(report);
+        return c;
+    }
+    
+    private void createReportContents(Composite parent) {
+        Label l = new Label(parent, SWT.HORIZONTAL);
+        l.setText("Validated files: " + noValidatedFiles);
+        l.setLayoutData(createGridData(false));
+        if (font == null) {
+            FontData fd = l.getFont().getFontData()[0];
+            fd.setStyle(SWT.ITALIC);
+            font = new Font(parent.getDisplay(),fd);
+        }
+        
+        l = new Label(parent, SWT.HORIZONTAL);
+        int ratio = (int)((noFilesWithFailures/(double)noValidatedFiles)*100);
+        l.setText("Files with errors: " + noFilesWithFailures + " (" + ratio + " %)");
+        l.setLayoutData(createGridData(true));
+        l.setFont(font);
+        
+        l = new Label(parent, SWT.HORIZONTAL);
+        l.setText("Validated widgets: " + noValidatedWidgets);
+        l.setLayoutData(createGridData(false));
+        
+        l = new Label(parent, SWT.HORIZONTAL);
+        ratio = (int)((noWidgetsWithFailures/(double)noValidatedWidgets)*100);
+        l.setText("Widgets with errors: " + noWidgetsWithFailures + " (" + ratio + " %)");
+        l.setLayoutData(createGridData(true));
+        l.setFont(font);
+        
+        l = new Label(parent, SWT.HORIZONTAL);
+        l.setText("Validated RO properties: " + noValidatedROProperties);
+        l.setLayoutData(createGridData(false));
+        
+        l = new Label(parent, SWT.HORIZONTAL);
+        ratio = (int)((noROPropertiesWithCriticalFailures/(double)noValidatedROProperties)*100);
+        int ratio1 = (int)((noROPropertiesWithMajorFailures/(double)noValidatedROProperties)*100);
+        l.setText("RO properties with major errors: " + noROPropertiesWithMajorFailures + " ("
+                    + ratio1 + " %)");
+        l.setLayoutData(createGridData(true));
+        l.setFont(font);
+        l = new Label(parent, SWT.HORIZONTAL);
+        l.setText("RO properties with critical errors: " + noROPropertiesWithCriticalFailures + " ("
+                + ratio + " %)");
+        l.setLayoutData(createGridData(true));
+        l.setFont(font);
+        
+        l = new Label(parent, SWT.HORIZONTAL);
+        l.setText("Validated WRITE properties: " + noValidatedWRITEProperties);
+        l.setLayoutData(createGridData(false));
+        l = new Label(parent, SWT.HORIZONTAL);
+        ratio = (int)((noWRITEPropertiesWithFailures/(double)noValidatedWRITEProperties)*100);
+        l.setText("WRITE properties with errors: " + noWRITEPropertiesWithFailures + " (" + ratio + " %)");
+        l.setLayoutData(createGridData(true));
+        l.setFont(font);
+    }
+    
+    private GridData createGridData(boolean indent) {
+        GridData d = new GridData(GridData.HORIZONTAL_ALIGN_FILL, GridData.VERTICAL_ALIGN_BEGINNING, true,false);
+        if (indent) {
+            d.horizontalIndent = 5;
+        } else {
+            d.verticalIndent = 5;
+        }
+        return d;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.jface.dialogs.Dialog#createButtonsForButtonBar(org.eclipse.swt.widgets.Composite)
+     */
+    @Override
+    protected void createButtonsForButtonBar(Composite parent) {
+        createButton(parent, IDialogConstants.OK_ID, IDialogConstants.CLOSE_LABEL, true);
+    }
+}

--- a/applications/plugins/pom.xml
+++ b/applications/plugins/pom.xml
@@ -91,6 +91,7 @@
     <module>org.csstudio.ndarray</module>
     <module>org.csstudio.numjy</module>
     <module>org.csstudio.opibuilder</module>
+    <module>org.csstudio.opibuilder.validation</module>
     <module>org.csstudio.opibuilder.adl2boy</module>
     <module>org.csstudio.opibuilder.alarm</module>
     <module>org.csstudio.opibuilder.converter</module>


### PR DESCRIPTION
Implementation of the OPI validation tool. It was written according to ITER specifications, but perhaps someone else may find it useful as well. That is why I put it into applications/plugins. 

It uses the eclipse wst.validation framework to validate an OPI file against the OPI Editor Schema according to the validation rules defined in the rules.def file (see Preferences -> Validation -> OPI Validation). Every property can be either 
- read-only: the value in the schema and the value in the OPI should always be the same
- write: the value in the OPI should always be different than in the schema
- read/write: whatever.
Quick fix is available for the read-only properties.

To use the tool include the it in the product definition or in one of the features. Be careful about its dependencies.