### PR TITLE
#799 fixing the core and application poms to include the released

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -206,7 +206,7 @@
 		</repository>
 		<repository>
 			<id>efx</id>
-			<url>http://download.eclipse.org/efxclipse/runtime-nightly/site</url>
+			<url>http://download.eclipse.org/efxclipse/runtime-released/1.2.0/site</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -209,7 +209,7 @@
 				</repository>
 				<repository>
 					<id>efx</id>
-					<url>http://download.eclipse.org/efxclipse/runtime-nightly/site</url>
+					<url>http://download.eclipse.org/efxclipse/runtime-released/1.2.0/site</url>
 					<layout>p2</layout>
 				</repository>
 			</repositories>


### PR DESCRIPTION
efxclipse p2 repository

-use a released verison of e(fx)clipse instead of the nightly releases
-include the required features in the products to ensure that logging.ui works with the javafxviews

Merge instructions:
command line build should continue work