### PR TITLE
Issue1103 revert linkingcontainer

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -44,6 +44,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.editparts.ZoomListener;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionFilter;
 
 /**The Editpart Controller for a linking Container
@@ -207,6 +208,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
                 widgetModel.setDisplayModelOpiRuntime(widgetModel.getRootDisplayModel(false).getOpiRuntime());
             }
         });
+        
 
         connectionList = displayModel.getConnectionList();
         if(connectionList !=null && !connectionList.isEmpty()){
@@ -255,6 +257,15 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 
         LinkedHashMap<String,String> map = new LinkedHashMap<>();
         AbstractContainerModel loadTarget = displayModel;
+        
+        if(!widgetModel.getGroupName().trim().equals("")){ //$NON-NLS-1$
+            AbstractWidgetModel group =
+                displayModel.getChildByName(widgetModel.getGroupName());
+            if(group != null && group instanceof AbstractContainerModel){
+                loadTarget = (AbstractContainerModel) group;
+            }
+        }
+        
         // Load "LCID" macro whose value is unique to this instance of Linking Container.
         if (widgetModel.getExecutionMode() == ExecutionMode.RUN_MODE) {
             map.put("LCID", "LCID_" + getLinkingContainerID());

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -191,9 +191,18 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         //This need to be executed after GUI created.
         if(getWidgetModel().getDisplayModel() == null) {
             IPath path = getWidgetModel().getOPIFilePath();
-            getWidgetModel().setDisplayModel(new DisplayModel(path));
+           
+            final DisplayModel tempDisplayModel = new DisplayModel(path);
+            getWidgetModel().setDisplayModel(tempDisplayModel);
+            try {
+                XMLUtil.fillDisplayModelFromInputStream(
+                        ResourceUtil.pathToInputStream(path), tempDisplayModel,
+                        getViewer().getControl().getDisplay());
+            } catch (Exception e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
         }
-
 
         LinkingContainerModel widgetModel = getWidgetModel();
         DisplayModel displayModel = widgetModel.getDisplayModel();
@@ -243,8 +252,6 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
             ((LinkingContainerFigure)getFigure()).updateZoom();
         });
 
-        getWidgetModel().setDisplayModel(displayModel);
-
         //Add scripts on display model
         if (getExecutionMode() == ExecutionMode.RUN_MODE) {
             widgetModel
@@ -254,7 +261,6 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
                             .getScriptList());
         }
         // tempDisplayModel.removeAllChildren();
-
         LinkedHashMap<String,String> map = new LinkedHashMap<>();
         AbstractContainerModel loadTarget = displayModel;
         
@@ -293,7 +299,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         DisplayModel parentDisplay2 = widgetModel.getRootDisplayModel(false);
         if (parentDisplay != parentDisplay2)
             parentDisplay2.syncConnections();
-        if (widgetModel.isAutoSize()) {
+        if(getWidgetModel().isAutoSize()){
             performAutosize();
         }
     }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -109,7 +109,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
                                 getWidgetModel(), absolutePath);
                     DisplayModel displayModel = new DisplayModel(absolutePath);
                     widgetModel.setDisplayModel(displayModel);
-                    loadWidgets(getWidgetModel(),true);
+                    //loadWidgets(getWidgetModel(),true);
                     configureDisplayModel();
                 }
                 return true;
@@ -122,7 +122,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         handler = new IWidgetPropertyChangeHandler() {
             @Override
             public boolean handleChange(Object oldValue, Object newValue, IFigure figure) {
-                loadWidgets(getWidgetModel(),true);
+                //loadWidgets(getWidgetModel(),true);
                 configureDisplayModel();
                 return false;
             }
@@ -147,7 +147,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
             }
         };
         setPropertyChangeHandler(LinkingContainerModel.PROP_RESIZE_BEHAVIOUR, handler);
-        loadWidgets(getWidgetModel(),true);
+        //loadWidgets(getWidgetModel(),true);
         configureDisplayModel();
     }
 
@@ -158,10 +158,14 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
 
     /**
      * @param path the path of the OPI file
+     * 
+     * Removing this call because the add remove children in fillLinkingContainer overlap
+     * with the add remove in configureDisplayModel, and cause pv connection issues.
+     * This reverts some of the work from #912
      */
     private synchronized void loadWidgets(LinkingContainerModel model, final boolean checkSelf) {
         try {
-            model.removeAllChildren();
+          //  model.removeAllChildren();
             XMLUtil.fillLinkingContainer(model);
         } catch (Exception e) {
             //log first
@@ -248,9 +252,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
                             .getScriptList());
         }
         // tempDisplayModel.removeAllChildren();
-        if (widgetModel.isAutoSize()) {
-            performAutosize();
-        }
+
         LinkedHashMap<String,String> map = new LinkedHashMap<>();
         AbstractContainerModel loadTarget = displayModel;
         // Load "LCID" macro whose value is unique to this instance of Linking Container.
@@ -272,9 +274,7 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         widgetModel.setMacroMap(map);
 
         widgetModel.removeAllChildren();
