### PR TITLE
Fixed a few issues in BOY

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/DisplayLauncher.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/DisplayLauncher.java
@@ -10,6 +10,8 @@ package org.csstudio.opibuilder.runmode;
 import java.util.Optional;
 
 import org.csstudio.opibuilder.runmode.RunModeService.DisplayMode;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.IEditorLauncher;
 
@@ -27,6 +29,10 @@ public class DisplayLauncher implements IEditorLauncher
     @Override
     public void open(final IPath path)
     {
-        RunModeService.openDisplay(path, Optional.empty(), DisplayMode.NEW_TAB, Optional.empty());
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        IPath workspacePath = path.makeRelativeTo(root.getLocation());
+        workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
+        //the view expects an absolute path within workspace, otherwise it doesn't find linked files
+        RunModeService.openDisplay(workspacePath, Optional.empty(), DisplayMode.NEW_TAB, Optional.empty());
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -28,6 +28,8 @@ import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
 import org.eclipse.gef.tools.DragEditPartsTracker;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.events.ShellListener;
 import org.eclipse.swt.graphics.Image;
@@ -49,11 +51,12 @@ public class OPIShell implements IOPIRuntime {
     // Cache of open OPI shells.
     private static final Set<OPIShell> openShells = new HashSet<OPIShell>();
 
-    private Shell shell;
-    private IPath path;
+    private final Image icon;
+    private final Shell shell;
+    private final IPath path;
     // macrosInput should not be null.  If there are no macros it should
     // be an empty MacrosInput object.
-    private MacrosInput macrosInput;
+    private final MacrosInput macrosInput;
     private final ActionRegistry actionRegistry;
     private DisplayModel displayModel;
 
@@ -61,9 +64,12 @@ public class OPIShell implements IOPIRuntime {
     // it to the cache.
     private OPIShell(Display display, IPath path, MacrosInput macrosInput) {
 
+        this.icon = OPIBuilderPlugin.imageDescriptorFromPlugin(OPIBuilderPlugin.PLUGIN_ID, "icons/OPIRunner.png")
+                .createImage(display);
         this.path = path;
         this.macrosInput = macrosInput;
         this.shell = new Shell(display);
+        this.shell.setImage(icon);
         this.displayModel = new DisplayModel(path);
         this.displayModel.setOpiRuntime(this);
         this.actionRegistry = new ActionRegistry();
@@ -118,6 +124,13 @@ public class OPIShell implements IOPIRuntime {
                         shell.setFocus();
                         firstRun = false;
                     }
+                }
+            });
+            shell.addDisposeListener(new DisposeListener() {
+
+                @Override
+                public void widgetDisposed(DisposeEvent e) {
+                    if (!icon.isDisposed()) icon.dispose();
                 }
             });
             shell.pack();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/ShellLauncher.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/ShellLauncher.java
@@ -7,6 +7,8 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.runmode;
 
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.IEditorLauncher;
 
@@ -25,6 +27,10 @@ public class ShellLauncher implements IEditorLauncher
     @Override
     public void open(final IPath path)
     {
-        OPIShell.openOPIShell(path, null);
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        IPath workspacePath = path.makeRelativeTo(root.getLocation());
+        workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
+        //the OPIShell expects an absolute path within workspace, otherwise it doesn't find linked files
+        OPIShell.openOPIShell(workspacePath, null);
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.gef.ui.actions.GEFActionConstants;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
@@ -98,6 +99,15 @@ public final class OPIRunnerContextMenuProvider extends ContextMenuProvider {
 //        MenuManager cssMenu = new MenuManager("CSS", "css");
 //        cssMenu.add(new Separator("additions")); //$NON-NLS-1$
 //        menu.add(cssMenu);
+    }
+
+    @Override
+    protected boolean allowItem(IContributionItem itemToAdd) {
+        //org.eclipse.wst.sse.ui adds some junk, which we don't need
+        if ("sourceMenuId".equals(itemToAdd.getId())) { //$NON-NLS-1$
+            return false;
+        }
+        return super.allowItem(itemToAdd);
     }
 
     /**


### PR DESCRIPTION
Bug fix for #1293: when opening an path, that path should always be transformed into a path relative to workspace. This way all files will be properly loaded.

The pull request includes two cosmetic bugfixes: 
- added missing icon in a standalone boy window,
- remove the Source -> Format menu item from the standalone OPI context menu