### PR TITLE
o.c.o.widgets: correctly handle Meter's value label

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/MeterEditPart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/MeterEditPart.java
@@ -34,9 +34,9 @@ public final class MeterEditPart extends AbstractMarkedWidgetEditPart {
 		initializeCommonFigureProperties(xMeter, model);
 		xMeter.setNeedleColor((model.getNeedleColor()));
 		xMeter.setGradient(model.isRampGradient());
+		xMeter.setValueLabelVisibility(model.isShowValueLabelVisible());
 
 		return xMeter;
-
 	}
 
 	@Override

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/MeterModel.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/MeterModel.java
@@ -96,7 +96,11 @@ public class MeterModel extends AbstractMarkedWidgetModel{
 	public boolean isRampGradient() {
 		return (Boolean) getProperty(PROP_RAMP_GRADIENT).getPropertyValue();
 	}
-	
+
+	public boolean isShowValueLabelVisible() {
+		return (Boolean) getProperty(PROP_SHOW_VALUE_LABEL).getPropertyValue();
+	}
+
 	@Override
 	public boolean isTransparent() {
 		return false;


### PR DESCRIPTION
Before, if you deselect 'Show value label', in run mode
the value label is shown anyway.

As discussed in #1024.