-        for (AbstractWidgetModel w : loadTarget.getChildren()){
-            widgetModel.addChild(w, true);
-        }
+        widgetModel.addChildren(loadTarget.getChildren(), true);
         widgetModel.setDisplayModel(displayModel);
 
         DisplayModel parentDisplay = widgetModel.getRootDisplayModel();
@@ -282,6 +282,9 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
         DisplayModel parentDisplay2 = widgetModel.getRootDisplayModel(false);
         if (parentDisplay != parentDisplay2)
             parentDisplay2.syncConnections();
+        if (widgetModel.isAutoSize()) {
+            performAutosize();
+        }
     }
 
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LinkingContainerModel.java
@@ -90,7 +90,7 @@ public class LinkingContainerModel extends AbstractLinkingContainerModel {
      * The geographical size of the children.
      */
     private Dimension childrenGeoSize = null;
-
+    
     public LinkingContainerModel() {
         setSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
         setBorderStyle(BorderStyle.LOWERED);
@@ -98,7 +98,6 @@ public class LinkingContainerModel extends AbstractLinkingContainerModel {
 
     @Override
     protected void configureProperties() {
-
         addProperty(new BooleanProperty(PROP_ZOOMTOFITALL, "Zoom to Fit", WidgetPropertyCategory.Display, true));
         setPropertyVisibleAndSavable(PROP_ZOOMTOFITALL, false, false);
 
@@ -168,16 +167,16 @@ public class LinkingContainerModel extends AbstractLinkingContainerModel {
     @Override
     public void processVersionDifference(org.osgi.framework.Version boyVersionOnFile) {
         super.processVersionDifference(boyVersionOnFile);
-        if(boyVersionOnFile.compareTo(VERSION_CHANGE_OF_RESIZE_BEHAVIOUR) < 0) {
-            Activator.getLogger().log(Level.CONFIG, "Converting linking container to new style of resizing behaviour.");
-            if((Boolean)getPropertyValue(PROP_AUTO_SIZE)) {
-                setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SIZE_CONTAINER_TO_OPI.ordinal());
-            } else if((Boolean)getPropertyValue(PROP_ZOOMTOFITALL)) {
-                setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SIZE_OPI_TO_CONTAINER.ordinal());
-            } else {
-                setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SCROLL_OPI.ordinal());
-            }
-        }
+//        if(boyVersionOnFile.compareTo(VERSION_CHANGE_OF_RESIZE_BEHAVIOUR) < 0) {
+//            Activator.getLogger().log(Level.CONFIG, "Converting linking container to new style of resizing behaviour.");
+//            if((Boolean)getPropertyValue(PROP_AUTO_SIZE)) {
+//                setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SIZE_CONTAINER_TO_OPI.ordinal());
+//            } else if((Boolean)getPropertyValue(PROP_ZOOMTOFITALL)) {
+//                setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SIZE_OPI_TO_CONTAINER.ordinal());
+//            } else {
+//                setPropertyValue(PROP_RESIZE_BEHAVIOUR, ResizeBehaviour.SCROLL_OPI.ordinal());
+//            }
+//        }
     };
 
     /**

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractContainerModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractContainerModel.java
@@ -78,6 +78,26 @@ public abstract class AbstractContainerModel extends AbstractWidgetModel {
         }
 
     }
+    
+    public synchronized void addChildren(List<AbstractWidgetModel> children, boolean changeParent){
+	ArrayList<AbstractWidgetModel> oldList = new ArrayList<AbstractWidgetModel>(childrenList);
+	for(AbstractWidgetModel child : children){
+	    if(child != null && !childrenList.contains(child)){
+	            int newIndex = -1;
+	            if(layoutWidget != null){
+	                newIndex = childrenList.size() -1;
+	                childrenList.add(newIndex, child);
+	            }
+	            else
+	                childrenList.add(child);
+	            if(child instanceof AbstractLayoutModel)
+	                layoutWidget = (AbstractLayoutModel) child;
+	            if(changeParent)
+	                child.setParent(this);
+	        }
+	}
+	childrenProperty.firePropertyChange(oldList, children);
+    }
 
     public void addChild(AbstractWidgetModel child){
         addChild(child, true);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/persistence/XMLUtil.java
@@ -474,7 +474,6 @@ public class XMLUtil {
                     for(ConnectionModel conn : w.getSourceConnections())
                         conn.setLoadedFromLinkedOpi(true);
 
-
                 AbstractContainerModel loadTarget = inside;
 
                 if(!container.getGroupName().trim().equals("")){ //$NON-NLS-1$
@@ -485,8 +484,7 @@ public class XMLUtil {
                     }
                 }
 
-                for (AbstractWidgetModel w : loadTarget.getChildren())
-                    container.addChild(w, true);
+//                container.addChildren(loadTarget.getChildren(), true);
 
                 container.setDisplayModel(inside);
             }


### PR DESCRIPTION
reverting work from #912 that caused pv connection issues.
Mainly, the issue is from the add/remove of children in XMLUtil.fillLinkingContainer and the add/remove of children in configureDisplayModel overlap property fires sometimes.
Side note, adding/removing children seems like a bad way to refresh the model anyway.