### PR TITLE
Bug 1236 alarmclient deadlock

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Alarm Server Application
 Bundle-SymbolicName: org.csstudio.alarm.beast.server;singleton:=true
-Bundle-Version: 4.0.2.qualifier
+Bundle-Version: 4.1.1.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen - SNS
 Bundle-Description: BEAST Alarm Server
 Require-Bundle: org.junit;bundle-version="4.8.2",

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.alarm.beast.server</artifactId>
-  <version>4.0.2-SNAPSHOT</version>
+  <version>4.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/Application.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/Application.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.alarm.beast.server;
 
+import org.csstudio.alarm.beast.Activator;
 import org.csstudio.alarm.beast.Preferences;
 import org.csstudio.alarm.beast.WorkQueue;
 import org.csstudio.apputil.args.ArgParser;
@@ -15,6 +16,8 @@ import org.csstudio.apputil.args.StringOption;
 import org.csstudio.logging.LogConfigurator;
 import org.csstudio.security.PasswordInput;
 import org.csstudio.security.preferences.SecurePreferences;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 import org.eclipse.osgi.framework.console.CommandProvider;
@@ -116,6 +119,9 @@ public class Application implements IApplication
         System.out.println("JMS Client Topic:   " + Preferences.getJMS_AlarmClientTopic(config_name.get()));
         System.out.println("JMS Talk Topic:     " + Preferences.getJMS_TalkTopic(config_name.get()));
         System.out.println("JMS Global Topic:   " + Preferences.getJMS_GlobalServerTopic());
+        // Peek into Channel Access settings
+        final IPreferencesService service = Platform.getPreferencesService();
+        System.out.println("EPICS Addr. List:   " + service.getString("org.csstudio.platform.libs.epics", "addr_list", "", null));
 
         final WorkQueue work_queue = new WorkQueue();
         try

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/ChangeLog.html
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/ChangeLog.html
@@ -13,6 +13,12 @@ by all other alarm system tools.
 Revisions before 3.1.0 refer to the associated SNS CSS update.
 </p>
 
+<h2>4.1.1 - 2015-07-15</h2>
+<ul>
+  <li>Alarm Server: Log EPICS addr. list on startup</li>
+  <li>Alarm Client: Fix deadlock during model reload (#1236)</li>
+</ul>
+
 <h2>4.1.0 - 2015-06-09</h2>
 <ul>
   <li>Alarm Table: Blinking of unacknowledged alarms</li>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Shared Alarm Components
 Bundle-SymbolicName: org.csstudio.alarm.beast;singleton:=true
-Bundle-Version: 4.1.0.qualifier
+Bundle-Version: 4.1.1.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen - SNS
 Bundle-Description: BEAST library: Alarm model, ...
 Require-Bundle: org.junit;bundle-version="4.8.2",

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.alarm.beast</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/TreeItem.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/TreeItem.java
@@ -9,8 +9,8 @@ package org.csstudio.alarm.beast;
 
 import java.io.PrintStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /** Base for alarm tree items: Tree hierarchy, ID, name, path.
  *
@@ -27,16 +27,16 @@ public class TreeItem implements Serializable
     /** RDB ID
      *  @see #setID(int)
      */
-    private int id;
+    private volatile int id;
 
     /** Visible name of the item */
     final private String name;
 
     /** Parent node */
-    private transient TreeItem parent;
+    private volatile transient TreeItem parent;
 
     /** Sub-tree elements of this item */
-    final private List<TreeItem> children = new ArrayList<TreeItem>();
+    final private List<TreeItem> children = new CopyOnWriteArrayList<>();
 
     // According to JProfiler, equals()/getPathName()/hashCode()
     // are called A LOT whenever the JFace tree view is updated or
@@ -74,7 +74,7 @@ public class TreeItem implements Serializable
     }
 
     /** @return Parent item. <code>null</code> for root */
-    synchronized public TreeItem getParent()
+    public TreeItem getParent()
     {
         return parent;
     }
@@ -93,7 +93,7 @@ public class TreeItem implements Serializable
     }
 
     /** @return RDB ID */
