### PR TITLE
 Add eclipse.{central,mirror}.url properties to core/applications POMs

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -20,7 +20,9 @@
     <tycho-extras.version>0.22.0</tycho-extras.version>
     <cs-studio.version>4.1</cs-studio.version>
     <cs-studio-central.url>http://download.controlsystemstudio.org/applications/4.1</cs-studio-central.url>
-    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository</orbit-site>
+    <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
+    <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>
+    <orbit-site>${eclipse.mirror.url}/tools/orbit/downloads/drops/R20140114142710/repository</orbit-site>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
     <baselineMode>fail</baselineMode>
@@ -61,13 +63,13 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>http://download.eclipse.org/releases/luna</eclipse-site>
-        <eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
-        <rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
-        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
-        <!--        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>    LATEST RAP HAS PROBLEMS -->
+        <eclipse-site>${eclipse.mirror.url}/releases/luna</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.4</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/2.3</rap-site>
+        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
+        <!--        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef</rap-incubator-site>    LATEST RAP HAS PROBLEMS -->
         <platform-version>[4.3,4.4)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/luna/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
     <profile>
@@ -79,13 +81,13 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>http://download.eclipse.org/releases/luna</eclipse-site>
-        <eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
-        <rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
-        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
-        <!--        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>  LATEST RAP HAS PROBLEMS -->
+        <eclipse-site>${eclipse.mirror.url}/releases/luna</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.4</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/2.3</rap-site>
+        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
+        <!--        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef</rap-incubator-site>  LATEST RAP HAS PROBLEMS -->
         <platform-version>[4.3,4.4)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/luna/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
     <profile>
@@ -97,12 +99,12 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>http://download.eclipse.org/releases/kepler</eclipse-site>
-        <eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.3</eclipse-update-site>
-        <rap-site>http://download.eclipse.org/rt/rap/2.2</rap-site>
-        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/2.2/gef</rap-incubator-site>
+        <eclipse-site>${eclipse.mirror.url}/releases/kepler</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.3</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/2.2</rap-site>
+        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/2.2/gef</rap-incubator-site>
         <platform-version>[4.2,4.3)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
     <profile>
@@ -236,7 +238,7 @@
     </repository>
     <repository>
       <id>efx</id>
-      <url>http://download.eclipse.org/efxclipse/runtime-released/1.2.0/site</url>
+      <url>${eclipse.mirror.url}/efxclipse/runtime-released/1.2.0/site</url>
       <layout>p2</layout>
     </repository>
   </repositories>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -20,6 +20,7 @@
     <tycho-extras.version>0.22.0</tycho-extras.version>
     <cs-studio.version>4.1</cs-studio.version>
     <cs-studio-central.url>http://download.controlsystemstudio.org/applications/4.1</cs-studio-central.url>
+    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository</orbit-site>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
     <baselineMode>fail</baselineMode>
@@ -230,7 +231,7 @@
     </repository>
     <repository>
       <id>orbit</id>
-      <url>http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository</url>
+      <url>${orbit-site}</url>
       <layout>p2</layout>
     </repository>
     <repository>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,9 @@
     <tycho-extras.version>0.22.0</tycho-extras.version>
     <cs-studio.version>4.1</cs-studio.version>
     <cs-studio-central.url>http://download.controlsystemstudio.org/core/4.1</cs-studio-central.url>
-    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository</orbit-site>
+    <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
+    <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>
+    <orbit-site>${eclipse.mirror.url}/tools/orbit/downloads/drops/R20140114142710/repository</orbit-site>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
     <baselineMode>fail</baselineMode>
@@ -61,13 +63,13 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>http://download.eclipse.org/releases/luna</eclipse-site>
-        <eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
-        <rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
-        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
-        <!--        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>    LATEST RAP HAS PROBLEMS -->
+        <eclipse-site>${eclipse.mirror.url}/releases/luna</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.4</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/2.3</rap-site>
+        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
+        <!--        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef</rap-incubator-site>    LATEST RAP HAS PROBLEMS -->
         <platform-version>[4.3,4.4)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/luna/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
     <profile>
@@ -79,13 +81,13 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>http://download.eclipse.org/releases/luna</eclipse-site>
-        <eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
-        <rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
-        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
-        <!--        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>    LATEST RAP HAS PROBLEMS -->
+        <eclipse-site>${eclipse.mirror.url}/releases/luna</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.4</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/2.3</rap-site>
+        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef/20150122-1538</rap-incubator-site>
+        <!--        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/nightly/gef</rap-incubator-site>    LATEST RAP HAS PROBLEMS -->
         <platform-version>[4.3,4.4)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/luna/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
     <profile>
@@ -97,12 +99,12 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>http://download.eclipse.org/releases/kepler</eclipse-site>
-        <eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.3</eclipse-update-site>
-        <rap-site>http://download.eclipse.org/rt/rap/2.2</rap-site>
-        <rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/2.2/gef</rap-incubator-site>
+        <eclipse-site>${eclipse.mirror.url}/releases/kepler</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.3</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/2.2</rap-site>
+        <rap-incubator-site>${eclipse.central.url}/rt/rap/incubator/2.2/gef</rap-incubator-site>
         <platform-version>[4.2,4.3)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
     <profile>
@@ -207,7 +209,7 @@
         </repository>
         <repository>
           <id>efx</id>
-          <url>http://download.eclipse.org/efxclipse/runtime-released/1.2.0/site</url>
+          <url>${eclipse.mirror.url}/efxclipse/runtime-released/1.2.0/site</url>
           <layout>p2</layout>
         </repository>
       </repositories>


### PR DESCRIPTION
Although Tycho uses mirrors to download actual artifacts (bundles), it always downloads p2 metadata (`content.jar`, `artifacts.jar`, etc.) from `download.eclipse.org`. Changing `eclipse.mirror.url` allows that metadata to be downloaded from a mirror instead, which can be much faster.

`eclipse.central.url` should not be changed.

By default `eclipse.mirror.url` is the same as `eclipse.central.url` (`download.eclipse.org`), but can be changed to point to a nearby mirror.