### PR TITLE
o.c.opibuilder: avoid uncaught infinite loops in macro expansion

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/OPIBuilderMacroUtil.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/OPIBuilderMacroUtil.java
@@ -77,7 +77,7 @@ class WidgetMacroTableProvider implements IMacroTableProvider{
 		if(macroMap != null && macroMap.containsKey(macroName))
 			return macroMap.get(macroName);
 		else if(widgetModel.getAllPropertyIDs().contains(macroName)){
-			Object propertyValue = widgetModel.getPropertyValue(macroName);
+			Object propertyValue = widgetModel.getRawPropertyValue(macroName);
 			if(propertyValue != null)
 				return propertyValue.toString();
 		}		


### PR DESCRIPTION
If you used a macro in an OPI property, and refer to the property
in the macro, the infinite loop was not caught.

WidgetMacroTableProvider shouldn't try to replace macros itself.

As discussed in #1032.