### PR TITLE
Add simplepv.pvmanager into opibuilder feature.

### DIFF
--- a/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/feature.xml
+++ b/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/feature.xml
@@ -160,6 +160,13 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
+         id="org.csstudio.simplepv.pvmanager"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.csstudio.examples"
          download-size="0"
          install-size="0"

--- a/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/feature.xml
+++ b/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/feature.xml
@@ -167,6 +167,13 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
+         id="org.csstudio.simplepv.vtypepv"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.csstudio.examples"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Otherwise pvmanager is not recognised by OPIBuilder.

@kasemir @shroffk is this the correct feature to add it into?