### PR TITLE
Bugfix for linking container, connection

### DIFF
--- a/applications/plugins/org.csstudio.opibuilder.rap/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
+++ b/applications/plugins/org.csstudio.opibuilder.rap/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
@@ -36,6 +36,16 @@ public class ResourceUtilSSHelperImpl extends ResourceUtilSSHelper{
 	private static final String NOT_IMPLEMENTED = 
 			"This method has not been implemented yet for RAP";
 
+	@Override
+	public File getFile(IPath path) throws Exception {
+		File local_file = path.toFile();
+        // Path URL for "file:..." so that it opens as FileInputStream
+        if (local_file.getPath().startsWith("file:"))
+            local_file = new File(local_file.getPath().substring(5));
+        
+        return local_file.exists() ? local_file : null;
+	}
+	
 	/**
 	 * Return the {@link InputStream} of the file that is available on the
 	 * specified path.
@@ -177,9 +187,4 @@ public class ResourceUtilSSHelperImpl extends ResourceUtilSSHelper{
 	public Image getScreenShotImage(GraphicalViewer viewer) {
 		throw new RuntimeException(NOT_IMPLEMENTED);
 	}	
-
-	
-
-
-
 }

--- a/applications/plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
+++ b/applications/plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
@@ -37,7 +37,26 @@ import org.eclipse.ui.part.FileEditorInput;
  */
 public class ResourceUtilSSHelperImpl extends ResourceUtilSSHelper {
 
+    /*
+     * (non-Javadoc)
+     * @see org.csstudio.opibuilder.util.ResourceUtilSSHelper#getFile(org.eclipse.core.runtime.IPath)
+     */
+    @Override
+    public File getFile(IPath path) throws Exception {
+        final IFile workspace_file = getIFileFromIPath(path);
+        // Valid file should either open, or give meaningful exception
+        if (workspace_file != null  &&  workspace_file.exists())
+            return workspace_file.getLocation().toFile().getAbsoluteFile();
 
+        // Not a workspace file. Try local file system
+        File local_file = path.toFile();
+        // Path URL for "file:..." so that it opens as FileInputStream
+        if (local_file.getPath().startsWith("file:"))
+            local_file = new File(local_file.getPath().substring(5));
+        
+        return local_file.exists() ? local_file.getAbsoluteFile() : null;
+        
+    }
 
 	
 	/* (non-Javadoc)

--- a/applications/plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.epics.util;bundle-version="0.3.2",
  org.csstudio.csdata;bundle-version="3.2.0",
  org.jdom
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.csstudio.opibuilder.widgets.actions,
  org.csstudio.opibuilder.widgets.editparts,

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -150,16 +150,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 	 * @param path the path of the OPI file
 	 */
 	private synchronized void loadWidgets(final IPath path, final boolean checkSelf) {
-	  //remove all children of this linking container
-        DisplayModel display = getWidgetModel().getDisplayModel();
-        List<AbstractWidgetModel> models = new ArrayList<>(getWidgetModel().getChildren());
-        getWidgetModel().removeAllChildren();
-        if (display != null) {
-            //if any of the children are also present in the display, remove them as well
-            for (AbstractWidgetModel m : models) {
-                display.removeChild(m);
-            }
-        }
+	    getWidgetModel().removeAllChildren();
 		if(path ==null || path.isEmpty())
 			return;
 		try {
@@ -169,7 +160,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 		    String message = "Failed to load: " + path.toString() + "\n"+ e.getMessage();
             Activator.getLogger().log(Level.WARNING, message , e);
             ConsoleService.getInstance().writeError(message);
-            //TODO this might not work - depends on the exception that happened
+            //TODO because this might not work - depends on the type of exception that happened
 			LabelModel loadingErrorLabel = new LabelModel();
 			loadingErrorLabel.setLocation(0, 0);
 			loadingErrorLabel.setSize(getWidgetModel().getSize().getCopy().shrink(3, 3));
@@ -258,6 +249,9 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 			((LinkingContainerFigure)getFigure()).setZoomToFitAll(getWidgetModel().isAutoFit());
 			((LinkingContainerFigure)getFigure()).updateZoom();				
 		});
+		
+		DisplayModel parentDisplay = getWidgetModel().getRootDisplayModel();
+        parentDisplay.syncConnections();
 	}
 
 

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -150,7 +150,16 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 	 * @param path the path of the OPI file
 	 */
 	private synchronized void loadWidgets(final IPath path, final boolean checkSelf) {
-		getWidgetModel().removeAllChildren();
+	  //remove all children of this linking container
+        DisplayModel display = getWidgetModel().getDisplayModel();
+        List<AbstractWidgetModel> models = new ArrayList<>(getWidgetModel().getChildren());
+        getWidgetModel().removeAllChildren();
+        if (display != null) {
+            //if any of the children are also present in the display, remove them as well
+            for (AbstractWidgetModel m : models) {
+                display.removeChild(m);
+            }
+        }
 		if(path ==null || path.isEmpty())
 			return;
 		try {

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -68,13 +68,8 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 					//can happen before the parent is set.
 					return;
 				}
-				getViewer().getControl().getDisplay().timerExec(100,new Runnable() {
+				getViewer().getControl().getDisplay().asyncExec(() -> updateConnectionList());
 					
-					@Override
-					public void run() {
-						updateConnectionList();
-					}
-				});
 			}
 		});
 		return f;
@@ -98,15 +93,10 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 	public LinkingContainerModel getWidgetModel() {
 		return (LinkingContainerModel)getModel();
 	}
-	
-
 
 	@Override
 	protected void registerPropertyChangeHandlers() {
-		
-	    loadWidgets(getWidgetModel().getOPIFilePath(), true); 
-		configureDisplayModel();
-		
+				
 		IWidgetPropertyChangeHandler handler = new IWidgetPropertyChangeHandler(){
 			public boolean handleChange(Object oldValue, Object newValue,
 					IFigure figure) {
@@ -151,6 +141,8 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 			}
 		};
 		setPropertyChangeHandler(LinkingContainerModel.PROP_RESIZE_BEHAVIOUR, handler);
+		loadWidgets(getWidgetModel().getOPIFilePath(), true);
+        configureDisplayModel();
 	}
 
 
@@ -233,12 +225,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 		}			
 		if (originalPoints != null && !originalPoints.isEmpty())
 			//update connections after the figure is repainted.
-			getViewer().getControl().getDisplay().timerExec(100, new Runnable() {			
-				@Override
-				public void run() {
-					updateConnectionList();				
-				}
-			});
+			getViewer().getControl().getDisplay().asyncExec(() -> updateConnectionList());
 
 		//Add scripts on display model
 		if(getExecutionMode() == ExecutionMode.RUN_MODE)
@@ -248,21 +235,19 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 		if(getWidgetModel().isAutoSize()){
 			performAutosize();
 		}
