### PR TITLE
o.c.util.clock: Replace ViewPart with E4 Pojo

### DIFF
--- a/applications/plugins/org.csstudio.utility.clock/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.utility.clock/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Clock Plug-in
-Bundle-SymbolicName: org.csstudio.utility.clock; singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-SymbolicName: org.csstudio.utility.clock;singleton:=true
+Bundle-Version: 4.0.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.eclipse.e4.core.di,
+ org.eclipse.e4.core.di.extensions,
+ org.eclipse.e4.ui.model.workbench,
+ org.eclipse.e4.ui.di
+Import-Package: javax.annotation;version="1.1.0"
 Bundle-ActivationPolicy: lazy
-Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen 
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Description: Configurable Clock

--- a/applications/plugins/org.csstudio.utility.clock/plugin.xml
+++ b/applications/plugins/org.csstudio.utility.clock/plugin.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.0"?>
 <plugin>
 
    <extension
@@ -8,13 +7,13 @@
             name="CSS"
             id="org.csstudio">
       </category>
-      <view
-            name="Clock"
+      <e4view
+            name="%Clock"
             icon="icons/clock.png"
             category="org.csstudio"
             class="org.csstudio.utility.clock.ClockView"
-            id="org.csstudio.utility.clock.ClockView">
-      </view>
+            id="org.csstudio.utility.clock.view">
+      </e4view>
    </extension>
    <extension
          point="org.eclipse.help.toc">
@@ -35,7 +34,7 @@
                tooltip="%ShowClock">
             <parameter
                   name="org.eclipse.ui.views.showView.viewId"
-                  value="org.csstudio.utility.clock.ClockView">
+                  value="org.csstudio.utility.clock.view">
             </parameter>
          </command>
       </menuContribution>

--- a/applications/plugins/org.csstudio.utility.clock/src/org/csstudio/utility/clock/ClockView.java
+++ b/applications/plugins/org.csstudio.utility.clock/src/org/csstudio/utility/clock/ClockView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * Copyright (c) 2010, 2015 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,44 +7,30 @@
  ******************************************************************************/
 package org.csstudio.utility.clock;
 
-import org.csstudio.utility.clock.preferences.PreferencePage;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.ui.part.ViewPart;
+import javax.annotation.PostConstruct;
 
-/** ViewPart for the clock.
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.core.di.extensions.Preference;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+
+import static org.csstudio.utility.clock.preferences.PreferencePage.DEFAULT_HOURS;
+
+import static java.util.Objects.isNull;
+
+/** Part for the clock.
  *  @author Kay Kasemir
  */
-public class ClockView extends ViewPart
+@SuppressWarnings("restriction")
+public class ClockView
 {
-	public static final String ID = ClockView.class.getName();
-    // The one and only widget in this view
-    private ClockWidget clock;
-
     /** Fill the view. */
-    @Override
-    public void createPartControl(Composite parent)
+	@PostConstruct @Optional
+    public void createPartControl(final Composite parent,
+    		@Preference(value = "hours") final String hours_pref)
     {
-        GridLayout gl = new GridLayout();
-        gl.numColumns = 1;
-        parent.setLayout(gl);
-        GridData gd;
-
-        clock = new ClockWidget(PreferencePage.getHours(), parent, 0);
-        gd = new GridData();
-        gd.grabExcessHorizontalSpace = true;
-        gd.grabExcessVerticalSpace = true;
-        gd.horizontalAlignment = SWT.FILL;
-        gd.verticalAlignment = SWT.FILL;
-        clock.setLayoutData(gd);
-    }
-
-    /** Set focus on clock, though that's a NOP. */
-    @Override
-    public void setFocus()
-    {
-        clock.setFocus();
+        parent.setLayout(new FillLayout());
+        final int hours = isNull(hours_pref) ? DEFAULT_HOURS : Integer.parseInt(hours_pref);
+        new ClockWidget(hours, parent, 0);
     }
 }

--- a/applications/plugins/org.csstudio.utility.clock/src/org/csstudio/utility/clock/preferences/PreferencePage.java
+++ b/applications/plugins/org.csstudio.utility.clock/src/org/csstudio/utility/clock/preferences/PreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * Copyright (c) 2010, 2015 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,14 +62,5 @@ public class PreferencePage extends FieldEditorPreferencePage
                                              min, max));
         hour_editor.setValidRange(min, max);
         addField(hour_editor);
-    }
-
-    /** @return Total hour setting */
-    static public int getHours()
-    {
-        final IPreferencesService prefs = Platform.getPreferencesService();
-        if (prefs == null)
-            return DEFAULT_HOURS;
-        return prefs.getInt(Plugin.ID, P_HOURS, DEFAULT_HOURS, null);
     }
 }


### PR DESCRIPTION
Example for #1012:
'e4view' that allows using E4 Pojo in RCP. Part is now Pojo, using DI to get parent and preference setting.
Could have used the same ID as the View, but that creates problems when
existing workspace had already used View with that ID.
Command to open the view, Preference page and online help remain unchanged, they're provided by RCP on top of E4.