### PR TITLE
o.c.scan: SequenceCommand needs empty constructor

### DIFF
--- a/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/SequenceCommand.java
+++ b/applications/plugins/org.csstudio.scan/src/org/csstudio/scan/command/SequenceCommand.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.csstudio.scan.command;
 
+import java.util.Collections;
 import java.util.List;
 
 /** Command that executes commands it its body
@@ -24,6 +25,12 @@ import java.util.List;
 @SuppressWarnings("nls")
 public class SequenceCommand extends ScanCommandWithBody
 {
+    /** Initialize with empty body */
+    public SequenceCommand()
+    {
+        super(Collections.emptyList());
+    }
+
     /** Initialize
      *  @param body Body commands, may be empty
      */


### PR DESCRIPTION
.. because that's called via reflection to for example put it into the
tree editor's command palette. Had deleted it because the var-arg
constructor is otherwise good enough, but turns out zero-arg constructor
is still needed.