### PR TITLE
Two minor bugfixes in csstudio perspective and databrowser

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/Model.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/Model.java
@@ -236,16 +236,23 @@ public class Model
         return axes.size();
     }
 
-    /** Get specific axis
+    /** Get specific axis. If the axis for the specified index does not exist, method returns null.
      *
      *  <p>Thread-safe access to multiple axes should use <code>getAxes()</code>
      *
      *  @param index Axis index
-     *  @return {@link AxisConfig}
+     *  @return {@link AxisConfig} or null if the config for the given index does not exist
      */
     public AxisConfig getAxis(final int index)
     {
-        return axes.get(index);
+        try
+        {
+            return axes.get(index);
+        }
+        catch (ArrayIndexOutOfBoundsException e)
+        {
+            return null;
+        }
     }
 
     /** Locate index of value axis

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
@@ -260,8 +260,11 @@ public class Controller
             @Override
             public void valueAxisChanged(final int index, final double lower, final double upper)
             {   // Update axis range in model, using UI thread because event may come from 'stagger' background thread
-                final AxisConfig axis = model.getAxis(index);
-                display.asyncExec(() -> axis.setRange(lower, upper));
+                if (index < model.getAxisCount()) {
+                    //only update if the model has that axis. If the trend is empty, the model may not have that axis
+                    final AxisConfig axis = model.getAxis(index);
+                    display.asyncExec(() -> axis.setRange(lower, upper));
+                }
             }
 
             @Override

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
@@ -260,9 +260,9 @@ public class Controller
             @Override
             public void valueAxisChanged(final int index, final double lower, final double upper)
             {   // Update axis range in model, using UI thread because event may come from 'stagger' background thread
-                if (index < model.getAxisCount()) {
+                final AxisConfig axis = model.getAxis(index);
+                if (axis != null) {
                     //only update if the model has that axis. If the trend is empty, the model may not have that axis
-                    final AxisConfig axis = model.getAxis(index);
                     display.asyncExec(() -> axis.setRange(lower, upper));
                 }
             }

--- a/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/CSStudioPerspective.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/CSStudioPerspective.java
@@ -119,10 +119,10 @@ public class CSStudioPerspective implements IPerspectiveFactory
             }
 
             if (viewPlaceholderInfo[3].trim().equalsIgnoreCase("multiple")) {
-            viewPlaceholderMap.put(viewPlaceholderInfo[0].trim(), location);
-            viewPlaceholderMap.put(viewPlaceholderInfo[0].trim() + MULTIPLE, location);
+            viewPlaceholderMap.put(viewPlaceholderInfo[1].trim(), location);
+            viewPlaceholderMap.put(viewPlaceholderInfo[1].trim() + MULTIPLE, location);
             } else {
-            viewPlaceholderMap.put(viewPlaceholderInfo[0].trim(), location);
+            viewPlaceholderMap.put(viewPlaceholderInfo[1].trim(), location);
             }
         }
         }else{


### PR DESCRIPTION
CSStudioPerspective: setting the layout via preferences did not work due to incorrect parsing of parameters.
DataBrowser was throwing ArrayIndexOutOfBoundsExceptions when the chart was empty.