### PR TITLE
o.c.opibuilder: Update shared links when an OPI is launched.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
@@ -36,7 +36,8 @@ Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.csstudio.swt.widgets;bundle-version="2.1.0",
  org.csstudio.swt.xygraph;bundle-version="2.0.4",
  org.eclipse.ui.ide,
- org.eclipse.core.resources
+ org.eclipse.core.resources,
+ org.csstudio.utility.product;bundle-version="1.2.2"
 Eclipse-RegisterBuddy: org.python.jython
 Bundle-ActivationPolicy: lazy
 Export-Package: org.csstudio.opibuilder,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/ExternalOpenDisplayAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/ExternalOpenDisplayAction.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.widgets.Display;
 
 /** Run OPI from external program, such as alarm GUI, data browser...
  *  @author Xihui Chen

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/OpenTopOPIsAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/OpenTopOPIsAction.java
@@ -101,19 +101,29 @@ public class OpenTopOPIsAction implements IWorkbenchWindowPulldownDelegate {
 
     public static void runOPI(final MacrosInput macrosInput, final IPath path)
     {
+        System.out.println("The macros: " + macrosInput);
         DisplayMode mode =  DisplayMode.NEW_TAB;
         if (macrosInput != null)
         {
+
             final String position = macrosInput.getMacrosMap().get(TOP_OPI_POSITION_KEY);
+            System.out.println("The position is " + position);
             if (position != null)
             {
-                try
+                if (position.toUpperCase().equals("NEW_SHELL"))
                 {
-                    mode = DisplayMode.valueOf("NEW_TAB_" + position.toUpperCase());
+                    mode = DisplayMode.NEW_SHELL;
                 }
-                catch (IllegalArgumentException ex)
+                else
                 {
-                    // Ignore
+                    try
+                    {
+                        mode = DisplayMode.valueOf("NEW_TAB_" + position.toUpperCase());
+                    }
+                    catch (IllegalArgumentException ex)
+                    {
+                        // Ignore
+                    }
                 }
             }
         }


### PR DESCRIPTION
In particular, this means after CS-Studio is started.  This requires
CS-Studio to understand a different syntax:

`cs-studio --launcher.openFile "/path/to/file macro1=value1¬links"`

Links are in the same format as the `-share_link` command-line argument.
The ¬ for separator may be changed before release.

I discussed this feature with @kasemir @shroffk @berryma4 at the code-a-thon.
See #544.  There are some gymnastics in keeping this off the UI thread but opening the OPI ON the UI thread.  You may want to review the threading.

It also allows opening OPI shells using the Position macro.