### PR TITLE
Simplify checkstyle configuration.

### DIFF
--- a/applications/alarm/pom.xml
+++ b/applications/alarm/pom.xml
@@ -14,36 +14,4 @@
     <module>alarm-features</module>
     <module>alarm-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/appunorganized/pom.xml
+++ b/applications/appunorganized/pom.xml
@@ -14,36 +14,4 @@
     <module>appunorganized-repository</module>
   </modules>
   <version>0.0.1-SNAPSHOT</version>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/apputil/pom.xml
+++ b/applications/apputil/pom.xml
@@ -14,36 +14,4 @@
     <module>apputil-features</module>
     <module>apputil-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/archive/pom.xml
+++ b/applications/archive/pom.xml
@@ -14,36 +14,4 @@
     <module>archive-features</module>
     <module>archive-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/channel/pom.xml
+++ b/applications/channel/pom.xml
@@ -14,36 +14,4 @@
     <module>channel-features</module>
     <module>channel-plugins</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/databrowser/pom.xml
+++ b/applications/databrowser/pom.xml
@@ -14,36 +14,4 @@
     <module>databrowser-features</module>
     <module>databrowser-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/diag/pom.xml
+++ b/applications/diag/pom.xml
@@ -14,36 +14,4 @@
     <module>diag-features</module>
     <module>diag-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/display/pom.xml
+++ b/applications/display/pom.xml
@@ -14,36 +14,4 @@
     <module>display-features</module>
     <module>display-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/logbook/pom.xml
+++ b/applications/logbook/pom.xml
@@ -15,36 +15,4 @@
     <module>logbook-features</module>
     <module>logbook-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/opibuilder/pom.xml
+++ b/applications/opibuilder/pom.xml
@@ -14,36 +14,4 @@
     <module>opibuilder-features</module>
     <module>opibuilder-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -176,6 +176,36 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>checkstyle</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <version>2.15</version>
+            <executions>
+              <execution>
+                <id>validate</id>
+                <phase>validate</phase>
+                <configuration>
+                  <configLocation>../build/cs-studio-jenkins-checkstyle</configLocation>
+                  <encoding>UTF-8</encoding>
+                  <consoleOutput>true</consoleOutput>
+                  <outputFile>checkstyle-output.xml</outputFile>
+                  <sourceDirectory>.</sourceDirectory>
+                  <failsOnError>true</failsOnError>
+                  <linkXRef>false</linkXRef>
+                </configuration>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
   <repositories>
     <repository>

--- a/applications/scan/pom.xml
+++ b/applications/scan/pom.xml
@@ -14,36 +14,4 @@
     <module>scan-features</module>
     <module>scan-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/applications/shift/pom.xml
+++ b/applications/shift/pom.xml
@@ -13,36 +13,4 @@
     <module>shift-features</module>
     <module>shift-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/base/pom.xml
+++ b/core/base/pom.xml
@@ -13,36 +13,4 @@
   <module>base-repository</module>
   </modules>
   <groupId>org.csstudio</groupId>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/diirt/pom.xml
+++ b/core/diirt/pom.xml
@@ -7,36 +7,4 @@
   </parent>
   <artifactId>diirt</artifactId>
   <packaging>pom</packaging>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/platform/pom.xml
+++ b/core/platform/pom.xml
@@ -13,36 +13,4 @@
     <module>platform-features</module>
     <module>platform-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -212,6 +212,36 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>checkstyle</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <version>2.15</version>
+            <executions>
+              <execution>
+                <id>validate</id>
+                <phase>validate</phase>
+                <configuration>
+                  <configLocation>../build/cs-studio-jenkins-checkstyle</configLocation>
+                  <encoding>UTF-8</encoding>
+                  <consoleOutput>true</consoleOutput>
+                  <outputFile>checkstyle-output.xml</outputFile>
+                  <sourceDirectory>.</sourceDirectory>
+                  <failsOnError>true</failsOnError>
+                  <linkXRef>false</linkXRef>
+                </configuration>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
   <distributionManagement>
     <site>

--- a/core/ui/pom.xml
+++ b/core/ui/pom.xml
@@ -13,36 +13,4 @@
     <module>ui-repository</module>
     <module>ui-features</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/unorganized/pom.xml
+++ b/core/unorganized/pom.xml
@@ -14,36 +14,4 @@
     <module>unorganized-plugins</module>
     <module>unorganized-repository</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/core/utility/pom.xml
+++ b/core/utility/pom.xml
@@ -14,36 +14,4 @@
     <module>utility-repository</module>
   </modules>
   <groupId>org.csstudio</groupId>
-  <profiles>
-    <profile>
-      <id>checkstyle</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.15</version>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <configuration>
-                  <configLocation>../../build/cs-studio-jenkins-checkstyle</configLocation>
-                  <encoding>UTF-8</encoding>
-                  <consoleOutput>true</consoleOutput>
-                  <outputFile>checkstyle-output.xml</outputFile>
-                  <sourceDirectory>.</sourceDirectory>
-                  <failsOnError>true</failsOnError>
-                  <linkXRef>false</linkXRef>
-                </configuration>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
Only need checkstyle config in each top-level pom.  You can still run the checks for each module.