### PR TITLE
#1219 compare the macromap and recreate the display model if there is a difference

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LinkingContainerEditpart.java
@@ -114,7 +114,11 @@ public class LinkingContainerEditpart extends AbstractLinkingContainerEditpart{
                         widgetModel.setDisplayModel(null);
                     }else{
                         DisplayModel displayModel = new DisplayModel(absolutePath);
-                        widgetModel.setDisplayModel(displayModel);
+                        if (widgetModel.getMacroMap().equals(displayModel.getMacroMap())) {
+                            widgetModel.setDisplayModel(displayModel);
+                        } else {
+                            widgetModel.setDisplayModel(null);
+                        }
                     }
                     configureDisplayModel();
                 }


### PR DESCRIPTION
When a linking container is being reloaded, there is an additional check to see if the macro map of the display model matches the widget model...if it does not then the display model is discarded

@berryma4 @kasemir can you check