-		UIBundlingThread.getInstance().addRunnable(new Runnable(){
-			public void run() {
-				layout();
-				if(//getExecutionMode() == ExecutionMode.RUN_MODE && 
-						!getWidgetModel().isAutoFit() && !getWidgetModel().isAutoSize()){					
-					Rectangle childrenRange = GeometryUtil.getChildrenRange(LinkingContainerEditpart.this);
-					getWidgetModel().setChildrenGeoSize(new Dimension(
-						childrenRange.width + childrenRange.x + figure.getInsets().left + figure.getInsets().right-1,
-						childrenRange.height +childrenRange.y+ figure.getInsets().top + figure.getInsets().bottom-1));
-					getWidgetModel().scaleChildren();
-				}
-				((LinkingContainerFigure)getFigure()).setShowScrollBars(getWidgetModel().isShowScrollBars());
-				((LinkingContainerFigure)getFigure()).setZoomToFitAll(getWidgetModel().isAutoFit());
-				((LinkingContainerFigure)getFigure()).updateZoom();				
+		UIBundlingThread.getInstance().addRunnable(() -> {
+			layout();
+			if(//getExecutionMode() == ExecutionMode.RUN_MODE && 
+					!getWidgetModel().isAutoFit() && !getWidgetModel().isAutoSize()){					
+				Rectangle childrenRange = GeometryUtil.getChildrenRange(LinkingContainerEditpart.this);
+				getWidgetModel().setChildrenGeoSize(new Dimension(
+					childrenRange.width + childrenRange.x + figure.getInsets().left + figure.getInsets().right-1,
+					childrenRange.height +childrenRange.y+ figure.getInsets().top + figure.getInsets().bottom-1));
+				getWidgetModel().scaleChildren();
 			}
+			((LinkingContainerFigure)getFigure()).setShowScrollBars(getWidgetModel().isShowScrollBars());
+			((LinkingContainerFigure)getFigure()).setZoomToFitAll(getWidgetModel().isAutoFit());
+			((LinkingContainerFigure)getFigure()).updateZoom();				
 		});
 	}
 
@@ -325,14 +310,8 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 	@Override
 	protected synchronized void doRefreshVisuals(IFigure refreshableFigure) {
 		super.doRefreshVisuals(refreshableFigure);
-		
 		//update connections after the figure is repainted.
-		getViewer().getControl().getDisplay().timerExec(100, new Runnable() {			
-			@Override
-			public void run() {
-				updateConnectionList();				
-			}
-		});
+		getViewer().getControl().getDisplay().asyncExec(() ->updateConnectionList());				
 		
 	}
 	

--- a/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -50,7 +50,7 @@ import org.eclipse.ui.IActionFilter;
  */
 public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 	
-	private static int linkingContainerID = 0;
+    private static int linkingContainerID = 0;
 
 	private List<ConnectionModel> connectionList;
 	private Map<ConnectionModel, PointList> originalPoints;
@@ -104,6 +104,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 	@Override
 	protected void registerPropertyChangeHandlers() {
 		
+	    loadWidgets(getWidgetModel().getOPIFilePath(), true); 
 		configureDisplayModel();
 		
 		IWidgetPropertyChangeHandler handler = new IWidgetPropertyChangeHandler(){
@@ -160,20 +161,21 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 		getWidgetModel().removeAllChildren();
 		if(path ==null || path.isEmpty())
 			return;
-
 		try {
 			XMLUtil.fillLinkingContainer(getWidgetModel());
 		} catch (Exception e) {
+		    //log first
+		    String message = "Failed to load: " + path.toString() + "\n"+ e.getMessage();
+            Activator.getLogger().log(Level.WARNING, message , e);
+            ConsoleService.getInstance().writeError(message);
+            //TODO this might not work - depends on the exception that happened
 			LabelModel loadingErrorLabel = new LabelModel();
 			loadingErrorLabel.setLocation(0, 0);
 			loadingErrorLabel.setSize(getWidgetModel().getSize().getCopy().shrink(3, 3));
 			loadingErrorLabel.setForegroundColor(CustomMediaFactory.COLOR_RED);
-			String message = "Failed to load: " + path.toString() + "\n"+ e.getMessage();
 			loadingErrorLabel.setText(message);
 			loadingErrorLabel.setName("Label");
 			getWidgetModel().addChild(loadingErrorLabel);
-			Activator.getLogger().log(Level.WARNING, message , e);
-			ConsoleService.getInstance().writeError(message);
 		}
 	}
 

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/OPIBuilderPlugin.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/OPIBuilderPlugin.java
@@ -83,6 +83,11 @@ public class OPIBuilderPlugin extends AbstractUIPlugin {
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
+		
+		//set this to resolve Xincludes in XMLs
+        System.setProperty("org.apache.xerces.xni.parser.XMLParserConfiguration",
+                "org.apache.xerces.parsers.XIncludeParserConfiguration");
+		
 		if(isRAP)
 			SingleSourceHelper.rapPluginStartUp();
 		

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractWidgetModel.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractWidgetModel.java
@@ -934,8 +934,10 @@ public abstract class AbstractWidgetModel implements IAdaptable,
 		{
 		    // If parent is a linking container,
 		    // use the display model of that
-		    if (parent instanceof AbstractLinkingContainerModel)
-		        return ((AbstractLinkingContainerModel)parent).getDisplayModel();
+		    if (parent instanceof AbstractLinkingContainerModel) {
+		        DisplayModel m = ((AbstractLinkingContainerModel)parent).getDisplayModel();
+		        if (m != null) return m;
+		    }
 		    // Otherwise follow links up the parent chain
 			parent = parent.getParent();
 		}

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/ConnectionModel.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/ConnectionModel.java
@@ -360,6 +360,41 @@ public class ConnectionModel extends AbstractWidgetModel {
 			isConnected = true;
 		}
 	}
+	
+	/**
+	 * Resync this connection with its source and target.
+	 */
+	public void resync() {
+	    if (source == null || target == null) {
+            return;
+        }
+	    boolean connected = isConnected;
+	    disconnect();
+	    String wuid = target.getWUID();
+        String path = getPropertyValue(PROP_TGT_PATH).toString();
+        AbstractWidgetModel w = null; 
+        if(path == null || path.equals("")){
+            w = getTerminal(displayModel, null, wuid);
+        }else {
+            List<String> paths = Arrays.asList(path.split(PATH_DELIMITER));
+            w = getTerminal(displayModel, paths, wuid);
+        }
+        setTarget(w);
+        
+        wuid = source.getWUID();
+        path = getPropertyValue(PROP_SRC_PATH).toString();
+        w = null;
+        if(path == null || path.equals("")){
+            w = getTerminal(displayModel, null, wuid);
+        }else {
+            List<String> paths = Arrays.asList(path.split(PATH_DELIMITER));
+            w = getTerminal(displayModel, paths, wuid);
+        }
+        setSource(w);
+        if (connected) {
+            reconnect();
+        }
+	}
 
 	/**
 	 * Reconnect to a different source and/or target shape. The connection will
@@ -430,6 +465,14 @@ public class ConnectionModel extends AbstractWidgetModel {
 	public int getLineWidth() {
 		return (Integer) getPropertyValue(PROP_LINE_WIDTH);
 	}
+	
+	public String[] getTargetPath() {
+	    return ((String)getPropertyValue(PROP_TGT_PATH)).split(PATH_DELIMITER);
+	}
+	
+	public String[] getSourcePath() {
+        return ((String)getPropertyValue(PROP_SRC_PATH)).split(PATH_DELIMITER);
+    }
 
 	/**
 	 * @return SWT line style

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
@@ -8,7 +8,9 @@
 package org.csstudio.opibuilder.model;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.csstudio.opibuilder.datadefinition.DisplayScaleData;
 import org.csstudio.opibuilder.properties.ActionsProperty;
@@ -268,7 +270,7 @@ public class DisplayModel extends AbstractContainerModel {
 	}
 	
 	private List<ConnectionModel> getConnectionList(AbstractContainerModel container){
-		List<ConnectionModel> connectionModels = new ArrayList<ConnectionModel>();
+		Set<ConnectionModel> connectionModels = new HashSet<ConnectionModel>();
 		List<AbstractWidgetModel> allDescendants = getAllDescendants();
 		for(AbstractWidgetModel widget : allDescendants){
 			if(!widget.getSourceConnections().isEmpty()){
@@ -277,9 +279,16 @@ public class DisplayModel extends AbstractContainerModel {
 						connectionModels.add(connectionModel);
 					}
 				}
-			}			
+			} 
+			if(!widget.getTargetConnections().isEmpty()){
+                for(ConnectionModel connectionModel: widget.getTargetConnections()){
+                    if(allDescendants.contains(connectionModel.getSource())){
+                        connectionModels.add(connectionModel);
+                    }
+                }
+            } 
 		}		
-		return connectionModels;
+		return new ArrayList<>(connectionModels);
 	}
 
 	public AbstractWidgetModel getWidgetFromWUID(String wuid) {

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
@@ -269,6 +269,33 @@ public class DisplayModel extends AbstractContainerModel {
 		return getConnectionList(this);
 	}
 	
+	/**
+	 * In connections are spanning over multiple display models (e.g. via linking containers),
+	 * and if one of those sub display models is reloaded, all the links will become invalid - 
+	 * the previously existing widgets will no longer exist. This methods intends to reconnect
+	 * such broken connections, by resetting the connectors sources and targets. 
+	 */
+	public void syncConnections() {
+        List<AbstractWidgetModel> allDescendants = getAllDescendants();
+        for(AbstractWidgetModel widget : allDescendants){
+            if(!widget.getSourceConnections().isEmpty()){
+                for(ConnectionModel connectionModel: widget.getSourceConnections()){
+                    if(!allDescendants.contains(connectionModel.getTarget())){
+                        //the target model no longer exists, perhaps it was reloaded
+                        connectionModel.resync();
+                    }
+                }
+            } 
+            if(!widget.getTargetConnections().isEmpty()){
+                for(ConnectionModel connectionModel: widget.getTargetConnections()){
+                    if(!allDescendants.contains(connectionModel.getSource())){
+                        connectionModel.resync();
+                    }
+                }
+            } 
+        }       
+	}
+		
 	private List<ConnectionModel> getConnectionList(AbstractContainerModel container){
 		Set<ConnectionModel> connectionModels = new HashSet<ConnectionModel>();
 		List<AbstractWidgetModel> allDescendants = getAllDescendants();

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
@@ -15,12 +15,9 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
@@ -56,581 +53,569 @@ import org.osgi.framework.Version;
  */
 public class XMLUtil {
 
-	public static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"; //$NON-NLS-1$
+    public static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"; //$NON-NLS-1$
 
-	public static String XMLTAG_DISPLAY = "display"; //$NON-NLS-1$
+    public static String XMLTAG_DISPLAY = "display"; //$NON-NLS-1$
 
-	public static String XMLTAG_WIDGET = "widget"; //$NON-NLS-1$
-	
-	public static String XMLTAG_CONNECTION = "connection"; //$NON-NLS-1$
-	
-	public static Set<String> WIDGET_TAGS = 
-			new HashSet<String>(Arrays.asList(XMLTAG_DISPLAY, XMLTAG_WIDGET, XMLTAG_CONNECTION));
-	
-	public static String XMLATTR_TYPEID = "typeId"; //$NON-NLS-1$
+    public static String XMLTAG_WIDGET = "widget"; //$NON-NLS-1$
+    
+    public static String XMLTAG_CONNECTION = "connection"; //$NON-NLS-1$
+    
+    public static Set<String> WIDGET_TAGS = 
+            new HashSet<String>(Arrays.asList(XMLTAG_DISPLAY, XMLTAG_WIDGET, XMLTAG_CONNECTION));
+    
+    public static String XMLATTR_TYPEID = "typeId"; //$NON-NLS-1$
 
-	public static String XMLATTR_PROPID = "id"; //$NON-NLS-1$
-	public static String XMLATTR_VERSION = "version"; //$NON-NLS-1$
+    public static String XMLATTR_PROPID = "id"; //$NON-NLS-1$
+    public static String XMLATTR_VERSION = "version"; //$NON-NLS-1$
 
-	public static String XMLTAG_WIDGET_UID = AbstractWidgetModel.PROP_WIDGET_UID; //$NON-NLS-1$
-	public static String XMLTAG_OPI_FILE = AbstractLinkingContainerModel.PROP_OPI_FILE;
-	
-	/**Flatten a widget to XML element.
-	 * @param widgetModel model of the widget
-	 * @return the XML element
-	 */
-	public static Element widgetToXMLElement(AbstractWidgetModel widgetModel){
+    public static String XMLTAG_WIDGET_UID = AbstractWidgetModel.PROP_WIDGET_UID; //$NON-NLS-1$
+    public static String XMLTAG_OPI_FILE = AbstractLinkingContainerModel.PROP_OPI_FILE;
+    
+    /**Flatten a widget to XML element.
+     * @param widgetModel model of the widget
+     * @return the XML element
+     */
+    public static Element widgetToXMLElement(AbstractWidgetModel widgetModel){
 
-		Element result = new Element((widgetModel instanceof DisplayModel) ? XMLTAG_DISPLAY :
-			(widgetModel instanceof ConnectionModel) ? XMLTAG_CONNECTION : XMLTAG_WIDGET);
-		result.setAttribute(XMLATTR_TYPEID, widgetModel.getTypeID());
-		result.setAttribute(XMLATTR_VERSION, widgetModel.getVersion().toString());
-		for(String propId : widgetModel.getAllPropertyIDs()){
-			if(widgetModel.getProperty(propId).isSavable()){
-				Element propElement = new Element(propId);
-				widgetModel.getProperty(propId).writeToXML(propElement);
-				result.addContent(propElement);
-			}
-		}
+        Element result = new Element((widgetModel instanceof DisplayModel) ? XMLTAG_DISPLAY :
+            (widgetModel instanceof ConnectionModel) ? XMLTAG_CONNECTION : XMLTAG_WIDGET);
+        result.setAttribute(XMLATTR_TYPEID, widgetModel.getTypeID());
+        result.setAttribute(XMLATTR_VERSION, widgetModel.getVersion().toString());
+        for(String propId : widgetModel.getAllPropertyIDs()){
+            if(widgetModel.getProperty(propId).isSavable()){
+                Element propElement = new Element(propId);
+                widgetModel.getProperty(propId).writeToXML(propElement);
+                result.addContent(propElement);
+            }
+        }
 
-		if(widgetModel instanceof AbstractContainerModel && !(widgetModel instanceof AbstractLinkingContainerModel)){
-			AbstractContainerModel containerModel = (AbstractContainerModel)widgetModel;
-			for(AbstractWidgetModel child : containerModel.getChildren()){
-				result.addContent(widgetToXMLElement(child));
-			}
-		}
-		
-		//convert connections on this displayModel to xml element
-		if(widgetModel instanceof DisplayModel && 
-				((DisplayModel)widgetModel).getConnectionList() != null){			
-			for(ConnectionModel connectionModel : ((DisplayModel)widgetModel).getConnectionList()){
-				if(!connectionModel.isLoadedFromLinkedOpi()) {
-					Element connElement = widgetToXMLElement(connectionModel);
-					result.addContent(connElement);
-				}
-			}		
-		}
+        if(widgetModel instanceof AbstractContainerModel && !(widgetModel instanceof AbstractLinkingContainerModel)){
+            AbstractContainerModel containerModel = (AbstractContainerModel)widgetModel;
+            for(AbstractWidgetModel child : containerModel.getChildren()){
+                result.addContent(widgetToXMLElement(child));
+            }
+        }
+        
+        //convert connections on this displayModel to xml element
+        if(widgetModel instanceof DisplayModel && 
+                ((DisplayModel)widgetModel).getConnectionList() != null){           
+            for(ConnectionModel connectionModel : ((DisplayModel)widgetModel).getConnectionList()){
+                if(!connectionModel.isLoadedFromLinkedOpi()) {
+                    Element connElement = widgetToXMLElement(connectionModel);
+                    result.addContent(connElement);
+                }
+            }       
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	/**Flatten a widget to XML String.
-	 * @param widgetModel model of the widget.
-	 * @param prettyFormat true if the string is in pretty format
-	 * @return the XML String
-	 */
-	public static String widgetToXMLString(AbstractWidgetModel widgetModel, boolean prettyFormat){
-		Format format = Format.getRawFormat();		
-		if(prettyFormat)
-			format.setIndent("  "); //$NON-NLS-1$
-		XMLOutputter xmlOutputter = new XMLOutputter();
-		xmlOutputter.setFormat(format);
+    /**Flatten a widget to XML String.
+     * @param widgetModel model of the widget.
+     * @param prettyFormat true if the string is in pretty format
+     * @return the XML String
+     */
+    public static String widgetToXMLString(AbstractWidgetModel widgetModel, boolean prettyFormat){
+        Format format = Format.getRawFormat();      
+        if(prettyFormat)
+            format.setIndent("  "); //$NON-NLS-1$
+        XMLOutputter xmlOutputter = new XMLOutputter();
+        xmlOutputter.setFormat(format);
 
-		return xmlOutputter.outputString(widgetToXMLElement(widgetModel));
-	}
+        return xmlOutputter.outputString(widgetToXMLElement(widgetModel));
+    }
 
-	/**Write widget to an output stream.
-	 * @param widgetModel model of the widget
-	 * @param out output stream
-	 * @param prettyFormat true if in pretty format
-	 * @throws IOException
-	 */
-	public static void widgetToOutputStream(AbstractWidgetModel widgetModel, OutputStream out, boolean prettyFormat) throws IOException{
-		Format format = Format.getRawFormat();		
-		if(prettyFormat)
-			format.setIndent("  "); //$NON-NLS-1$
-		XMLOutputter xmlOutputter = new XMLOutputter(format);
-		out.write(XML_HEADER.getBytes("UTF-8")); //$NON-NLS-1$
-		xmlOutputter.output(widgetToXMLElement(widgetModel), out);
-	}
+    /**Write widget to an output stream.
+     * @param widgetModel model of the widget
+     * @param out output stream
+     * @param prettyFormat true if in pretty format
+     * @throws IOException
+     */
+    public static void widgetToOutputStream(AbstractWidgetModel widgetModel, OutputStream out, boolean prettyFormat) throws IOException{
+        Format format = Format.getRawFormat();      
+        if(prettyFormat)
+            format.setIndent("  "); //$NON-NLS-1$
+        XMLOutputter xmlOutputter = new XMLOutputter(format);
+        out.write(XML_HEADER.getBytes("UTF-8")); //$NON-NLS-1$
+        xmlOutputter.output(widgetToXMLElement(widgetModel), out);
+    }
 
+    /**Convert an XML String to widget model
+     * @param xmlString
+     * @return the widget model
+     * @throws Exception
+     */
+    public static AbstractWidgetModel XMLStringToWidget(String xmlString) throws Exception{
+        return XMLElementToWidget(stringToXML(xmlString));
+    }
 
-	/**Convert an XML String to widget model
-	 * @param xmlString
-	 * @return the widget model
-	 * @throws Exception
-	 */
-	public static AbstractWidgetModel XMLStringToWidget(String xmlString) throws Exception{
-		return XMLElementToWidget(stringToXML(xmlString));
-	}
+    /**Convert an XML element to widget.
+     * @param element the element
+     * @return model of the widget.
+     * @throws Exception
+     */
+    public static AbstractWidgetModel XMLElementToWidget(Element element) throws Exception {
+        return XMLElementToWidget(element, null);
+    }
 
-	/**Convert an XML element to widget.
-	 * @param element the element
-	 * @return model of the widget.
-	 * @throws Exception
-	 */
-	public static AbstractWidgetModel XMLElementToWidget(Element element) throws Exception {
-	    Map<Element,ConnectionModel> connections = new HashMap<>();
-		AbstractWidgetModel model = XMLElementToWidget(element, null, connections);
-		addConnections(connections);
-		return model;
-	}
+    /**Fill the DisplayModel from an OPI file inputstream
+     * @param inputStream the inputstream will be closed in this method before return.
+     * @param displayModel. The {@link DisplayModel} to be filled.
+     * @param display the display in UI Thread.
+     * @throws Exception
+     */
+    public static void fillDisplayModelFromInputStream(
+            final InputStream inputStream, final DisplayModel displayModel, Display display) throws Exception{
+        fillDisplayModelFromInputStreamSub(inputStream, displayModel, display, new ArrayList<IPath>());
+    }
+    
+    private static void fillDisplayModelFromInputStreamSub(
+            final InputStream inputStream, final DisplayModel displayModel, Display display, List<IPath> trace)
+                    throws Exception{
+    
+        if(display == null){
+            display = Display.getCurrent();
+        }
+        IPath opiPath = displayModel.getOpiFilePath();
+        if (OPIBuilderPlugin.isRAP() && opiPath != null
+                && !SingleSourceHelper.rapIsLoggedIn(display)) {
+            //check secured opi paths
+            String[] securedPaths = PreferencesHelper.getSecuredOpiPaths();
+            if (securedPaths != null){
+                for(String securedPath : securedPaths){
+                    if(opiPath.toString().startsWith(securedPath)) {
+                        if (!SingleSourceHelper.rapAuthenticate(display)) {
+                            inputStream.close();
+                            throw new FailedLoginException();
+                        }
+                    }
+                }               
+            }
+            //check unsecured opi paths
+            if(PreferencesHelper.isWholeSiteSecured()){
+                String[] unSecuredPaths = PreferencesHelper.getUnSecuredOpiPaths();
+                if (unSecuredPaths != null){
+                    boolean shouldBeSecured=true;
+                    for(String unSecuredPath : unSecuredPaths){
+                        if(opiPath.toString().startsWith(unSecuredPath)) {
+                            shouldBeSecured=false;
+                            break;
+                        }
+                    }               
+                    if(shouldBeSecured){
+                        if (!SingleSourceHelper.rapAuthenticate(display)) {
+                            inputStream.close();
+                            throw new FailedLoginException();
+                        }
+                    }
+                }
+            }
+            
+        }
+        
+        Element root = inputStreamToXML(inputStream);
+        if(root != null){
+             XMLElementToWidgetSub(root, displayModel, trace);
+             
+             //check version
+             if(compareVersion(displayModel.getBOYVersion(),
+                     OPIBuilderPlugin.getDefault().getBundle().getVersion()) > 0){              
+                final String message = displayModel.getOpiFilePath() == null ? "This OPI"
+                        : displayModel.getOpiFilePath().lastSegment()
+                                + " was created in a newer version of BOY ("
+                                + displayModel.getBOYVersion().toString()
+                                + "). It may not function properly! "
+                                + "Please update your " + 
+                                (OPIBuilderPlugin.isRAP()? "WebOPI":"BOY") 
+                                + " (" + OPIBuilderPlugin.getDefault().getBundle().getVersion() +
+                                ") to the latest version.";
+                if(display == null){
+                    display = Display.getDefault();
+                }
+                if (display != null)
+                    display.asyncExec(new Runnable() {
+                        @Override
+                        public void run() {
+//                          MessageDialog.openWarning(null, "Warning", message);
+                            ConsoleService.getInstance().writeWarning(message);
+                            OPIBuilderPlugin.getLogger().log(Level.WARNING,
+                                    message); //$NON-NLS-1$ 
+                        }
+                    });         
+             }   
+             
+        }
+        inputStream.close();
+    }
 
-	/**Fill the DisplayModel from an OPI file inputstream
-	 * @param inputStream the inputstream will be closed in this method before return.
-	 * @param displayModel. The {@link DisplayModel} to be filled.
-	 * @param display the display in UI Thread.
-	 * @param mapToReceiveConnections a map to which all connections will be added so that they can be handled last
-	 * @throws Exception
-	 */
-	public static void fillDisplayModelFromInputStream(
-			final InputStream inputStream, final DisplayModel displayModel, Display display) throws Exception{
-		fillDisplayModelFromInputStreamSub(inputStream, displayModel, display, new ArrayList<IPath>());
-	}
-
-	private static void fillDisplayModelFromInputStreamSub(
-			final InputStream inputStream, final DisplayModel displayModel, Display display, List<IPath> trace) throws Exception{	
-		if(display == null){
-			display = Display.getCurrent();
-		}
-		IPath opiPath = displayModel.getOpiFilePath();
-		if (OPIBuilderPlugin.isRAP() && opiPath != null
-				&& !SingleSourceHelper.rapIsLoggedIn(display)) {
-			//check secured opi paths
-			String[] securedPaths = PreferencesHelper.getSecuredOpiPaths();
-			if (securedPaths != null){
-				for(String securedPath : securedPaths){
-					if(opiPath.toString().startsWith(securedPath)) {
-						if (!SingleSourceHelper.rapAuthenticate(display)) {
-							inputStream.close();
-							throw new FailedLoginException();
-						}
-					}
-				}				
-			}
-			//check unsecured opi paths
-			if(PreferencesHelper.isWholeSiteSecured()){
-				String[] unSecuredPaths = PreferencesHelper.getUnSecuredOpiPaths();
-				if (unSecuredPaths != null){
-					boolean shouldBeSecured=true;
-					for(String unSecuredPath : unSecuredPaths){
-						if(opiPath.toString().startsWith(unSecuredPath)) {
-							shouldBeSecured=false;
-							break;
-						}
-					}				
-					if(shouldBeSecured){
-						if (!SingleSourceHelper.rapAuthenticate(display)) {
-							inputStream.close();
-							throw new FailedLoginException();
-						}
-					}
-				}
-			}
-			
-		}
-		
-		Element root = inputStreamToXML(inputStream);
-		if(root != null){
-			 XMLElementToWidgetSub(root, displayModel, trace);
-			 
-			 //check version
-			 if(compareVersion(displayModel.getBOYVersion(),
-					 OPIBuilderPlugin.getDefault().getBundle().getVersion()) > 0){				
-				final String message = displayModel.getOpiFilePath() == null ? "This OPI"
-						: displayModel.getOpiFilePath().lastSegment()
-								+ " was created in a newer version of BOY ("
-								+ displayModel.getBOYVersion().toString()
-								+ "). It may not function properly! "
-								+ "Please update your " + 
-								(OPIBuilderPlugin.isRAP()? "WebOPI":"BOY") 
-								+ " (" + OPIBuilderPlugin.getDefault().getBundle().getVersion() +
-								") to the latest version.";
-				if(display == null){
-					display = Display.getDefault();
-				}
-				if (display != null)
-					display.asyncExec(new Runnable() {
-						@Override
-						public void run() {
-//							MessageDialog.openWarning(null, "Warning", message);
-							ConsoleService.getInstance().writeWarning(message);
-							OPIBuilderPlugin.getLogger().log(Level.WARNING,
-						            message); //$NON-NLS-1$	
-						}
-					});			
-			 }	 
-			 
-		}
-		inputStream.close();
-	}
-
-	/**Fill the DisplayModel from an OPI file inputstream. In RAP, it must be called in UI Thread.
-	 * @param inputStream the inputstream will be closed in this method before return.
-	 * @param displayModel
-	 * @throws Exception
-	 */
-	public static void fillDisplayModelFromInputStream(
-			final InputStream inputStream, final DisplayModel displayModel) throws Exception {
-	    Map<Element,ConnectionModel> connections = new HashMap<>();
-	    fillDisplayModelFromInputStream(inputStream, displayModel, connections, null);
-		addConnections(connections);
-	}
+    /**Fill the DisplayModel from an OPI file inputstream. In RAP, it must be called in UI Thread.
+     * @param inputStream the inputstream will be closed in this method before return.
+     * @param displayModel
+     * @throws Exception
+     */
+    public static void fillDisplayModelFromInputStream(
+            final InputStream inputStream, final DisplayModel displayModel) throws Exception {
+        fillDisplayModelFromInputStream(inputStream, displayModel, null);
+    }
 
 
-	/**Construct widget model from XML element. Sometimes it includes filling LinkingContainer and/or construct Connection model between widgets.
-	 * @param element
-	 * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
-	 * instead of creating a new one. If this is null, a new one will be created.
-	 * @param mapToReceiveConnections the map to which all found connections will be added so that they can be added 
-	 *         to the canvas last 
-	 * @return the root widget model
-	 * @throws Exception
-	 */
-	public static AbstractWidgetModel XMLElementToWidget(Element element, DisplayModel displayModel) throws Exception{
-		return XMLElementToWidgetSub(element, displayModel, new ArrayList<IPath> ());
-	}
+    /**Construct widget model from XML element. Sometimes it includes filling LinkingContainer and/or construct Connection model between widgets.
+     * @param element
+     * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
+     * instead of creating a new one. If this is null, a new one will be created. 
+     * @return the root widget model
+     * @throws Exception
+     */
+    public static AbstractWidgetModel XMLElementToWidget(Element element, DisplayModel displayModel) throws Exception{
+        return XMLElementToWidgetSub(element, displayModel, new ArrayList<IPath> ());
+    }
 
-	private static AbstractWidgetModel XMLElementToWidgetSub(Element element, DisplayModel displayModel, List<IPath> trace) throws Exception{
-		if(element == null) return null;
+    private static AbstractWidgetModel XMLElementToWidgetSub(Element element, DisplayModel displayModel, List<IPath> trace) throws Exception{
+        if(element == null) return null;
 
-		AbstractWidgetModel result = null;
+        AbstractWidgetModel result = null;
 
-		if(WIDGET_TAGS.contains(element.getName())) {
-			result = fillWidgets(element, displayModel);
-			
-			if(result instanceof AbstractContainerModel)
-				fillLinkingContainersSub((AbstractContainerModel)result, trace);
-			fillConnections(element, displayModel);
+        if(WIDGET_TAGS.contains(element.getName())) {
+            result = fillWidgets(element, displayModel);
+            
+            if(result instanceof AbstractContainerModel)
+                fillLinkingContainersSub((AbstractContainerModel)result, trace);
+            fillConnections(element, displayModel);
 
-			return result;
-		} else {
-			String errorMessage = "Unknown Tag: " + element.getName();
-			ConsoleService.getInstance().writeError(errorMessage);
-			return null;
-		}
-	}
+            return result;
+        } else {
+            String errorMessage = "Unknown Tag: " + element.getName();
+            ConsoleService.getInstance().writeError(errorMessage);
+            return null;
+        }
+    }
 
-	/**Convert XML String to a widget model.
-	 * @param xmlString
-	 * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
-	 * instead of creating a new one. If this is null, a new one will be created. 
-	 * @throws Exception
-	 */
-	public static AbstractWidgetModel fillWidgetsFromXMLString(String xmlString, DisplayModel displayModel) throws Exception {
-		return fillWidgets(stringToXML(xmlString), displayModel);
-	}
+    /**Convert XML String to a widget model.
+     * @param xmlString
+     * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
+     * instead of creating a new one. If this is null, a new one will be created. 
+     * @throws Exception
+     */
+    public static AbstractWidgetModel fillWidgetsFromXMLString(String xmlString, DisplayModel displayModel) throws Exception {
+        return fillWidgets(stringToXML(xmlString), displayModel);
+    }
 
-	/**Convert XML Element to a widget model.
-	 * @param element
-	 * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
-	 * instead of creating a new one. If this is null, a new one will be created. 
-	 * @throws Exception
-	 */
-	@SuppressWarnings("rawtypes")
-	private static AbstractWidgetModel fillWidgets(Element element, DisplayModel displayModel) throws Exception{
-		if(element == null) return null;
-		
-		AbstractWidgetModel rootWidgetModel = null;
-		
-		//Determine root widget model
-		if(element.getName().equals(XMLTAG_DISPLAY)){
-			if(displayModel != null)
-				rootWidgetModel =displayModel;
-			else
-				rootWidgetModel = new DisplayModel(null);
-		}else if(element.getName().equals(XMLTAG_WIDGET)){
-			String typeId = element.getAttributeValue(XMLATTR_TYPEID);
-			WidgetDescriptor desc = WidgetsService.getInstance().getWidgetDescriptor(typeId);
-			if(desc != null)
-				rootWidgetModel = desc.getWidgetModel();
-			if(rootWidgetModel == null){
-				String errorMessage = NLS.bind("Fail to load the widget: {0}\n " +
-					"The widget may not exist, as a consequence, the widget will be ignored.", typeId);
-				ErrorHandlerUtil.handleError(errorMessage, new Exception("Widget does not exist."));
-				return null;
-			}
-		}else if(element.getName().equals(XMLTAG_CONNECTION)){
-			rootWidgetModel = new ConnectionModel(displayModel);			
-		}else {
-			String errorMessage = "Unknown Tag: " + element.getName();
-			ConsoleService.getInstance().writeError(errorMessage);
-			return null;
-		}
+    /**Convert XML Element to a widget model.
+     * @param element
+     * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
+     * instead of creating a new one. If this is null, a new one will be created. 
+     * @throws Exception
+     */
+    @SuppressWarnings("rawtypes")
+    public static AbstractWidgetModel fillWidgets(Element element, DisplayModel displayModel) throws Exception{
+        if(element == null) return null;
+        
+        AbstractWidgetModel rootWidgetModel = null;
+        
+        //Determine root widget model
+        if(element.getName().equals(XMLTAG_DISPLAY)){
+            if(displayModel != null)
+                rootWidgetModel =displayModel;
+            else
+                rootWidgetModel = new DisplayModel(null);
+        }else if(element.getName().equals(XMLTAG_WIDGET)){
+            String typeId = element.getAttributeValue(XMLATTR_TYPEID);
+            WidgetDescriptor desc = WidgetsService.getInstance().getWidgetDescriptor(typeId);
+            if(desc != null)
+                rootWidgetModel = desc.getWidgetModel();
+            if(rootWidgetModel == null){
+                String errorMessage = NLS.bind("Fail to load the widget: {0}\n " +
+                    "The widget may not exist, as a consequence, the widget will be ignored.", typeId);
+                ErrorHandlerUtil.handleError(errorMessage, new Exception("Widget does not exist."));
+                return null;
+            }
+        }else if(element.getName().equals(XMLTAG_CONNECTION)){
+            rootWidgetModel = new ConnectionModel(displayModel);            
+        }else {
+            String errorMessage = "Unknown Tag: " + element.getName();
+            ConsoleService.getInstance().writeError(errorMessage);
+            return null;
+        }
 
-		setPropertiesFromXML(element, rootWidgetModel); 
+        setPropertiesFromXML(element, rootWidgetModel); 
 
-		if(rootWidgetModel instanceof AbstractContainerModel) {
-			AbstractContainerModel container = (AbstractContainerModel)rootWidgetModel;
-			List children = element.getChildren();
-			Iterator iterator = children.iterator();
-			while (iterator.hasNext()) {
-				Element subElement = (Element) iterator.next();
-				if(subElement.getName().equals(XMLTAG_WIDGET)) 
-					container.addChild(fillWidgets(subElement, displayModel));
-			}
-		}
-		
-		
-		if(displayModel !=null)
-			rootWidgetModel.processVersionDifference(displayModel.getBOYVersion());
-		
-		return rootWidgetModel;
-	}
-	
-	/**
-	 * Fill all LinkingContainers under the model.
-	 * 
-	 * @param container LinkingContainer to be filled.
-	 * @throws Exception
-	 */
-	public static void fillLinkingContainers(AbstractContainerModel container) throws Exception {
-	    Map<Element, ConnectionModel> connections = new HashMap<>();
-		fillLinkingContainersSub(container, new ArrayList<IPath>(), connections);
-		addConnections(connections);
-	}
-	
-	private static void fillLinkingContainersSub(AbstractContainerModel container, List<IPath> trace, 
-	        Map<Element,ConnectionModel> mapToReceiveConnections) throws Exception{
-		if(container instanceof AbstractLinkingContainerModel) {
-			AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)container;
-			List<IPath> tempTrace = new ArrayList<IPath>();
-			tempTrace.addAll(trace);
-			fillLinkingContainerSub(linkingContainer, tempTrace, mapToReceiveConnections);
-		}
+        if(rootWidgetModel instanceof AbstractContainerModel) {
+            AbstractContainerModel container = (AbstractContainerModel)rootWidgetModel;
+            List children = element.getChildren();
+            Iterator iterator = children.iterator();
+            while (iterator.hasNext()) {
+                Element subElement = (Element) iterator.next();
+                if(subElement.getName().equals(XMLTAG_WIDGET)) 
+                    container.addChild(fillWidgets(subElement, displayModel));
+            }
+        }
+        
+        
+        if(displayModel !=null)
+            rootWidgetModel.processVersionDifference(displayModel.getBOYVersion());
+        
+        return rootWidgetModel;
+    }
+    
+    /**
+     * Fill all LinkingContainers under the model.
+     * 
+     * @param container LinkingContainer to be filled.
+     * @throws Exception
+     */
+    public static void fillLinkingContainers(AbstractContainerModel container) throws Exception {
+        fillLinkingContainersSub(container, new ArrayList<IPath>());
+    }
+    
+    private static void fillLinkingContainersSub(AbstractContainerModel container, List<IPath> trace) throws Exception{
+        if(container instanceof AbstractLinkingContainerModel) {
+            AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)container;
+            List<IPath> tempTrace = new ArrayList<IPath>();
+            tempTrace.addAll(trace);
+            fillLinkingContainerSub(linkingContainer, tempTrace);
+        }
 
-		for(AbstractWidgetModel w : container.getAllDescendants()) {
-			if(w instanceof AbstractLinkingContainerModel) {
-				AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)w;
-				List<IPath> tempTrace = new ArrayList<IPath>();
-				tempTrace.addAll(trace);
-				fillLinkingContainerSub(linkingContainer, tempTrace, mapToReceiveConnections);
-			}
-		}
-	}
-	
-	@SuppressWarnings("rawtypes")
-	private static void fillConnections(final Element element, final DisplayModel displayModel, 
-	        Map<Element,ConnectionModel> connections) throws Exception {
-		if(element.getName().equals(XMLTAG_CONNECTION)) {
-		    //gather all connections - they need to be added last
-		    connections.put(element,new ConnectionModel(displayModel));
-//		    final ConnectionModel result = new ConnectionModel(displayModel);
-//            setPropertiesFromXML(element, result); 
-			
-	        
-		} else if(element.getName().equals(XMLTAG_DISPLAY)){
-			List children = element.getChildren();
-			Iterator iterator = children.iterator();
-			while (iterator.hasNext()) {
-				Element subElement = (Element) iterator.next();
-				if(subElement.getName().equals(XMLTAG_CONNECTION))  {
-					fillConnections(subElement, displayModel, connections);
-				}
-			}
-		}
-	}
+        for(AbstractWidgetModel w : container.getAllDescendants()) {
+            if(w instanceof AbstractLinkingContainerModel) {
+                AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)w;
+                List<IPath> tempTrace = new ArrayList<IPath>();
+                tempTrace.addAll(trace);
+                fillLinkingContainerSub(linkingContainer, tempTrace);
+            }
+        }
+    }
+    
+    @SuppressWarnings("rawtypes")
+    private static void fillConnections(Element element, DisplayModel displayModel) throws Exception {
+        if(element.getName().equals(XMLTAG_CONNECTION)) {
+            ConnectionModel result = new ConnectionModel(displayModel);
+            setPropertiesFromXML(element, result); 
+        } else if(element.getName().equals(XMLTAG_DISPLAY)){
+            List children = element.getChildren();
+            Iterator iterator = children.iterator();
+            while (iterator.hasNext()) {
+                Element subElement = (Element) iterator.next();
+                if(subElement.getName().equals(XMLTAG_CONNECTION))  {
+                    fillConnections(subElement, displayModel);
+                }
+            }
+        }
+    }
 
-	@SuppressWarnings("rawtypes")
-	private static void setPropertiesFromXML(Element element, AbstractWidgetModel model) {
-		if(model == null || element == null) return;
-		
-		String versionOnFile = element.getAttributeValue(XMLATTR_VERSION);
-		model.setVersionOnFile(Version.parseVersion(versionOnFile));
-		
-		List children = element.getChildren();
-		Iterator iterator = children.iterator();
-		Set<String> propIdSet = model.getAllPropertyIDs();
-		while (iterator.hasNext()) {
-			Element subElement = (Element) iterator.next();
-			//handle property
-			if(propIdSet.contains(subElement.getName())){
-				String propId = subElement.getName();
-				try {				
-					model.setPropertyValue(propId,
-							model.getProperty(propId).readValueFromXML(subElement));
-				} catch (Exception e) {
-					String errorMessage = "Failed to read the " + propId + " property for " + model.getName() +". " +
-							"The default property value will be setted instead. \n" + e;
-					//MessageDialog.openError(null, "OPI File format error", errorMessage + "\n" + e.getMessage());
-					OPIBuilderPlugin.getLogger().log(Level.WARNING, errorMessage, e);
-					ConsoleService.getInstance().writeWarning(errorMessage);
-				}
-			}
-		}
-	}
-	
-	/**
-	 * Load opi file attached to LinkingContainer widget. 
-	 * 
-	 * @param container LinkingContainer to be filled.
-	 * @throws Exception
-	 */
-	public static void fillLinkingContainer(final AbstractLinkingContainerModel container) 
-			throws Exception {
-	    Map<Element,ConnectionModel> connections = new HashMap<>();
-		fillLinkingContainerSub(container, new ArrayList<IPath>(), connections);
-		addConnections(connections);
-	}
+    @SuppressWarnings("rawtypes")
+    private static void setPropertiesFromXML(Element element, AbstractWidgetModel model) {
+        if(model == null || element == null) return;
+        
+        String versionOnFile = element.getAttributeValue(XMLATTR_VERSION);
+        model.setVersionOnFile(Version.parseVersion(versionOnFile));
+        
+        if (element instanceof LineAwareElement) {
+            model.setLineNumber(((LineAwareElement) element).getLineNumber());
+        }
+        
+        List children = element.getChildren();
+        Iterator iterator = children.iterator();
+        Set<String> propIdSet = model.getAllPropertyIDs();
+        while (iterator.hasNext()) {
+            Element subElement = (Element) iterator.next();
+            //handle property
+            if(propIdSet.contains(subElement.getName())){
+                String propId = subElement.getName();
+                try {               
+                    model.setPropertyValue(propId,
+                            model.getProperty(propId).readValueFromXML(subElement));
+                } catch (Exception e) {
+                    String errorMessage = "Failed to read the " + propId + " property for " + model.getName() +". " +
+                            "The default property value will be setted instead. \n" + e;
+                    //MessageDialog.openError(null, "OPI File format error", errorMessage + "\n" + e.getMessage());
+                    OPIBuilderPlugin.getLogger().log(Level.WARNING, errorMessage, e);
+                    ConsoleService.getInstance().writeWarning(errorMessage);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Load opi file attached to LinkingContainer widget. 
+     * 
+     * @param container LinkingContainer to be filled.
+     * @throws Exception
+     */
+    public static void fillLinkingContainer(final AbstractLinkingContainerModel container) 
+            throws Exception {
+        fillLinkingContainerSub(container, new ArrayList<IPath>());
+    }
 
-	private static void fillLinkingContainerSub(final AbstractLinkingContainerModel container, List<IPath> trace,
-	        Map<Element,ConnectionModel> mapToReceiveConnections)  
-		throws Exception {
+    private static void fillLinkingContainerSub(final AbstractLinkingContainerModel container, List<IPath> trace)  
+        throws Exception {
 
-		if(container == null) return;
+        if(container == null) return;
 
-		if(container.getRootDisplayModel() != null && 
-				container.getRootDisplayModel().getOpiFilePath() != null) {
-			if(trace.contains(container.getRootDisplayModel().getOpiFilePath())) {
-				container.setOPIFilePath("");
-				throw new Exception("Opi link contains some loops.\n" + trace.toString());
-			} else {
-				trace.add(container.getRootDisplayModel().getOpiFilePath());
-			}
+        if(container.getRootDisplayModel() != null && 
+                container.getRootDisplayModel().getOpiFilePath() != null) {
+            if(trace.contains(container.getRootDisplayModel().getOpiFilePath())) {
+                container.setOPIFilePath("");
+                throw new Exception("Opi link contains some loops.\n" + trace.toString());
+            } else {
+                trace.add(container.getRootDisplayModel().getOpiFilePath());
+            }
 
-			IPath path = container.getOPIFilePath();
-			if(path != null && !path.isEmpty()) {
-				final DisplayModel inside = new DisplayModel(path);
+            IPath path = container.getOPIFilePath();
+            if(path != null && !path.isEmpty()) {
+                DisplayModel inside = container.getDisplayModel();
+                if (inside == null) {
+                    inside = new DisplayModel(path);
+                }
 
-				fillDisplayModelFromInputStreamSub(ResourceUtil.pathToInputStream(path), inside, Display.getCurrent(), trace);
-				
-				// mark connection as it is loaded from linked opi
-				for(AbstractWidgetModel w : inside.getAllDescendants()) 
-					for(ConnectionModel conn : w.getSourceConnections()) 
-						conn.setLoadedFromLinkedOpi(true);
+                fillDisplayModelFromInputStreamSub(ResourceUtil.pathToInputStream(path), inside, Display.getCurrent(), trace);
+                
+                // mark connection as it is loaded from linked opi
+                for(AbstractWidgetModel w : inside.getAllDescendants()) 
+                    for(ConnectionModel conn : w.getSourceConnections()) 
+                        conn.setLoadedFromLinkedOpi(true);
 
 
-				AbstractContainerModel loadTarget = inside;
+                AbstractContainerModel loadTarget = inside;
 
-				if(!container.getGroupName().trim().equals("")){ //$NON-NLS-1$
-					AbstractWidgetModel group =
-							inside.getChildByName(container.getGroupName());
-					if(group != null && group instanceof AbstractContainerModel){
-						loadTarget = (AbstractContainerModel) group;
-					}
-				}
+                if(!container.getGroupName().trim().equals("")){ //$NON-NLS-1$
+                    AbstractWidgetModel group =
+                            inside.getChildByName(container.getGroupName());
+                    if(group != null && group instanceof AbstractContainerModel){
+                        loadTarget = (AbstractContainerModel) group;
+                    }
+                }
+                
+                if(loadTarget.getMacrosInput().isInclude_parent_macros()){              
+                    loadTarget.getMacroMap().putAll(inside.getParentMacroMap());
+                }
+                loadTarget.getMacroMap().putAll(loadTarget.getMacrosInput().getMacrosMap());
+                loadTarget.getMacroMap().putAll(container.getMacroMap());
+                
+                for (AbstractWidgetModel w : loadTarget.getChildren()) 
+                    container.addChild(w, true);
 
-		        if(loadTarget.getMacrosInput().isInclude_parent_macros()){              
-		            loadTarget.getMacroMap().putAll(
-		                    (LinkedHashMap<String, String>) inside.getParentMacroMap());
-		        }
-		        loadTarget.getMacroMap().putAll(loadTarget.getMacrosInput().getMacrosMap());
-		        loadTarget.getMacroMap().putAll(container.getMacroMap());
-				
-				for (AbstractWidgetModel w : loadTarget.getChildren()) 
-					container.addChild(w, true);
+                container.setDisplayModel(inside);
+            }
+        }
+    }
+    
+    
+    /**Compare version without comparing qualifier.
+     * @param v1
+     * @param v2
+     * @return
+     */
+    private static int compareVersion(Version v1, Version v2) {
+        if (v2 == v1) { 
+            return 0;
+        }
 
-				container.setDisplayModel(inside);
-			}
-		}
-	}
-	
-	
-	/**Compare version without comparing qualifier.
-	 * @param v1
-	 * @param v2
-	 * @return
-	 */
-	private static int compareVersion(Version v1, Version v2) {
-		if (v2 == v1) { 
-			return 0;
-		}
+        int result = v1.getMajor() - v2.getMajor();
+        if (result != 0) {
+            return result;
+        }
 
-		int result = v1.getMajor() - v2.getMajor();
-		if (result != 0) {
-			return result;
-		}
+        result = v1.getMinor() - v2.getMinor();
+        if (result != 0) {
+            return result;
+        }
 
-		result = v1.getMinor() - v2.getMinor();
-		if (result != 0) {
-			return result;
-		}
+        result = v1.getMicro() - v2.getMicro();
+        if (result != 0) {
+            return result;
+        }
 
-		result = v1.getMicro() - v2.getMicro();
-		if (result != 0) {
-			return result;
-		}
-
-		return 0;
-	}
-	
-	/**
-	 * Return the wuid of the closest widget to offset char position in input stream
-	 * @param in the OPI file input stream
-	 * @param offset the character offset
-	 * @return String wuid
-	 * @throws IOException
-	 */
-	public static String findClosestWidgetUid(InputStream in, int offset)
-			throws IOException {
-		if (in == null) {
-			return null;
-		}
-		StringBuffer out = new StringBuffer();
-		BufferedReader br = new BufferedReader(new InputStreamReader(in));
-		char[] buf = new char[1024];
-		for (int len = br.read(buf); len>0; len = br.read(buf)) {
-			out.append(buf, 0, len);
-		}
-		br.close();
-		if (offset + XMLUtil.XMLTAG_WIDGET.length() + 2 >= out.length()) {
-			// The offset position is too close to the end of file
-			// No widget will be found
-			return null;
-		}
-		int widgetElementStart = offset;
-		while (widgetElementStart >= 0
-				&& !matchXMLTag(out, widgetElementStart, XMLUtil.XMLTAG_WIDGET)) {
-			widgetElementStart--;
-		}
-		if (widgetElementStart > 0) {
-			// corresponding widget element found
-			int wuidAttrStart = widgetElementStart + 1;
-			// looking for <wuid> before a <widget> or </widget
-			String xmlEndTagWidget = "/" + XMLUtil.XMLTAG_WIDGET;
-			while (!matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)
-					&& !matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET)
-					&& !matchXMLTag(out, wuidAttrStart, xmlEndTagWidget)) {
-				wuidAttrStart++;
-			}
-			if (matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)) {
-				//  <wuid> found
-				wuidAttrStart = out.indexOf(">", wuidAttrStart);
-				if (wuidAttrStart >= 0) {
-					wuidAttrStart++;
-					if (wuidAttrStart < out.length()) {
-						int wuidAttrEnd = out.indexOf("</" + XMLTAG_WIDGET_UID,
-								wuidAttrStart);
-						if (wuidAttrEnd >= 0) {
-							return out.substring(wuidAttrStart, wuidAttrEnd);
-						}
-					}
-				}
-			}
-		}
-		return null;
-	}
-	
-	/**
-	 * Return true if the string starting at offset in sb matches with xmlTag.
-	 * @param sb StringBuffer
-	 * @param offset int
-	 * @param xmlTag String The XML tag name to check without '&lt;' and '&gt;'
-	 * @return
-	 */
-	private static boolean matchXMLTag(StringBuffer sb, int offset,
-			String xmlTag) {
-		if (offset >= sb.length()) {
-			return false;
-		}
-		if (sb.charAt(offset) != '<') {
-			return false;
-		}
-		int indexOfSpace = sb.indexOf(" ", offset);
-		int indexOfGt = sb.indexOf(">", offset);
-		int indexOfEndTag = Integer.MAX_VALUE;
-		if (indexOfSpace >= 0) {
-			indexOfEndTag = indexOfSpace;
-		}
-		if (indexOfGt >= 0 && indexOfGt < indexOfEndTag) {
-			indexOfEndTag = indexOfGt;
-		}
-		if (indexOfEndTag == Integer.MAX_VALUE) {
-			return false;
-		}
-		String potentialTag = sb.substring(offset + 1, indexOfEndTag);
-		return potentialTag.equals(xmlTag);
-	}
+        return 0;
+    }
+    
+    /**
+     * Return the wuid of the closest widget to offset char position in input stream
+     * @param in the OPI file input stream
+     * @param offset the character offset
+     * @return String wuid
+     * @throws IOException
+     */
+    public static String findClosestWidgetUid(InputStream in, int offset)
+            throws IOException {
+        if (in == null) {
+            return null;
+        }
+        StringBuffer out = new StringBuffer();
+        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        char[] buf = new char[1024];
+        for (int len = br.read(buf); len>0; len = br.read(buf)) {
+            out.append(buf, 0, len);
+        }
+        br.close();
+        if (offset + XMLUtil.XMLTAG_WIDGET.length() + 2 >= out.length()) {
+            // The offset position is too close to the end of file
+            // No widget will be found
+            return null;
+        }
+        int widgetElementStart = offset;
+        while (widgetElementStart >= 0
+                && !matchXMLTag(out, widgetElementStart, XMLUtil.XMLTAG_WIDGET)) {
+            widgetElementStart--;
+        }
+        if (widgetElementStart > 0) {
+            // corresponding widget element found
+            int wuidAttrStart = widgetElementStart + 1;
+            // looking for <wuid> before a <widget> or </widget
+            String xmlEndTagWidget = "/" + XMLUtil.XMLTAG_WIDGET;
+            while (!matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)
+                    && !matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET)
+                    && !matchXMLTag(out, wuidAttrStart, xmlEndTagWidget)) {
+                wuidAttrStart++;
+            }
+            if (matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)) {
+                //  <wuid> found
+                wuidAttrStart = out.indexOf(">", wuidAttrStart);
+                if (wuidAttrStart >= 0) {
+                    wuidAttrStart++;
+                    if (wuidAttrStart < out.length()) {
+                        int wuidAttrEnd = out.indexOf("</" + XMLTAG_WIDGET_UID,
+                                wuidAttrStart);
+                        if (wuidAttrEnd >= 0) {
+                            return out.substring(wuidAttrStart, wuidAttrEnd);
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Return true if the string starting at offset in sb matches with xmlTag.
+     * @param sb StringBuffer
+     * @param offset int
+     * @param xmlTag String The XML tag name to check without '&lt;' and '&gt;'
+     * @return
+     */
+    private static boolean matchXMLTag(StringBuffer sb, int offset,
+            String xmlTag) {
+        if (offset >= sb.length()) {
+            return false;
+        }
+        if (sb.charAt(offset) != '<') {
+            return false;
+        }
+        int indexOfSpace = sb.indexOf(" ", offset);
+        int indexOfGt = sb.indexOf(">", offset);
+        int indexOfEndTag = Integer.MAX_VALUE;
+        if (indexOfSpace >= 0) {
+            indexOfEndTag = indexOfSpace;
+        }
+        if (indexOfGt >= 0 && indexOfGt < indexOfEndTag) {
+            indexOfEndTag = indexOfGt;
+        }
+        if (indexOfEndTag == Integer.MAX_VALUE) {
+            return false;
+        }
+        String potentialTag = sb.substring(offset + 1, indexOfEndTag);
+        return potentialTag.equals(xmlTag);
+    }
 
 	private static Element inputStreamToXML(InputStream stream) throws JDOMException, IOException {
 	    SAXBuilder saxBuilder = LineAwareXMLParser.createBuilder(); 

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
@@ -29,6 +29,7 @@ import org.csstudio.opibuilder.model.AbstractLinkingContainerModel;
 import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.csstudio.opibuilder.model.ConnectionModel;
 import org.csstudio.opibuilder.model.DisplayModel;
+import org.csstudio.opibuilder.persistence.LineAwareXMLParser.LineAwareElement;
 import org.csstudio.opibuilder.preferences.PreferencesHelper;
 import org.csstudio.opibuilder.util.ConsoleService;
 import org.csstudio.opibuilder.util.ErrorHandlerUtil;
@@ -53,569 +54,560 @@ import org.osgi.framework.Version;
  */
 public class XMLUtil {
 
-    public static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"; //$NON-NLS-1$
+	public static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"; //$NON-NLS-1$
 
-    public static String XMLTAG_DISPLAY = "display"; //$NON-NLS-1$
+	public static String XMLTAG_DISPLAY = "display"; //$NON-NLS-1$
 
-    public static String XMLTAG_WIDGET = "widget"; //$NON-NLS-1$
-    
-    public static String XMLTAG_CONNECTION = "connection"; //$NON-NLS-1$
-    
-    public static Set<String> WIDGET_TAGS = 
-            new HashSet<String>(Arrays.asList(XMLTAG_DISPLAY, XMLTAG_WIDGET, XMLTAG_CONNECTION));
-    
-    public static String XMLATTR_TYPEID = "typeId"; //$NON-NLS-1$
+	public static String XMLTAG_WIDGET = "widget"; //$NON-NLS-1$
+	
+	public static String XMLTAG_CONNECTION = "connection"; //$NON-NLS-1$
+	
+	public static Set<String> WIDGET_TAGS = 
+			new HashSet<String>(Arrays.asList(XMLTAG_DISPLAY, XMLTAG_WIDGET, XMLTAG_CONNECTION));
+	
+	public static String XMLATTR_TYPEID = "typeId"; //$NON-NLS-1$
 
-    public static String XMLATTR_PROPID = "id"; //$NON-NLS-1$
-    public static String XMLATTR_VERSION = "version"; //$NON-NLS-1$
+	public static String XMLATTR_PROPID = "id"; //$NON-NLS-1$
+	public static String XMLATTR_VERSION = "version"; //$NON-NLS-1$
 
-    public static String XMLTAG_WIDGET_UID = AbstractWidgetModel.PROP_WIDGET_UID; //$NON-NLS-1$
-    public static String XMLTAG_OPI_FILE = AbstractLinkingContainerModel.PROP_OPI_FILE;
-    
-    /**Flatten a widget to XML element.
-     * @param widgetModel model of the widget
-     * @return the XML element
-     */
-    public static Element widgetToXMLElement(AbstractWidgetModel widgetModel){
+	public static String XMLTAG_WIDGET_UID = AbstractWidgetModel.PROP_WIDGET_UID; //$NON-NLS-1$
+	public static String XMLTAG_OPI_FILE = AbstractLinkingContainerModel.PROP_OPI_FILE;
+	
+	/**Flatten a widget to XML element.
+	 * @param widgetModel model of the widget
+	 * @return the XML element
+	 */
+	public static Element widgetToXMLElement(AbstractWidgetModel widgetModel){
 
-        Element result = new Element((widgetModel instanceof DisplayModel) ? XMLTAG_DISPLAY :
-            (widgetModel instanceof ConnectionModel) ? XMLTAG_CONNECTION : XMLTAG_WIDGET);
-        result.setAttribute(XMLATTR_TYPEID, widgetModel.getTypeID());
-        result.setAttribute(XMLATTR_VERSION, widgetModel.getVersion().toString());
-        for(String propId : widgetModel.getAllPropertyIDs()){
-            if(widgetModel.getProperty(propId).isSavable()){
-                Element propElement = new Element(propId);
-                widgetModel.getProperty(propId).writeToXML(propElement);
-                result.addContent(propElement);
-            }
-        }
+		Element result = new Element((widgetModel instanceof DisplayModel) ? XMLTAG_DISPLAY :
+			(widgetModel instanceof ConnectionModel) ? XMLTAG_CONNECTION : XMLTAG_WIDGET);
+		result.setAttribute(XMLATTR_TYPEID, widgetModel.getTypeID());
+		result.setAttribute(XMLATTR_VERSION, widgetModel.getVersion().toString());
+		for(String propId : widgetModel.getAllPropertyIDs()){
+			if(widgetModel.getProperty(propId).isSavable()){
+				Element propElement = new Element(propId);
+				widgetModel.getProperty(propId).writeToXML(propElement);
+				result.addContent(propElement);
+			}
+		}
 
-        if(widgetModel instanceof AbstractContainerModel && !(widgetModel instanceof AbstractLinkingContainerModel)){
-            AbstractContainerModel containerModel = (AbstractContainerModel)widgetModel;
-            for(AbstractWidgetModel child : containerModel.getChildren()){
-                result.addContent(widgetToXMLElement(child));
-            }
-        }
-        
-        //convert connections on this displayModel to xml element
-        if(widgetModel instanceof DisplayModel && 
-                ((DisplayModel)widgetModel).getConnectionList() != null){           
-            for(ConnectionModel connectionModel : ((DisplayModel)widgetModel).getConnectionList()){
-                if(!connectionModel.isLoadedFromLinkedOpi()) {
-                    Element connElement = widgetToXMLElement(connectionModel);
-                    result.addContent(connElement);
-                }
-            }       
-        }
+		if(widgetModel instanceof AbstractContainerModel && !(widgetModel instanceof AbstractLinkingContainerModel)){
+			AbstractContainerModel containerModel = (AbstractContainerModel)widgetModel;
+			for(AbstractWidgetModel child : containerModel.getChildren()){
+				result.addContent(widgetToXMLElement(child));
+			}
+		}
+		
+		//convert connections on this displayModel to xml element
+		if(widgetModel instanceof DisplayModel && 
+				((DisplayModel)widgetModel).getConnectionList() != null){			
+			for(ConnectionModel connectionModel : ((DisplayModel)widgetModel).getConnectionList()){
+				if(!connectionModel.isLoadedFromLinkedOpi()) {
+					Element connElement = widgetToXMLElement(connectionModel);
+					result.addContent(connElement);
+				}
+			}		
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    /**Flatten a widget to XML String.
-     * @param widgetModel model of the widget.
-     * @param prettyFormat true if the string is in pretty format
-     * @return the XML String
-     */
-    public static String widgetToXMLString(AbstractWidgetModel widgetModel, boolean prettyFormat){
-        Format format = Format.getRawFormat();      
-        if(prettyFormat)
-            format.setIndent("  "); //$NON-NLS-1$
-        XMLOutputter xmlOutputter = new XMLOutputter();
-        xmlOutputter.setFormat(format);
+	/**Flatten a widget to XML String.
+	 * @param widgetModel model of the widget.
+	 * @param prettyFormat true if the string is in pretty format
+	 * @return the XML String
+	 */
+	public static String widgetToXMLString(AbstractWidgetModel widgetModel, boolean prettyFormat){
+		Format format = Format.getRawFormat();		
+		if(prettyFormat)
+			format.setIndent("  "); //$NON-NLS-1$
+		XMLOutputter xmlOutputter = new XMLOutputter();
+		xmlOutputter.setFormat(format);
 
-        return xmlOutputter.outputString(widgetToXMLElement(widgetModel));
-    }
+		return xmlOutputter.outputString(widgetToXMLElement(widgetModel));
+	}
 
-    /**Write widget to an output stream.
-     * @param widgetModel model of the widget
-     * @param out output stream
-     * @param prettyFormat true if in pretty format
-     * @throws IOException
-     */
-    public static void widgetToOutputStream(AbstractWidgetModel widgetModel, OutputStream out, boolean prettyFormat) throws IOException{
-        Format format = Format.getRawFormat();      
-        if(prettyFormat)
-            format.setIndent("  "); //$NON-NLS-1$
-        XMLOutputter xmlOutputter = new XMLOutputter(format);
-        out.write(XML_HEADER.getBytes("UTF-8")); //$NON-NLS-1$
-        xmlOutputter.output(widgetToXMLElement(widgetModel), out);
-    }
-
-    /**Convert an XML String to widget model
-     * @param xmlString
-     * @return the widget model
-     * @throws Exception
-     */
-    public static AbstractWidgetModel XMLStringToWidget(String xmlString) throws Exception{
-        return XMLElementToWidget(stringToXML(xmlString));
-    }
-
-    /**Convert an XML element to widget.
-     * @param element the element
-     * @return model of the widget.
-     * @throws Exception
-     */
-    public static AbstractWidgetModel XMLElementToWidget(Element element) throws Exception {
-        return XMLElementToWidget(element, null);
-    }
-
-    /**Fill the DisplayModel from an OPI file inputstream
-     * @param inputStream the inputstream will be closed in this method before return.
-     * @param displayModel. The {@link DisplayModel} to be filled.
-     * @param display the display in UI Thread.
-     * @throws Exception
-     */
-    public static void fillDisplayModelFromInputStream(
-            final InputStream inputStream, final DisplayModel displayModel, Display display) throws Exception{
-        fillDisplayModelFromInputStreamSub(inputStream, displayModel, display, new ArrayList<IPath>());
-    }
-    
-    private static void fillDisplayModelFromInputStreamSub(
-            final InputStream inputStream, final DisplayModel displayModel, Display display, List<IPath> trace)
-                    throws Exception{
-    
-        if(display == null){
-            display = Display.getCurrent();
-        }
-        IPath opiPath = displayModel.getOpiFilePath();
-        if (OPIBuilderPlugin.isRAP() && opiPath != null
-                && !SingleSourceHelper.rapIsLoggedIn(display)) {
-            //check secured opi paths
-            String[] securedPaths = PreferencesHelper.getSecuredOpiPaths();
-            if (securedPaths != null){
-                for(String securedPath : securedPaths){
-                    if(opiPath.toString().startsWith(securedPath)) {
-                        if (!SingleSourceHelper.rapAuthenticate(display)) {
-                            inputStream.close();
-                            throw new FailedLoginException();
-                        }
-                    }
-                }               
-            }
-            //check unsecured opi paths
-            if(PreferencesHelper.isWholeSiteSecured()){
-                String[] unSecuredPaths = PreferencesHelper.getUnSecuredOpiPaths();
-                if (unSecuredPaths != null){
-                    boolean shouldBeSecured=true;
-                    for(String unSecuredPath : unSecuredPaths){
-                        if(opiPath.toString().startsWith(unSecuredPath)) {
-                            shouldBeSecured=false;
-                            break;
-                        }
-                    }               
-                    if(shouldBeSecured){
-                        if (!SingleSourceHelper.rapAuthenticate(display)) {
-                            inputStream.close();
-                            throw new FailedLoginException();
-                        }
-                    }
-                }
-            }
-            
-        }
-        
-        Element root = inputStreamToXML(inputStream);
-        if(root != null){
-             XMLElementToWidgetSub(root, displayModel, trace);
-             
-             //check version
-             if(compareVersion(displayModel.getBOYVersion(),
-                     OPIBuilderPlugin.getDefault().getBundle().getVersion()) > 0){              
-                final String message = displayModel.getOpiFilePath() == null ? "This OPI"
-                        : displayModel.getOpiFilePath().lastSegment()
-                                + " was created in a newer version of BOY ("
-                                + displayModel.getBOYVersion().toString()
-                                + "). It may not function properly! "
-                                + "Please update your " + 
-                                (OPIBuilderPlugin.isRAP()? "WebOPI":"BOY") 
-                                + " (" + OPIBuilderPlugin.getDefault().getBundle().getVersion() +
-                                ") to the latest version.";
-                if(display == null){
-                    display = Display.getDefault();
-                }
-                if (display != null)
-                    display.asyncExec(new Runnable() {
-                        @Override
-                        public void run() {
-//                          MessageDialog.openWarning(null, "Warning", message);
-                            ConsoleService.getInstance().writeWarning(message);
-                            OPIBuilderPlugin.getLogger().log(Level.WARNING,
-                                    message); //$NON-NLS-1$ 
-                        }
-                    });         
-             }   
-             
-        }
-        inputStream.close();
-    }
-
-    /**Fill the DisplayModel from an OPI file inputstream. In RAP, it must be called in UI Thread.
-     * @param inputStream the inputstream will be closed in this method before return.
-     * @param displayModel
-     * @throws Exception
-     */
-    public static void fillDisplayModelFromInputStream(
-            final InputStream inputStream, final DisplayModel displayModel) throws Exception {
-        fillDisplayModelFromInputStream(inputStream, displayModel, null);
-    }
+	/**Write widget to an output stream.
+	 * @param widgetModel model of the widget
+	 * @param out output stream
+	 * @param prettyFormat true if in pretty format
+	 * @throws IOException
+	 */
+	public static void widgetToOutputStream(AbstractWidgetModel widgetModel, OutputStream out, boolean prettyFormat) throws IOException{
+		Format format = Format.getRawFormat();		
+		if(prettyFormat)
+			format.setIndent("  "); //$NON-NLS-1$
+		XMLOutputter xmlOutputter = new XMLOutputter(format);
+		out.write(XML_HEADER.getBytes("UTF-8")); //$NON-NLS-1$
+		xmlOutputter.output(widgetToXMLElement(widgetModel), out);
+	}
 
 
-    /**Construct widget model from XML element. Sometimes it includes filling LinkingContainer and/or construct Connection model between widgets.
-     * @param element
-     * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
-     * instead of creating a new one. If this is null, a new one will be created. 
-     * @return the root widget model
-     * @throws Exception
-     */
-    public static AbstractWidgetModel XMLElementToWidget(Element element, DisplayModel displayModel) throws Exception{
-        return XMLElementToWidgetSub(element, displayModel, new ArrayList<IPath> ());
-    }
+	/**Convert an XML String to widget model
+	 * @param xmlString
+	 * @return the widget model
+	 * @throws Exception
+	 */
+	public static AbstractWidgetModel XMLStringToWidget(String xmlString) throws Exception{
+		return XMLElementToWidget(stringToXML(xmlString));
+	}
 
-    private static AbstractWidgetModel XMLElementToWidgetSub(Element element, DisplayModel displayModel, List<IPath> trace) throws Exception{
-        if(element == null) return null;
+	/**Convert an XML element to widget.
+	 * @param element the element
+	 * @return model of the widget.
+	 * @throws Exception
+	 */
+	public static AbstractWidgetModel XMLElementToWidget(Element element) throws Exception {
+		return XMLElementToWidget(element, null);
+	}
 
-        AbstractWidgetModel result = null;
+	/**Fill the DisplayModel from an OPI file inputstream
+	 * @param inputStream the inputstream will be closed in this method before return.
+	 * @param displayModel. The {@link DisplayModel} to be filled.
+	 * @param display the display in UI Thread.
+	 * @throws Exception
+	 */
+	public static void fillDisplayModelFromInputStream(
+			final InputStream inputStream, final DisplayModel displayModel, Display display) throws Exception{
+		fillDisplayModelFromInputStreamSub(inputStream, displayModel, display, new ArrayList<IPath>());
+	}
 
-        if(WIDGET_TAGS.contains(element.getName())) {
-            result = fillWidgets(element, displayModel);
-            
-            if(result instanceof AbstractContainerModel)
-                fillLinkingContainersSub((AbstractContainerModel)result, trace);
-            fillConnections(element, displayModel);
+	private static void fillDisplayModelFromInputStreamSub(
+			final InputStream inputStream, final DisplayModel displayModel, Display display, List<IPath> trace) throws Exception{
+	
+		if(display == null){
+			display = Display.getCurrent();
+		}
+		IPath opiPath = displayModel.getOpiFilePath();
+		if (OPIBuilderPlugin.isRAP() && opiPath != null
+				&& !SingleSourceHelper.rapIsLoggedIn(display)) {
+			//check secured opi paths
+			String[] securedPaths = PreferencesHelper.getSecuredOpiPaths();
+			if (securedPaths != null){
+				for(String securedPath : securedPaths){
+					if(opiPath.toString().startsWith(securedPath)) {
+						if (!SingleSourceHelper.rapAuthenticate(display)) {
+							inputStream.close();
+							throw new FailedLoginException();
+						}
+					}
+				}				
+			}
+			//check unsecured opi paths
+			if(PreferencesHelper.isWholeSiteSecured()){
+				String[] unSecuredPaths = PreferencesHelper.getUnSecuredOpiPaths();
+				if (unSecuredPaths != null){
+					boolean shouldBeSecured=true;
+					for(String unSecuredPath : unSecuredPaths){
+						if(opiPath.toString().startsWith(unSecuredPath)) {
+							shouldBeSecured=false;
+							break;
+						}
+					}				
+					if(shouldBeSecured){
+						if (!SingleSourceHelper.rapAuthenticate(display)) {
+							inputStream.close();
+							throw new FailedLoginException();
+						}
+					}
+				}
+			}
+			
+		}
+		
+		Element root = inputStreamToXML(inputStream);
+		if(root != null){
+			 XMLElementToWidgetSub(root, displayModel, trace);
+			 
+			 //check version
+			 if(compareVersion(displayModel.getBOYVersion(),
+					 OPIBuilderPlugin.getDefault().getBundle().getVersion()) > 0){				
+				final String message = displayModel.getOpiFilePath() == null ? "This OPI"
+						: displayModel.getOpiFilePath().lastSegment()
+								+ " was created in a newer version of BOY ("
+								+ displayModel.getBOYVersion().toString()
+								+ "). It may not function properly! "
+								+ "Please update your " + 
+								(OPIBuilderPlugin.isRAP()? "WebOPI":"BOY") 
+								+ " (" + OPIBuilderPlugin.getDefault().getBundle().getVersion() +
+								") to the latest version.";
+				if(display == null){
+					display = Display.getDefault();
+				}
+				if (display != null)
+					display.asyncExec(new Runnable() {
+						@Override
+						public void run() {
+//							MessageDialog.openWarning(null, "Warning", message);
+							ConsoleService.getInstance().writeWarning(message);
+							OPIBuilderPlugin.getLogger().log(Level.WARNING,
+						            message); //$NON-NLS-1$	
+						}
+					});			
+			 }	 
+			 
+		}
+		inputStream.close();
+	}
 
-            return result;
-        } else {
-            String errorMessage = "Unknown Tag: " + element.getName();
-            ConsoleService.getInstance().writeError(errorMessage);
-            return null;
-        }
-    }
-
-    /**Convert XML String to a widget model.
-     * @param xmlString
-     * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
-     * instead of creating a new one. If this is null, a new one will be created. 
-     * @throws Exception
-     */
-    public static AbstractWidgetModel fillWidgetsFromXMLString(String xmlString, DisplayModel displayModel) throws Exception {
-        return fillWidgets(stringToXML(xmlString), displayModel);
-    }
-
-    /**Convert XML Element to a widget model.
-     * @param element
-     * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
-     * instead of creating a new one. If this is null, a new one will be created. 
-     * @throws Exception
-     */
-    @SuppressWarnings("rawtypes")
-    public static AbstractWidgetModel fillWidgets(Element element, DisplayModel displayModel) throws Exception{
-        if(element == null) return null;
-        
-        AbstractWidgetModel rootWidgetModel = null;
-        
-        //Determine root widget model
-        if(element.getName().equals(XMLTAG_DISPLAY)){
-            if(displayModel != null)
-                rootWidgetModel =displayModel;
-            else
-                rootWidgetModel = new DisplayModel(null);
-        }else if(element.getName().equals(XMLTAG_WIDGET)){
-            String typeId = element.getAttributeValue(XMLATTR_TYPEID);
-            WidgetDescriptor desc = WidgetsService.getInstance().getWidgetDescriptor(typeId);
-            if(desc != null)
-                rootWidgetModel = desc.getWidgetModel();
-            if(rootWidgetModel == null){
-                String errorMessage = NLS.bind("Fail to load the widget: {0}\n " +
-                    "The widget may not exist, as a consequence, the widget will be ignored.", typeId);
-                ErrorHandlerUtil.handleError(errorMessage, new Exception("Widget does not exist."));
-                return null;
-            }
-        }else if(element.getName().equals(XMLTAG_CONNECTION)){
-            rootWidgetModel = new ConnectionModel(displayModel);            
-        }else {
-            String errorMessage = "Unknown Tag: " + element.getName();
-            ConsoleService.getInstance().writeError(errorMessage);
-            return null;
-        }
-
-        setPropertiesFromXML(element, rootWidgetModel); 
-
-        if(rootWidgetModel instanceof AbstractContainerModel) {
-            AbstractContainerModel container = (AbstractContainerModel)rootWidgetModel;
-            List children = element.getChildren();
-            Iterator iterator = children.iterator();
-            while (iterator.hasNext()) {
-                Element subElement = (Element) iterator.next();
-                if(subElement.getName().equals(XMLTAG_WIDGET)) 
-                    container.addChild(fillWidgets(subElement, displayModel));
-            }
-        }
-        
-        
-        if(displayModel !=null)
-            rootWidgetModel.processVersionDifference(displayModel.getBOYVersion());
-        
-        return rootWidgetModel;
-    }
-    
-    /**
-     * Fill all LinkingContainers under the model.
-     * 
-     * @param container LinkingContainer to be filled.
-     * @throws Exception
-     */
-    public static void fillLinkingContainers(AbstractContainerModel container) throws Exception {
-        fillLinkingContainersSub(container, new ArrayList<IPath>());
-    }
-    
-    private static void fillLinkingContainersSub(AbstractContainerModel container, List<IPath> trace) throws Exception{
-        if(container instanceof AbstractLinkingContainerModel) {
-            AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)container;
-            List<IPath> tempTrace = new ArrayList<IPath>();
-            tempTrace.addAll(trace);
-            fillLinkingContainerSub(linkingContainer, tempTrace);
-        }
-
-        for(AbstractWidgetModel w : container.getAllDescendants()) {
-            if(w instanceof AbstractLinkingContainerModel) {
-                AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)w;
-                List<IPath> tempTrace = new ArrayList<IPath>();
-                tempTrace.addAll(trace);
-                fillLinkingContainerSub(linkingContainer, tempTrace);
-            }
-        }
-    }
-    
-    @SuppressWarnings("rawtypes")
-    private static void fillConnections(Element element, DisplayModel displayModel) throws Exception {
-        if(element.getName().equals(XMLTAG_CONNECTION)) {
-            ConnectionModel result = new ConnectionModel(displayModel);
-            setPropertiesFromXML(element, result); 
-        } else if(element.getName().equals(XMLTAG_DISPLAY)){
-            List children = element.getChildren();
-            Iterator iterator = children.iterator();
-            while (iterator.hasNext()) {
-                Element subElement = (Element) iterator.next();
-                if(subElement.getName().equals(XMLTAG_CONNECTION))  {
-                    fillConnections(subElement, displayModel);
-                }
-            }
-        }
-    }
-
-    @SuppressWarnings("rawtypes")
-    private static void setPropertiesFromXML(Element element, AbstractWidgetModel model) {
-        if(model == null || element == null) return;
-        
-        String versionOnFile = element.getAttributeValue(XMLATTR_VERSION);
-        model.setVersionOnFile(Version.parseVersion(versionOnFile));
-        
-        if (element instanceof LineAwareElement) {
-            model.setLineNumber(((LineAwareElement) element).getLineNumber());
-        }
-        
-        List children = element.getChildren();
-        Iterator iterator = children.iterator();
-        Set<String> propIdSet = model.getAllPropertyIDs();
-        while (iterator.hasNext()) {
-            Element subElement = (Element) iterator.next();
-            //handle property
-            if(propIdSet.contains(subElement.getName())){
-                String propId = subElement.getName();
-                try {               
-                    model.setPropertyValue(propId,
-                            model.getProperty(propId).readValueFromXML(subElement));
-                } catch (Exception e) {
-                    String errorMessage = "Failed to read the " + propId + " property for " + model.getName() +". " +
-                            "The default property value will be setted instead. \n" + e;
-                    //MessageDialog.openError(null, "OPI File format error", errorMessage + "\n" + e.getMessage());
-                    OPIBuilderPlugin.getLogger().log(Level.WARNING, errorMessage, e);
-                    ConsoleService.getInstance().writeWarning(errorMessage);
-                }
-            }
-        }
-    }
-    
-    /**
-     * Load opi file attached to LinkingContainer widget. 
-     * 
-     * @param container LinkingContainer to be filled.
-     * @throws Exception
-     */
-    public static void fillLinkingContainer(final AbstractLinkingContainerModel container) 
-            throws Exception {
-        fillLinkingContainerSub(container, new ArrayList<IPath>());
-    }
-
-    private static void fillLinkingContainerSub(final AbstractLinkingContainerModel container, List<IPath> trace)  
-        throws Exception {
-
-        if(container == null) return;
-
-        if(container.getRootDisplayModel() != null && 
-                container.getRootDisplayModel().getOpiFilePath() != null) {
-            if(trace.contains(container.getRootDisplayModel().getOpiFilePath())) {
-                container.setOPIFilePath("");
-                throw new Exception("Opi link contains some loops.\n" + trace.toString());
-            } else {
-                trace.add(container.getRootDisplayModel().getOpiFilePath());
-            }
-
-            IPath path = container.getOPIFilePath();
-            if(path != null && !path.isEmpty()) {
-                DisplayModel inside = container.getDisplayModel();
-                if (inside == null) {
-                    inside = new DisplayModel(path);
-                }
-
-                fillDisplayModelFromInputStreamSub(ResourceUtil.pathToInputStream(path), inside, Display.getCurrent(), trace);
-                
-                // mark connection as it is loaded from linked opi
-                for(AbstractWidgetModel w : inside.getAllDescendants()) 
-                    for(ConnectionModel conn : w.getSourceConnections()) 
-                        conn.setLoadedFromLinkedOpi(true);
+	/**Fill the DisplayModel from an OPI file inputstream. In RAP, it must be called in UI Thread.
+	 * @param inputStream the inputstream will be closed in this method before return.
+	 * @param displayModel
+	 * @throws Exception
+	 */
+	public static void fillDisplayModelFromInputStream(
+			final InputStream inputStream, final DisplayModel displayModel) throws Exception {
+		fillDisplayModelFromInputStream(inputStream, displayModel, null);
+	}
 
 
-                AbstractContainerModel loadTarget = inside;
+	/**Construct widget model from XML element. Sometimes it includes filling LinkingContainer and/or construct Connection model between widgets.
+	 * @param element
+	 * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
+	 * instead of creating a new one. If this is null, a new one will be created. 
+	 * @return the root widget model
+	 * @throws Exception
+	 */
+	public static AbstractWidgetModel XMLElementToWidget(Element element, DisplayModel displayModel) throws Exception{
+		return XMLElementToWidgetSub(element, displayModel, new ArrayList<IPath> ());
+	}
 
-                if(!container.getGroupName().trim().equals("")){ //$NON-NLS-1$
-                    AbstractWidgetModel group =
-                            inside.getChildByName(container.getGroupName());
-                    if(group != null && group instanceof AbstractContainerModel){
-                        loadTarget = (AbstractContainerModel) group;
-                    }
-                }
-                
-                if(loadTarget.getMacrosInput().isInclude_parent_macros()){              
-                    loadTarget.getMacroMap().putAll(inside.getParentMacroMap());
-                }
-                loadTarget.getMacroMap().putAll(loadTarget.getMacrosInput().getMacrosMap());
-                loadTarget.getMacroMap().putAll(container.getMacroMap());
-                
-                for (AbstractWidgetModel w : loadTarget.getChildren()) 
-                    container.addChild(w, true);
+	private static AbstractWidgetModel XMLElementToWidgetSub(Element element, DisplayModel displayModel, List<IPath> trace) throws Exception{
+		if(element == null) return null;
 
-                container.setDisplayModel(inside);
-            }
-        }
-    }
-    
-    
-    /**Compare version without comparing qualifier.
-     * @param v1
-     * @param v2
-     * @return
-     */
-    private static int compareVersion(Version v1, Version v2) {
-        if (v2 == v1) { 
-            return 0;
-        }
+		AbstractWidgetModel result = null;
 
-        int result = v1.getMajor() - v2.getMajor();
-        if (result != 0) {
-            return result;
-        }
+		if(WIDGET_TAGS.contains(element.getName())) {
+			result = fillWidgets(element, displayModel);
+			
+			if(result instanceof AbstractContainerModel)
+				fillLinkingContainersSub((AbstractContainerModel)result, trace);
+			fillConnections(element, displayModel);
 
-        result = v1.getMinor() - v2.getMinor();
-        if (result != 0) {
-            return result;
-        }
+			return result;
+		} else {
+			String errorMessage = "Unknown Tag: " + element.getName();
+			ConsoleService.getInstance().writeError(errorMessage);
+			return null;
+		}
+	}
 
-        result = v1.getMicro() - v2.getMicro();
-        if (result != 0) {
-            return result;
-        }
+	/**Convert XML String to a widget model.
+	 * @param xmlString
+	 * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
+	 * instead of creating a new one. If this is null, a new one will be created. 
+	 * @throws Exception
+	 */
+	public static AbstractWidgetModel fillWidgetsFromXMLString(String xmlString, DisplayModel displayModel) throws Exception {
+		return fillWidgets(stringToXML(xmlString), displayModel);
+	}
 
-        return 0;
-    }
-    
-    /**
-     * Return the wuid of the closest widget to offset char position in input stream
-     * @param in the OPI file input stream
-     * @param offset the character offset
-     * @return String wuid
-     * @throws IOException
-     */
-    public static String findClosestWidgetUid(InputStream in, int offset)
-            throws IOException {
-        if (in == null) {
-            return null;
-        }
-        StringBuffer out = new StringBuffer();
-        BufferedReader br = new BufferedReader(new InputStreamReader(in));
-        char[] buf = new char[1024];
-        for (int len = br.read(buf); len>0; len = br.read(buf)) {
-            out.append(buf, 0, len);
-        }
-        br.close();
-        if (offset + XMLUtil.XMLTAG_WIDGET.length() + 2 >= out.length()) {
-            // The offset position is too close to the end of file
-            // No widget will be found
-            return null;
-        }
-        int widgetElementStart = offset;
-        while (widgetElementStart >= 0
-                && !matchXMLTag(out, widgetElementStart, XMLUtil.XMLTAG_WIDGET)) {
-            widgetElementStart--;
-        }
-        if (widgetElementStart > 0) {
-            // corresponding widget element found
-            int wuidAttrStart = widgetElementStart + 1;
-            // looking for <wuid> before a <widget> or </widget
-            String xmlEndTagWidget = "/" + XMLUtil.XMLTAG_WIDGET;
-            while (!matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)
-                    && !matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET)
-                    && !matchXMLTag(out, wuidAttrStart, xmlEndTagWidget)) {
-                wuidAttrStart++;
-            }
-            if (matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)) {
-                //  <wuid> found
-                wuidAttrStart = out.indexOf(">", wuidAttrStart);
-                if (wuidAttrStart >= 0) {
-                    wuidAttrStart++;
-                    if (wuidAttrStart < out.length()) {
-                        int wuidAttrEnd = out.indexOf("</" + XMLTAG_WIDGET_UID,
-                                wuidAttrStart);
-                        if (wuidAttrEnd >= 0) {
-                            return out.substring(wuidAttrStart, wuidAttrEnd);
-                        }
-                    }
-                }
-            }
-        }
-        return null;
-    }
-    
-    /**
-     * Return true if the string starting at offset in sb matches with xmlTag.
-     * @param sb StringBuffer
-     * @param offset int
-     * @param xmlTag String The XML tag name to check without '&lt;' and '&gt;'
-     * @return
-     */
-    private static boolean matchXMLTag(StringBuffer sb, int offset,
-            String xmlTag) {
-        if (offset >= sb.length()) {
-            return false;
-        }
-        if (sb.charAt(offset) != '<') {
-            return false;
-        }
-        int indexOfSpace = sb.indexOf(" ", offset);
-        int indexOfGt = sb.indexOf(">", offset);
-        int indexOfEndTag = Integer.MAX_VALUE;
-        if (indexOfSpace >= 0) {
-            indexOfEndTag = indexOfSpace;
-        }
-        if (indexOfGt >= 0 && indexOfGt < indexOfEndTag) {
-            indexOfEndTag = indexOfGt;
-        }
-        if (indexOfEndTag == Integer.MAX_VALUE) {
-            return false;
-        }
-        String potentialTag = sb.substring(offset + 1, indexOfEndTag);
-        return potentialTag.equals(xmlTag);
-    }
+	/**Convert XML Element to a widget model.
+	 * @param element
+	 * @param displayModel the root display model. If root of the element is a display, use this display model as root model 
+	 * instead of creating a new one. If this is null, a new one will be created. 
+	 * @throws Exception
+	 */
+	@SuppressWarnings("rawtypes")
+	public static AbstractWidgetModel fillWidgets(Element element, DisplayModel displayModel) throws Exception{
+		if(element == null) return null;
+		
+		AbstractWidgetModel rootWidgetModel = null;
+		
+		//Determine root widget model
+		if(element.getName().equals(XMLTAG_DISPLAY)){
+			if(displayModel != null)
+				rootWidgetModel =displayModel;
+			else
+				rootWidgetModel = new DisplayModel(null);
+		}else if(element.getName().equals(XMLTAG_WIDGET)){
+			String typeId = element.getAttributeValue(XMLATTR_TYPEID);
+			WidgetDescriptor desc = WidgetsService.getInstance().getWidgetDescriptor(typeId);
+			if(desc != null)
+				rootWidgetModel = desc.getWidgetModel();
+			if(rootWidgetModel == null){
+				String errorMessage = NLS.bind("Fail to load the widget: {0}\n " +
+					"The widget may not exist, as a consequence, the widget will be ignored.", typeId);
+				ErrorHandlerUtil.handleError(errorMessage, new Exception("Widget does not exist."));
+				return null;
+			}
+		}else if(element.getName().equals(XMLTAG_CONNECTION)){
+			rootWidgetModel = new ConnectionModel(displayModel);			
+		}else {
+			String errorMessage = "Unknown Tag: " + element.getName();
+			ConsoleService.getInstance().writeError(errorMessage);
+			return null;
+		}
+
+		setPropertiesFromXML(element, rootWidgetModel); 
+
+		if(rootWidgetModel instanceof AbstractContainerModel) {
+			AbstractContainerModel container = (AbstractContainerModel)rootWidgetModel;
+			List children = element.getChildren();
+			Iterator iterator = children.iterator();
+			while (iterator.hasNext()) {
+				Element subElement = (Element) iterator.next();
+				if(subElement.getName().equals(XMLTAG_WIDGET)) 
+					container.addChild(fillWidgets(subElement, displayModel));
+			}
+		}
+		
+		
+		if(displayModel !=null)
+			rootWidgetModel.processVersionDifference(displayModel.getBOYVersion());
+		
+		return rootWidgetModel;
+	}
+	
+	/**
+	 * Fill all LinkingContainers under the model.
+	 * 
+	 * @param container LinkingContainer to be filled.
+	 * @throws Exception
+	 */
+	public static void fillLinkingContainers(AbstractContainerModel container) throws Exception {
+		fillLinkingContainersSub(container, new ArrayList<IPath>());
+	}
+	
+	private static void fillLinkingContainersSub(AbstractContainerModel container, List<IPath> trace) throws Exception{
+		if(container instanceof AbstractLinkingContainerModel) {
+			AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)container;
+			List<IPath> tempTrace = new ArrayList<IPath>();
+			tempTrace.addAll(trace);
+			fillLinkingContainerSub(linkingContainer, tempTrace);
+		}
+
+		for(AbstractWidgetModel w : container.getAllDescendants()) {
+			if(w instanceof AbstractLinkingContainerModel) {
+				AbstractLinkingContainerModel linkingContainer = (AbstractLinkingContainerModel)w;
+				List<IPath> tempTrace = new ArrayList<IPath>();
+				tempTrace.addAll(trace);
+				fillLinkingContainerSub(linkingContainer, tempTrace);
+			}
+		}
+	}
+	
+	@SuppressWarnings("rawtypes")
+	private static void fillConnections(Element element, DisplayModel displayModel) throws Exception {
+		if(element.getName().equals(XMLTAG_CONNECTION)) {
+			ConnectionModel result = new ConnectionModel(displayModel);
+			setPropertiesFromXML(element, result); 
+		} else if(element.getName().equals(XMLTAG_DISPLAY)){
+			List children = element.getChildren();
+			Iterator iterator = children.iterator();
+			while (iterator.hasNext()) {
+				Element subElement = (Element) iterator.next();
+				if(subElement.getName().equals(XMLTAG_CONNECTION))  {
+					fillConnections(subElement, displayModel);
+				}
+			}
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static void setPropertiesFromXML(Element element, AbstractWidgetModel model) {
+		if(model == null || element == null) return;
+		
+		String versionOnFile = element.getAttributeValue(XMLATTR_VERSION);
+		model.setVersionOnFile(Version.parseVersion(versionOnFile));
+		
+		if (element instanceof LineAwareElement) {
+		    model.setLineNumber(((LineAwareElement) element).getLineNumber());
+		}
+		
+		List children = element.getChildren();
+		Iterator iterator = children.iterator();
+		Set<String> propIdSet = model.getAllPropertyIDs();
+		while (iterator.hasNext()) {
+			Element subElement = (Element) iterator.next();
+			//handle property
+			if(propIdSet.contains(subElement.getName())){
+				String propId = subElement.getName();
+				try {				
+					model.setPropertyValue(propId,
+							model.getProperty(propId).readValueFromXML(subElement));
+				} catch (Exception e) {
+					String errorMessage = "Failed to read the " + propId + " property for " + model.getName() +". " +
+							"The default property value will be setted instead. \n" + e;
+					//MessageDialog.openError(null, "OPI File format error", errorMessage + "\n" + e.getMessage());
+					OPIBuilderPlugin.getLogger().log(Level.WARNING, errorMessage, e);
+					ConsoleService.getInstance().writeWarning(errorMessage);
+				}
+			}
+		}
+	}
+	
+	/**
+	 * Load opi file attached to LinkingContainer widget. 
+	 * 
+	 * @param container LinkingContainer to be filled.
+	 * @throws Exception
+	 */
+	public static void fillLinkingContainer(final AbstractLinkingContainerModel container) 
+			throws Exception {
+		fillLinkingContainerSub(container, new ArrayList<IPath>());
+	}
+
+	private static void fillLinkingContainerSub(final AbstractLinkingContainerModel container, List<IPath> trace)  
+		throws Exception {
+
+		if(container == null) return;
+
+		if(container.getRootDisplayModel() != null && 
+				container.getRootDisplayModel().getOpiFilePath() != null) {
+			if(trace.contains(container.getRootDisplayModel().getOpiFilePath())) {
+				container.setOPIFilePath("");
+				throw new Exception("Opi link contains some loops.\n" + trace.toString());
+			} else {
+				trace.add(container.getRootDisplayModel().getOpiFilePath());
+			}
+
+			IPath path = container.getOPIFilePath();
+			if(path != null && !path.isEmpty()) {
+				final DisplayModel inside = new DisplayModel(path);
+
+				fillDisplayModelFromInputStreamSub(ResourceUtil.pathToInputStream(path), inside, Display.getCurrent(), trace);
+				
+				// mark connection as it is loaded from linked opi
+				for(AbstractWidgetModel w : inside.getAllDescendants()) 
+					for(ConnectionModel conn : w.getSourceConnections()) 
+						conn.setLoadedFromLinkedOpi(true);
+
+
+				AbstractContainerModel loadTarget = inside;
+
+				if(!container.getGroupName().trim().equals("")){ //$NON-NLS-1$
+					AbstractWidgetModel group =
+							inside.getChildByName(container.getGroupName());
+					if(group != null && group instanceof AbstractContainerModel){
+						loadTarget = (AbstractContainerModel) group;
+					}
+				}
+
+				for (AbstractWidgetModel w : loadTarget.getChildren()) 
+					container.addChild(w, true);
+
+				container.setDisplayModel(inside);
+			}
+		}
+	}
+	
+	
+	/**Compare version without comparing qualifier.
+	 * @param v1
+	 * @param v2
+	 * @return
+	 */
+	private static int compareVersion(Version v1, Version v2) {
+		if (v2 == v1) { 
+			return 0;
+		}
+
+		int result = v1.getMajor() - v2.getMajor();
+		if (result != 0) {
+			return result;
+		}
+
+		result = v1.getMinor() - v2.getMinor();
+		if (result != 0) {
+			return result;
+		}
+
+		result = v1.getMicro() - v2.getMicro();
+		if (result != 0) {
+			return result;
+		}
+
+		return 0;
+	}
+	
+	/**
+	 * Return the wuid of the closest widget to offset char position in input stream
+	 * @param in the OPI file input stream
+	 * @param offset the character offset
+	 * @return String wuid
+	 * @throws IOException
+	 */
+	public static String findClosestWidgetUid(InputStream in, int offset)
+			throws IOException {
+		if (in == null) {
+			return null;
+		}
+		StringBuffer out = new StringBuffer();
+		BufferedReader br = new BufferedReader(new InputStreamReader(in));
+		char[] buf = new char[1024];
+		for (int len = br.read(buf); len>0; len = br.read(buf)) {
+			out.append(buf, 0, len);
+		}
+		br.close();
+		if (offset + XMLUtil.XMLTAG_WIDGET.length() + 2 >= out.length()) {
+			// The offset position is too close to the end of file
+			// No widget will be found
+			return null;
+		}
+		int widgetElementStart = offset;
+		while (widgetElementStart >= 0
+				&& !matchXMLTag(out, widgetElementStart, XMLUtil.XMLTAG_WIDGET)) {
+			widgetElementStart--;
+		}
+		if (widgetElementStart > 0) {
+			// corresponding widget element found
+			int wuidAttrStart = widgetElementStart + 1;
+			// looking for <wuid> before a <widget> or </widget
+			String xmlEndTagWidget = "/" + XMLUtil.XMLTAG_WIDGET;
+			while (!matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)
+					&& !matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET)
+					&& !matchXMLTag(out, wuidAttrStart, xmlEndTagWidget)) {
+				wuidAttrStart++;
+			}
+			if (matchXMLTag(out, wuidAttrStart, XMLUtil.XMLTAG_WIDGET_UID)) {
+				//  <wuid> found
+				wuidAttrStart = out.indexOf(">", wuidAttrStart);
+				if (wuidAttrStart >= 0) {
+					wuidAttrStart++;
+					if (wuidAttrStart < out.length()) {
+						int wuidAttrEnd = out.indexOf("</" + XMLTAG_WIDGET_UID,
+								wuidAttrStart);
+						if (wuidAttrEnd >= 0) {
+							return out.substring(wuidAttrStart, wuidAttrEnd);
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * Return true if the string starting at offset in sb matches with xmlTag.
+	 * @param sb StringBuffer
+	 * @param offset int
+	 * @param xmlTag String The XML tag name to check without '&lt;' and '&gt;'
+	 * @return
+	 */
+	private static boolean matchXMLTag(StringBuffer sb, int offset,
+			String xmlTag) {
+		if (offset >= sb.length()) {
+			return false;
+		}
+		if (sb.charAt(offset) != '<') {
+			return false;
+		}
+		int indexOfSpace = sb.indexOf(" ", offset);
+		int indexOfGt = sb.indexOf(">", offset);
+		int indexOfEndTag = Integer.MAX_VALUE;
+		if (indexOfSpace >= 0) {
+			indexOfEndTag = indexOfSpace;
+		}
+		if (indexOfGt >= 0 && indexOfGt < indexOfEndTag) {
+			indexOfEndTag = indexOfGt;
+		}
+		if (indexOfEndTag == Integer.MAX_VALUE) {
+			return false;
+		}
+		String potentialTag = sb.substring(offset + 1, indexOfEndTag);
+		return potentialTag.equals(xmlTag);
+	}
 
 	private static Element inputStreamToXML(InputStream stream) throws JDOMException, IOException {
 	    SAXBuilder saxBuilder = LineAwareXMLParser.createBuilder(); 

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
@@ -8,6 +8,7 @@
 package org.csstudio.opibuilder.scriptUtil;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
@@ -27,7 +28,6 @@ import org.jdom.input.SAXBuilder;
  *
  */
 public class FileUtil {
-
 	
 	/**Load the root element of an XML file. The element is a JDOM Element.
 	 * @param filePath path of the file. It must be an absolute path which can be either<br>
@@ -52,13 +52,19 @@ public class FileUtil {
 	 * @return root element of the XML file.
 	 * @throws Exception if the file does not exist or is not a correct XML file. 
 	 */
-	public static Element loadXMLFile(String filePath, AbstractBaseEditPart widget) throws Exception{	
-		IPath path = buildAbsolutePath(filePath, widget);
-		InputStream inputStream = ResourceUtil.pathToInputStream(path);
+	public static Element loadXMLFile(final String filePath, final AbstractBaseEditPart widget) throws Exception{	
+		final IPath path = buildAbsolutePath(filePath, widget);
 		SAXBuilder saxBuilder = new SAXBuilder();
-		Document doc = saxBuilder.build(inputStream);
-		Element root = doc.getRootElement();
-		return root;
+		File file = ResourceUtil.getFile(path);
+		final Document doc;
+		if (file == null) {
+		    InputStream inputStream = ResourceUtil.pathToInputStream(path);
+		    doc = saxBuilder.build(inputStream);
+		    inputStream.close();
+		} else {
+		    doc = saxBuilder.build(file);
+		}
+        return doc.getRootElement();        
 	}
 	
 	/**Return an {@link InputStream} of the file on the specified path.

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
@@ -54,6 +54,9 @@ public class FileUtil {
 	 */
 	public static Element loadXMLFile(final String filePath, final AbstractBaseEditPart widget) throws Exception{	
 		final IPath path = buildAbsolutePath(filePath, widget);
+		//set this to resolve Xincludes
+		System.setProperty("org.apache.xerces.xni.parser.XMLParserConfiguration",
+		        "org.apache.xerces.parsers.XIncludeParserConfiguration");
 		SAXBuilder saxBuilder = new SAXBuilder();
 		File file = ResourceUtil.getFile(path);
 		final Document doc;

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
@@ -54,9 +54,6 @@ public class FileUtil {
 	 */
 	public static Element loadXMLFile(final String filePath, final AbstractBaseEditPart widget) throws Exception{	
 		final IPath path = buildAbsolutePath(filePath, widget);
-		//set this to resolve Xincludes
-		System.setProperty("org.apache.xerces.xni.parser.XMLParserConfiguration",
-		        "org.apache.xerces.parsers.XIncludeParserConfiguration");
 		SAXBuilder saxBuilder = new SAXBuilder();
 		File file = ResourceUtil.getFile(path);
 		final Document doc;

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/ResourceUtil.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/ResourceUtil.java
@@ -69,7 +69,17 @@ public class ResourceUtil {
 				ResourceUtilSSHelper.class);
 	}
 	
-	
+	/**
+	 * Returns the absolute file represented by the <code>path</code> if such file exists.
+	 * If it does not exist null is returned.
+	 * 
+	 * @param path the path for which the file is requested
+	 * @return the absolute file
+	 * @throws Exception in case of an error
+	 */
+	public static File getFile(final IPath path) throws Exception {
+	    return IMPL.getFile(path);
+	}
 		
 	/**
 	 *Return the {@link InputStream} of the file that is available on the
@@ -323,6 +333,7 @@ public class ResourceUtil {
 	            sc = SSLContext.getInstance("SSL");
 	        } catch (NoSuchAlgorithmException e) {
 	            e.printStackTrace();
+	            return null;
 	        }
 	        try {
 	            sc.init(null, trustAllCerts, new java.security.SecureRandom());

--- a/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/ResourceUtilSSHelper.java
+++ b/applications/plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/ResourceUtilSSHelper.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.util;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
@@ -20,6 +21,16 @@ import org.eclipse.ui.IEditorInput;
  */
 public abstract class ResourceUtilSSHelper {
 	
+    /**
+     * Tries to return an absolute file represented by the given path.
+     * If such file does not exist null is returned.
+     * 
+     * @param path the path to the file
+     * @return the file 
+     * @throws Exception
+     */
+    public abstract File getFile(final IPath path) throws Exception;
+    
 	/**
 	 * Return the {@link InputStream} of the file that is available on the
 	 * specified path.


### PR DESCRIPTION
With #912 some of the existing features no longer worked (e.g. relative paths were incorrectly resolved, macros were not correctly propagated, connection did not work if it started in one linking container and ended in another one etc.). The issues have been fixed, at least the ones that are covered by ITER's test plans.

In addition, the FileUtil has been updated to resolve relative paths and to support Xinclude.
