### PR TITLE
Linking Container Bugfix

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -56,7 +56,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 
     private List<ConnectionModel> connectionList;
     private Map<ConnectionModel, PointList> originalPoints;
-    
+
     @Override
     protected IFigure doCreateFigure() {
         LinkingContainerFigure f = new LinkingContainerFigure();
@@ -98,6 +98,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
     @Override
     protected void registerPropertyChangeHandlers() {
         IWidgetPropertyChangeHandler handler = new IWidgetPropertyChangeHandler(){
+            @Override
             public boolean handleChange(Object oldValue, Object newValue,
                     IFigure figure) {
                 if(newValue != null && newValue instanceof IPath){
@@ -119,6 +120,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 
         //load from group
         handler = new IWidgetPropertyChangeHandler() {
+            @Override
             public boolean handleChange(Object oldValue, Object newValue, IFigure figure) {
                 loadWidgets(getWidgetModel(),true);
                 configureDisplayModel();
@@ -129,6 +131,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         setPropertyChangeHandler(LinkingContainerModel.PROP_GROUP_NAME, handler);
 
         handler = new IWidgetPropertyChangeHandler() {
+            @Override
             public boolean handleChange(Object oldValue, Object newValue, IFigure figure) {
                 if((int)newValue == LinkingContainerModel.ResizeBehaviour.SIZE_OPI_TO_CONTAINER.ordinal()) {
                     ((LinkingContainerFigure)figure).setZoomToFitAll(true);
@@ -157,7 +160,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
      * @param path the path of the OPI file
      */
     private synchronized void loadWidgets(LinkingContainerModel model, final boolean checkSelf) {
-        try {           
+        try {
             model.removeAllChildren();
             XMLUtil.fillLinkingContainer(model);
         } catch (Exception e) {
@@ -190,14 +193,14 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         LinkingContainerModel widgetModel = getWidgetModel();
         DisplayModel displayModel = widgetModel.getDisplayModel();
         widgetModel.setDisplayModelViewer((GraphicalViewer) getViewer());
-        widgetModel.setDisplayModelDisplayID(widgetModel.getRootDisplayModel().getDisplayID());
+        widgetModel.setDisplayModelDisplayID(widgetModel.getRootDisplayModel(false).getDisplayID());
 
         UIBundlingThread.getInstance().addRunnable(new Runnable() {
             @Override
             public void run() {
                 LinkingContainerModel widgetModel = getWidgetModel();
                 widgetModel.setDisplayModelExecutionMode(getExecutionMode());
-                widgetModel.setDisplayModelOpiRuntime(widgetModel.getRootDisplayModel().getOpiRuntime());
+                widgetModel.setDisplayModelOpiRuntime(widgetModel.getRootDisplayModel(false).getOpiRuntime());
             }
         });
 
@@ -257,7 +260,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         //Load system macro
         if(displayModel.getMacrosInput().isInclude_parent_macros()){
             map.putAll(
-                    (LinkedHashMap<String, String>) displayModel.getParentMacroMap());
+                    displayModel.getParentMacroMap());
         }
         //Load macro from its macrosInput
         map.putAll(displayModel.getMacrosInput().getMacrosMap());
@@ -276,6 +279,9 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 
         DisplayModel parentDisplay = widgetModel.getRootDisplayModel();
         parentDisplay.syncConnections();
+        DisplayModel parentDisplay2 = widgetModel.getRootDisplayModel(false);
+        if (parentDisplay != parentDisplay2)
+            parentDisplay2.syncConnections();
     }
 
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractWidgetModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractWidgetModel.java
@@ -921,7 +921,16 @@ public abstract class AbstractWidgetModel implements IAdaptable,
     /**
      * @return the root display model for this widget. null if its parent is not set yet.
      */
-    public DisplayModel getRootDisplayModel(){
+    public DisplayModel getRootDisplayModel() {
+        return getRootDisplayModel(true);
+    }
+
+    /**
+     * @param useLinkingContainersDisplayModel if one of the parents of this widget is
+     *          a linking container use its display model
+     * @return the root display model for this widget. null if its parent is not set yet.
+     */
+    public DisplayModel getRootDisplayModel(boolean useLinkingContainersDisplayModel){
         AbstractContainerModel parent = getParent();
         if(parent == null){
             if(this instanceof DisplayModel)
@@ -934,7 +943,7 @@ public abstract class AbstractWidgetModel implements IAdaptable,
         {
             // If parent is a linking container,
             // use the display model of that
-            if (parent instanceof AbstractLinkingContainerModel) {
+            if (useLinkingContainersDisplayModel && parent instanceof AbstractLinkingContainerModel) {
                 DisplayModel m = ((AbstractLinkingContainerModel)parent).getDisplayModel();
                 if (m != null) return m;
             }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
@@ -465,6 +465,7 @@ public class XMLUtil {
             IPath path = container.getOPIFilePath();
             if(path != null && !path.isEmpty()) {
                 final DisplayModel inside = new DisplayModel(path);
+                inside.setDisplayID(container.getRootDisplayModel(false).getDisplayID());
 
                 fillDisplayModelFromInputStreamSub(ResourceUtil.pathToInputStream(path), inside, Display.getCurrent(), trace);
 


### PR DESCRIPTION
Another bug was discovered by @utzeln : when linking containers were stacked the $(DID) marco was not properly initialized. That resulted in scripts being triggered by incorrect pvs. It seems this also goes back to #913. 