### PR TITLE
apputil: do not build test plugins that aren't compiling

### DIFF
--- a/applications/apputil/apputil-plugins/pom.xml
+++ b/applications/apputil/apputil-plugins/pom.xml
@@ -14,7 +14,6 @@
     <module>org.csstudio.apputil.ui</module>
     <module>org.csstudio.apputil.ui.test</module>
     <module>org.csstudio.remote</module>
-    <module>org.csstudio.remote.test</module>
     <module>org.csstudio.utility.adlParser</module>
     <module>org.csstudio.utility.caSnooperUi</module>
     <module>org.csstudio.utility.clock</module>
@@ -41,7 +40,6 @@
     <module>org.csstudio.utility.treemodel</module>
     <module>org.csstudio.utility.treemodel.test</module>
     <module>org.csstudio.servicelocator</module>
-    <module>org.csstudio.servicelocator.test</module>
     <module>org.csstudio.domain.common</module>
     <module>org.csstudio.domain.common.test</module>
   </modules>


### PR DESCRIPTION
* org.csstudio.remote.test
* org.csstudio.servicelocator.test

These plugins fail our build once `-DskipTests=true` is *removed*.  It would be better to fix their compilation, but in my opinion it's better that it's possible to run ANY tests than just running no tests at all.  Feel free not to merge if you disagree.

As discussed in #1154.