-    final public synchronized int getID()
+    final public int getID()
     {
         return id;
     }
@@ -125,7 +125,7 @@ public class TreeItem implements Serializable
     }
 
     /** @return Number of child nodes */
-    final public synchronized int getChildCount()
+    final public int getChildCount()
     {
         return children.size();
     }
@@ -135,7 +135,7 @@ public class TreeItem implements Serializable
      *  @throws IndexOutOfBoundsException if the index is out of range
      *          (<tt>index &lt; 0 || index &gt;= getChildCount()</tt>)
      */
-    public synchronized TreeItem getChild(final int index)
+    public TreeItem getChild(final int index)
     {
         return children.get(index);
     }
@@ -144,7 +144,7 @@ public class TreeItem implements Serializable
      *  @param child_name Name of child to locate.
      *  @return Child with given name or <code>null</code> if not found.
      */
-    public synchronized TreeItem getChild(final String name)
+    public TreeItem getChild(final String name)
     {
         for (TreeItem child : children)
             if (child.getName().equals(name))
@@ -156,7 +156,7 @@ public class TreeItem implements Serializable
      *  'private' because child items add themself in constructor.
      *  @param child New child item
      */
-    final synchronized private void addChild(final TreeItem child)
+    final private void addChild(final TreeItem child)
     {
         children.add(child);
     }
@@ -184,7 +184,7 @@ public class TreeItem implements Serializable
      *  @param child
      *  @throws Error if child not known
      */
-    private synchronized void removeChild(final TreeItem child)
+    private void removeChild(final TreeItem child)
     {
         if (! children.remove(child))
             throw new Error("Corrupted tree item: " + toString());
@@ -194,7 +194,7 @@ public class TreeItem implements Serializable
      *  @param path Path to item
      *  @return Item or <code>null</code> if not found
      */
-    public synchronized TreeItem getItemByPath(final String path)
+    public TreeItem getItemByPath(final String path)
     {
         if (path == null)
             return null;
@@ -218,7 +218,7 @@ public class TreeItem implements Serializable
      *  Derived classes should override <code>dump_item()</code>
      *  @param out PrintStream
      */
-    final synchronized public void dump(final PrintStream out)
+    final public void dump(final PrintStream out)
     {
         dump(out, "");
     }
@@ -249,7 +249,7 @@ public class TreeItem implements Serializable
     /** Perform hierarchy consistency check
      *  @throws Exception on error
      */
-    final synchronized public void check() throws Exception
+    final public void check() throws Exception
     {
         // All subtree entries must point back to this as their parent
         for (TreeItem child : children)

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeItem.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeItem.java
@@ -269,6 +269,10 @@ public class AlarmTreeItem extends TreeItem
     }
 
     /** Update alarm state of this item, maximize alarm tree severities.
+     *
+     *  Ends up maximizing severity of parent chain,
+     *  so caller must lock root.
+     *
      *  @param current_severity Current severity of PV
      *  @param severity Alarm severity
      *  @param message Alarm message
@@ -320,7 +324,7 @@ public class AlarmTreeItem extends TreeItem
 
     /** Set severity/status of this item by maximizing over its child
      *  severities.
-     *  Recursively updates parent items.
+     *  Recursively updates parent items, so caller must have locked the root.
      *
      *  @return <code>true</code> if the severity of this item or any of its parents changed after
      *          this method is executed, or <code>false</code> if the severity remained the same

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeItem.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeItem.java
@@ -9,9 +9,10 @@ package org.csstudio.alarm.beast.client;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.csstudio.alarm.beast.Messages;
 import org.csstudio.alarm.beast.SeverityLevel;
@@ -40,36 +41,36 @@ public class AlarmTreeItem extends TreeItem
 {
     private static final long serialVersionUID = -8597126519675742036L;
 
-    private int disabled_children = 0;
+    private volatile int disabled_children = 0;
 
     /** Sub-tree elements of this item which are currently in alarm */
-    final private transient List<AlarmTreeItem> alarm_children = new ArrayList<AlarmTreeItem>();
+    final private transient List<AlarmTreeItem> alarm_children = new CopyOnWriteArrayList<>();
 
     // Using arrays for guidance, ..., commands to be thread-safe
 
     /** Guidance messages */
-    private GDCDataStructure guidance[] = new GDCDataStructure[0];
+    private volatile GDCDataStructure guidance[] = new GDCDataStructure[0];
 
     /** Related displays */
-    private GDCDataStructure displays[] = new GDCDataStructure[0];
+    private volatile GDCDataStructure displays[] = new GDCDataStructure[0];
 
     /** Commands */
-    private GDCDataStructure commands[] = new GDCDataStructure[0];
+    private volatile GDCDataStructure commands[] = new GDCDataStructure[0];
 
     /** Automated Actions */
-    private AADataStructure automated_actions[] = new AADataStructure[0];
+    private volatile AADataStructure automated_actions[] = new AADataStructure[0];
 
     /** Current severity of this item/subtree */
-    private SeverityLevel current_severity = SeverityLevel.OK;
+    private volatile SeverityLevel current_severity = SeverityLevel.OK;
 
     /** Highest/latched alarm severity of this item/subtree */
-    private SeverityLevel severity = SeverityLevel.OK;
+    private volatile SeverityLevel severity = SeverityLevel.OK;
 
     /**  Highest/latched alarm message of this item/subtree */
-    private String message = SeverityLevel.OK.getDisplayName();
+    private volatile String message = SeverityLevel.OK.getDisplayName();
 
     /** Time of last configuration change */
-    private transient Timestamp config_time; //it would be nice if Timestamp implemented Serializable
+    private volatile transient Timestamp config_time; //it would be nice if Timestamp implemented Serializable
 
     /** Initialize alarm tree item
      *  @param parent Parent item or <code>null</code>
@@ -85,7 +86,7 @@ public class AlarmTreeItem extends TreeItem
     /** @return Text (multi-line) that can be used as a tool-tip to
      *          describe this item and its current state
      */
-    public synchronized String getToolTipText()
+    public String getToolTipText()
     {
         return NLS.bind(Messages.Alarm_TT,
             new Object[]
@@ -123,7 +124,7 @@ public class AlarmTreeItem extends TreeItem
     }
 
     /** @return Number of child nodes */
-    final public synchronized int getDisabledChildCount()
+    final public int getDisabledChildCount()
     {
         return disabled_children;
     }
@@ -153,82 +154,80 @@ public class AlarmTreeItem extends TreeItem
     }
 
     /** @return Guidance messages */
-    public synchronized GDCDataStructure[] getGuidance()
+    public GDCDataStructure[] getGuidance()
     {
-        return Arrays.copyOf(guidance, guidance.length);
+        final GDCDataStructure[] safe_copy = guidance;
+        return Arrays.copyOf(safe_copy, safe_copy.length);
     }
 
     /** @param guidance Guidance messages */
-    synchronized void setGuidance(final GDCDataStructure guidance[])
+    void setGuidance(final GDCDataStructure guidance[])
     {
-        if (guidance == null)
-            throw new IllegalArgumentException();
-        this.guidance = guidance;
+        this.guidance = Objects.requireNonNull(guidance);
     }
 
     /** @return Related displays */
-    public synchronized GDCDataStructure[] getDisplays()
+    public GDCDataStructure[] getDisplays()
     {
-        return Arrays.copyOf(displays, displays.length);
+        final GDCDataStructure[] safe_copy = displays;
+        return Arrays.copyOf(safe_copy, safe_copy.length);
     }
 
     /** Add related display
      *  @param title
      *  @param display
      */
-    public synchronized void addDisplay(final String title, final String display)
+    public void addDisplay(final String title, final String display)
     {
-        final GDCDataStructure new_displays[] = Arrays.copyOf(displays, displays.length + 1);
+        final GDCDataStructure[] safe_copy = displays;
+        final GDCDataStructure[] new_displays = Arrays.copyOf(safe_copy, safe_copy.length + 1);
         new_displays[displays.length] = new GDCDataStructure(title, display);
         displays = new_displays;
     }
 
     /** @param displays Related displays */
-    synchronized void setDisplays(final GDCDataStructure displays[])
+    void setDisplays(final GDCDataStructure displays[])
     {
-        if (displays == null)
-            throw new IllegalArgumentException();
-        this.displays = displays;
+        this.displays = Objects.requireNonNull(displays);
     }
 
     /** @return Commands */
-    public synchronized GDCDataStructure[] getCommands()
+    public GDCDataStructure[] getCommands()
     {
-        return Arrays.copyOf(commands, commands.length);
+        final GDCDataStructure[] safe_copy = commands;
+        return Arrays.copyOf(safe_copy, safe_copy.length);
     }
 
     /** @param commands Commands */
-    synchronized void setCommands(final GDCDataStructure[] commands)
+    void setCommands(final GDCDataStructure[] commands)
     {
-        if (commands == null)
-            throw new IllegalArgumentException();
-        this.commands = commands;
+        this.commands = Objects.requireNonNull(commands);
     }
 
     /** @return Automated Actions */
-    public synchronized AADataStructure[] getAutomatedActions()
+    public AADataStructure[] getAutomatedActions()
     {
-        return Arrays.copyOf(automated_actions, automated_actions.length);
+        final AADataStructure[] safe_copy = automated_actions;
+        return Arrays.copyOf(safe_copy, safe_copy.length);
     }
 
     /** @param automated_actions Automated Actions */
-    synchronized void setAutomatedActions(final AADataStructure[] automated_actions)
+    void setAutomatedActions(final AADataStructure[] automated_actions)
     {
-        if (automated_actions == null)
-            throw new IllegalArgumentException();
-        this.automated_actions = automated_actions;
+        this.automated_actions = Objects.requireNonNull(automated_actions);
     }
 
     /** @return Time of last configuration change */
-    public synchronized String getConfigTime()
+    public String getConfigTime()
     {
-        if (config_time == null)
+        final Timestamp save_copy = config_time;
+        if (save_copy == null)
             return Messages.Unknown;
-        return TimestampHelper.format(config_time);
+        return TimestampHelper.format(save_copy);
     }
 
     /** @param config_time Time of last configuration change */
-    synchronized void setConfigTime(final Timestamp config_time)
+    void setConfigTime(final Timestamp config_time)
     {
         this.config_time = config_time;
     }
@@ -236,7 +235,7 @@ public class AlarmTreeItem extends TreeItem
     /** @return Number of sub-elements in configuration hierarchy
      *          which are currently in alarm
      */
-    public synchronized int getAlarmChildCount()
+    public int getAlarmChildCount()
     {
         return alarm_children.size();
     }
@@ -245,25 +244,25 @@ public class AlarmTreeItem extends TreeItem
      *  @param index Child element index 0 .. (getAlarmChildCount()-1)
      *  @return Sub-item in alarm hierarchy
      */
-    public synchronized AlarmTreeItem getAlarmChild(final int index)
+    public AlarmTreeItem getAlarmChild(final int index)
     {
         return alarm_children.get(index);
     }
 
     /** @return Current severity */
-    public synchronized SeverityLevel getCurrentSeverity()
+    public SeverityLevel getCurrentSeverity()
     {
         return current_severity;
     }
 
     /** @return Highest or latched severity */
-    public synchronized SeverityLevel getSeverity()
+    public SeverityLevel getSeverity()
     {
         return severity;
     }
 
     /** @return Highest or latched alarm message */
-    public synchronized String getMessage()
+    public String getMessage()
     {
         return message;
     }
@@ -439,15 +438,18 @@ public class AlarmTreeItem extends TreeItem
      *  @throws Exception on error
      */
     @SuppressWarnings("nls")
-    final protected synchronized void writeItemXML(final PrintWriter out, final int level) throws Exception
+    final protected void writeItemXML(final PrintWriter out, final int level) throws Exception
     {
         final String tag = getXMLTag();
         XMLWriter.start(out, level, tag + " " + XMLTags.NAME + "=\"" + getName() + "\"");
         out.println();
         writeConfigXML(out, level+1);
-        final int n = getChildCount();
-        for (int i=0; i<n; ++i)
-            getChild(i).writeItemXML(out, level+1);
+        synchronized (this)
+        {
+            final int n = getChildCount();
+            for (int i=0; i<n; ++i)
+                getChild(i).writeItemXML(out, level+1);
+        }
         XMLWriter.end(out, level, tag);
         out.println();
     }
@@ -458,7 +460,7 @@ public class AlarmTreeItem extends TreeItem
      *  @param out PrintWriter to which to send XML output
      *  @param level Indentation level
      */
-    protected synchronized void writeConfigXML(final PrintWriter out, final int level)
+    protected void writeConfigXML(final PrintWriter out, final int level)
     {
         writeGCD_XML(out, level, XMLTags.GUIDANCE, guidance);
         writeGCD_XML(out, level, XMLTags.DISPLAY, displays);
@@ -512,7 +514,7 @@ public class AlarmTreeItem extends TreeItem
     /** @return Short string representation for debugging */
     @SuppressWarnings("nls")
     @Override
-    public synchronized String toString()
+    public String toString()
     {
         final StringBuilder buf = new StringBuilder();
         buf.append(super.toString());

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeLeaf.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeLeaf.java
@@ -97,6 +97,9 @@ public class AlarmTreeLeaf extends AlarmTreeItem
     /** Update status/message/time stamp and maximize
      *  severities of parent entries.
      *
+     *  Ends up maximizing severity of parent chain,
+     *  so caller must lock root.
+     *
      *  @param current_severity Current severity of PV
      *  @param severity Alarm severity
      *  @param message Alarm message

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeLeaf.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreeLeaf.java
@@ -24,10 +24,10 @@ public class AlarmTreeLeaf extends AlarmTreeItem
     private static final long serialVersionUID = -2107556902460644540L;
 
     /** Description of alarm */
-    private String description = ""; //$NON-NLS-1$
+    private volatile String description = ""; //$NON-NLS-1$
 
     /** Timestamp of last alarm update */
-    private transient Timestamp timestamp = null;
+    private volatile transient Timestamp timestamp = null;
 
     /** Initialize
      *  @param parent Parent item
@@ -41,13 +41,13 @@ public class AlarmTreeLeaf extends AlarmTreeItem
     }
 
     /** @param description New description */
-    public synchronized void setDescription(final String description)
+    public void setDescription(final String description)
     {
         this.description = description == null ? "" : description; //$NON-NLS-1$
     }
 
     /** @return Alarm description */
-    public synchronized String getDescription()
+    public String getDescription()
     {
         return description;
     }
@@ -55,7 +55,7 @@ public class AlarmTreeLeaf extends AlarmTreeItem
     /** @return Verbose, multi-line description of the current alarm
      *          meant for elog entry or usage as drag/drop text
      */
-    public synchronized String getVerboseDescription()
+    public String getVerboseDescription()
     {
         return NLS.bind(Messages.VerboseAlarmDescriptionFmt,
                 new Object[]
@@ -70,28 +70,30 @@ public class AlarmTreeLeaf extends AlarmTreeItem
     }
 
     /** @return Time stamp of last status/severity update */
-    public synchronized Timestamp getTimestamp()
+    public Timestamp getTimestamp()
     {
         return timestamp;
     }
 
     /** @return Duration of current alarm state or empty text */
-    public synchronized String getDuration()
+    public String getDuration()
     {
-        if (timestamp == null)
+        final Timestamp safe_copy = timestamp;
+        if (safe_copy == null)
             return ""; //$NON-NLS-1$
-        final TimeDuration duration = Timestamp.now().durationFrom(timestamp);
+        final TimeDuration duration = Timestamp.now().durationFrom(safe_copy);
         if (duration.isNegative())
             return ""; //$NON-NLS-1$
         return SecondsParser.formatSeconds(duration.toSeconds());
     }
 
     /** @return Time stamp of last status/severity update as text */
-    public synchronized String getTimestampText()
+    public String getTimestampText()
     {
-        if (timestamp == null)
+        final Timestamp safe_copy = timestamp;
+        if (safe_copy == null)
             return ""; //$NON-NLS-1$
-        return TimestampHelper.format(timestamp);
+        return TimestampHelper.format(safe_copy);
     }
 
     /** Update status/message/time stamp and maximize
@@ -107,7 +109,7 @@ public class AlarmTreeLeaf extends AlarmTreeItem
      *  @see #getTimestamp()
      *  @return <code>true</code> if alarm state actually changed
      */
-    protected synchronized boolean setAlarmState(final SeverityLevel current_severity,
+    protected boolean setAlarmState(final SeverityLevel current_severity,
             final SeverityLevel severity, final String message,
             final Timestamp timestamp)
     {

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
@@ -24,21 +24,21 @@ import org.epics.util.time.Timestamp;
 public class AlarmTreePV extends AlarmTreeLeaf
 {
     private static final long serialVersionUID = 5262966990320748429L;
-    private boolean enabled = true;
-    private boolean latching = true;
-    private boolean annunciating = false;
+    private volatile boolean enabled = true;
+    private volatile boolean latching = true;
+    private volatile boolean annunciating = false;
 
-    private int delay = 0;
+    private volatile int delay = 0;
 
     /* Alarm when PV != OK more often than this count within delay */
-    private int count = 0;
+    private volatile int count = 0;
 
-    private String filter = ""; //$NON-NLS-1$
+    private volatile String filter = ""; //$NON-NLS-1$
 
     /** Current message of this item/subtree */
-    private String current_message = SeverityLevel.OK.getDisplayName();
+    private volatile String current_message = SeverityLevel.OK.getDisplayName();
 
-    private String value = null;
+    private volatile String value = null;
 
     /** Initialize
      *  @param parent Parent component in hierarchy
@@ -60,7 +60,7 @@ public class AlarmTreePV extends AlarmTreeLeaf
 
     /** {@inheritDoc} */
     @Override
-    public synchronized String getToolTipText()
+    public String getToolTipText()
     {
         return NLS.bind(Messages.AlarmPV_TT,
             new Object[]
@@ -78,33 +78,33 @@ public class AlarmTreePV extends AlarmTreeLeaf
 
     /** @return Current severity */
     @Override
-    public synchronized SeverityLevel getCurrentSeverity()
+    public SeverityLevel getCurrentSeverity()
     {
         return enabled ? super.getCurrentSeverity() : SeverityLevel.OK;
     }
 
     /** @return Current message */
-    public synchronized String getCurrentMessage()
+    public String getCurrentMessage()
     {
         return current_message;
     }
 
     /** @return Highest or latched severity */
     @Override
-    public synchronized SeverityLevel getSeverity()
+    public SeverityLevel getSeverity()
     {
         return enabled ? super.getSeverity() : SeverityLevel.OK;
     }
 
     /** @return Highest or latched alarm message */
     @Override
-    public synchronized String getMessage()
+    public String getMessage()
     {
         return enabled ? super.getMessage() : SeverityLevel.OK.getDisplayName();
     }
 
     /** @return <code>true</code> if alarms from PV are enabled */
-    public synchronized boolean isEnabled()
+    public boolean isEnabled()
     {
         return enabled;
     }
@@ -112,7 +112,7 @@ public class AlarmTreePV extends AlarmTreeLeaf
     /** Set filter expression for enablement
      *  @param filter New filter
      */
-    public synchronized void setFilter(final String filter)
+    public void setFilter(final String filter)
     {
         if (filter == null)
             this.filter = ""; //$NON-NLS-1$
@@ -121,55 +121,55 @@ public class AlarmTreePV extends AlarmTreeLeaf
     }
 
     /** @param enable Enable the PV? */
-    public synchronized void setEnabled(final boolean enable)
+    public void setEnabled(final boolean enable)
     {
         enabled = enable;
     }
 
     /** @return Filter expression for enablement (never <code>null</code>) */
-    public synchronized String getFilter()
+    public String getFilter()
     {
         return filter;
     }
 
     /** @param annunciating New annunciating behavior */
-    public synchronized void setAnnunciating(final boolean annunciating)
+    public void setAnnunciating(final boolean annunciating)
     {
         this.annunciating = annunciating;
     }
 
     /** @return <code>true</code> if alarms get annunciated */
-    public synchronized boolean isAnnunciating()
+    public boolean isAnnunciating()
     {
         return annunciating;
     }
 
     /** @param latching New latching behavior */
-    public synchronized void setLatching(final boolean latching)
+    public void setLatching(final boolean latching)
     {
         this.latching = latching;
     }
 
     /** @return <code>true</code> if alarms latch for acknowledgment */
-    public synchronized boolean isLatching()
+    public boolean isLatching()
     {
         return latching;
     }
 
     /** @param seconds Alarm delay */
-    public synchronized void setDelay(final double seconds)
+    public void setDelay(final double seconds)
     {
         delay = (int) Math.round(seconds);
     }
 
     /** @return Alarm delay in seconds */
-    public synchronized int getDelay()
+    public int getDelay()
     {
         return delay;
     }
 
     /** @return count Alarm when PV != OK more often than this count within delay */
-    public synchronized int getCount()
+    public int getCount()
     {
         return count;
     }
@@ -177,13 +177,13 @@ public class AlarmTreePV extends AlarmTreeLeaf
     /** Alarm when PV != OK more often than this count within delay
      *  @param count New count
      */
-    public synchronized void setCount(final int count)
+    public void setCount(final int count)
     {
         this.count = count;
     }
 
     /** @return Value that triggered last status/severity update */
-    public synchronized String getValue()
+    public String getValue()
     {
         return value;
     }
@@ -248,7 +248,7 @@ public class AlarmTreePV extends AlarmTreeLeaf
      *  @see AlarmTree#writeConfigXML(PrintWriter, String)
      */
     @Override
-    protected synchronized void writeConfigXML(final PrintWriter out, final int level)
+    protected void writeConfigXML(final PrintWriter out, final int level)
     {
         XMLWriter.XML(out, level, XMLTags.DESCRIPTION, getDescription());
         if (!enabled)
@@ -271,7 +271,7 @@ public class AlarmTreePV extends AlarmTreeLeaf
      *          meant for elog entry or usage as drag/drop text
      */
     @Override
-    public synchronized String getVerboseDescription()
+    public String getVerboseDescription()
     {
         return NLS.bind(Messages.VerboseAlarmPVDescriptionFmt,
                 new Object[]

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/ui/clientmodel/AlarmClientModel.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/ui/clientmodel/AlarmClientModel.java
@@ -918,12 +918,11 @@ public class AlarmClientModel
             {
                 config.closeStatements();
             }
+            // This could change the alarm tree after a PV was disabled or enabled.
+            final AlarmTreeItem parent = pv.getParent();
+            if (parent != null)
+                parent.maximizeSeverity();
         }
-
-        // This could change the alarm tree after a PV was disabled or enabled.
-        final AlarmTreeItem parent = pv.getParent();
-        if (parent != null)
-            parent.maximizeSeverity();
 
         // Note that this may actually be a new PV that this instance
         // of the client GUI has just added.
@@ -948,6 +947,8 @@ public class AlarmClientModel
     public void updateEnablement(final String name, final boolean enabled)
     {
         final AlarmTreePV pv;
+        // Lock model because complete tree is searched for PV,
+        // then severity maximized up to root.
         synchronized (this)
         {
             pv = findPV(name);
@@ -959,11 +960,11 @@ public class AlarmClientModel
                 return;
             }
             pv.setEnabled(enabled);
+            // This could change the alarm tree after a PV was disabled or enabled.
+            final AlarmTreeItem parent = pv.getParent();
+            if (parent != null)
+                parent.maximizeSeverity();
         }
-        // This could change the alarm tree after a PV was disabled or enabled.
-        final AlarmTreeItem parent = pv.getParent();
-        if (parent != null)
-            parent.maximizeSeverity();
         // Update alarm display
         fireNewAlarmState(pv, true);
     }


### PR DESCRIPTION
Fixes #1236:

maximizeSeverity() needs to be called with locked 'root', because it traverses the alarm tree.

Replaced several sync'ed sections with volatile variables and safe copies.