### PR TITLE
Scan 1297

### DIFF
--- a/applications/scan/scan-plugins/org.csstudio.scan.server/plugin_customization.ini
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/plugin_customization.ini
@@ -46,7 +46,7 @@ org.csstudio.platform.libs.epics/use_pure_java=true
 org.csstudio.platform.libs.epics/addr_list=127.0.0.1
 
 # Logging preferences
-org.csstudio.logging/console_level=INFO
+org.csstudio.logging/console_level=CONFIG
 org.csstudio.logging/jms_url=
 
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = false

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ExecutableScan.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ExecutableScan.java
@@ -380,7 +380,7 @@ public class ExecutableScan extends LoggedScan implements ScanContext, Callable<
     @Override
     public Object call() throws Exception
     {
-        logger.log(Level.CONFIG, "Executing \"{0}\" [{1}]", new Object[] { getName(), new MemoryInfo()});
+        logger.log(Level.CONFIG, "Executing ID {0} \"{1}\" [{2}]", new Object[] { getId(), getName(), new MemoryInfo()});
 
         try
         (

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tree display of Scan
 Bundle-SymbolicName: org.csstudio.scan.ui.scantree;singleton:=true
-Bundle-Version: 4.1.0.qualifier
+Bundle-Version: 4.2.2.qualifier
 Bundle-Activator: org.csstudio.scan.ui.scantree.Activator
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Localization: plugin

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/plugin.properties
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/plugin.properties
@@ -4,3 +4,5 @@ ScanCommands=Scan Command Palette
 SimulateScan=Simulate Scan
 SubmitScan=Submit Scan
 OpenScanTree=Open in Scan Editor
+ResubmitScan=Re-submit Scan
+SaveScan=Save Scan as *.scn file

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/plugin.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/plugin.xml
@@ -76,6 +76,16 @@
             name="%OpenScanTree">
       </command>
       <command
+            defaultHandler="org.csstudio.scan.ui.scantree.ResubmitScanHandler"
+            id="org.csstudio.scan.ui.scantree.resubmit"
+            name="%ResubmitScan">
+      </command>
+      <command
+            defaultHandler="org.csstudio.scan.ui.scantree.SaveScanHandler"
+            id="org.csstudio.scan.ui.scantree.save_as"
+            name="%SaveScan">
+      </command>
+      <command
             defaultHandler="org.csstudio.scan.ui.scantree.operations.ShowSimulationHandler"
             id="org.csstudio.scan.ui.scantree.show_simulation"
             name="Show Simulation Result">
@@ -152,6 +162,54 @@
          <command
                commandId="org.csstudio.scan.ui.scantree.submit"
                icon="icons/run.png">
+         </command>
+      </menuContribution>
+      <menuContribution
+            locationURI="popup:org.eclipse.ui.popup.any?after=scan">
+         <command
+               commandId="org.csstudio.scan.ui.scantree.save_as"
+               icon="platform:/plugin/org.eclipse.ui/icons/full/etool16/saveas_edit.gif"
+               label="%SaveScan"
+               style="push">
+            <visibleWhen
+                  checkEnabled="false">
+               <with
+                     variable="selection">
+                  <!-- Enable on 1 ScanInfo, but if the 'active' scan updates,
+                       the selection will be empty, so look for 0 or 1
+                    -->
+                  <count value="+"/>
+                  <iterate>
+                     <instanceof
+                           value="org.csstudio.scan.server.ScanInfo">
+                     </instanceof>
+                  </iterate>
+               </with>
+            </visibleWhen>
+         </command>
+      </menuContribution>
+      <menuContribution
+            locationURI="popup:org.eclipse.ui.popup.any?after=scan">
+         <command
+               commandId="org.csstudio.scan.ui.scantree.resubmit"
+               icon="icons/run.png"
+               label="%ResubmitScan"
+               style="push">
+            <visibleWhen
+                  checkEnabled="false">
+               <with
+                     variable="selection">
+                  <!-- Enable on 1 ScanInfo, but if the 'active' scan updates,
+                       the selection will be empty, so look for 0 or 1
+                    -->
+                  <count value="+"/>
+                  <iterate>
+                     <instanceof
+                           value="org.csstudio.scan.server.ScanInfo">
+                     </instanceof>
+                  </iterate>
+               </with>
+            </visibleWhen>
          </command>
       </menuContribution>
       <menuContribution

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan.ui.scantree</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.2.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/AbstractScanHandler.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/AbstractScanHandler.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.scan.ui.scantree;
+
+import org.csstudio.scan.client.ScanClient;
+import org.csstudio.scan.server.ScanInfo;
+import org.csstudio.scan.server.ScanState;
+import org.csstudio.scan.ui.ScanHandlerUtil;
+import org.csstudio.ui.util.dialogs.ExceptionDetailsErrorDialog;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+/** Base for Command handler that fetches a scan from server and then does something with it
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+abstract public class AbstractScanHandler extends AbstractHandler
+{
+    /** Shell which the command was invoked */
+    protected volatile Shell shell;
+
+    /** To be implemented: Perform something on a downloaded scan.
+     *
+     *  <p>Will be executed off the UI thread.
+     *
+     *  @param client {@link ScanClient}
+     *  @param info {@link ScanInfo}
+     *  @param xml_commands XML of scan
+     *  @throws Exception on error
+     */
+    abstract protected void handleScan(final ScanClient client, final ScanInfo info, final String xml_commands) throws Exception;
+
+    /** {@inheritDoc} */
+    @Override
+    public Object execute(final ExecutionEvent event) throws ExecutionException
+    {
+        final ScanInfo info = ScanHandlerUtil.getScanInfo(event);
+        if (info == null)
+            return null;
+
+        shell = HandlerUtil.getActiveShellChecked(event);
+        if (info.getState() == ScanState.Logged)
+        {
+            MessageDialog.openInformation(shell, Messages.OpenScanTreeError,
+                  NLS.bind(Messages.NoScanCommandsFmt, info.getName()));
+            return null;
+        }
+
+        // Use Job to read commands from server
+        final Job job = new Job("Download Scan")
+        {
+            @Override
+            protected IStatus run(final IProgressMonitor monitor)
+            {
+                try
+                {
+                    // Fetch commands from server
+                    final ScanClient client = new ScanClient();
+                    final String xml_commands = client.getScanCommands(info.getId());
+                    // Do something
+                    handleScan(client, info, xml_commands);
+                }
+                catch (Exception ex)
+                {
+                    final Display display = shell.getDisplay();
+                    display.asyncExec(() -> ExceptionDetailsErrorDialog.openError(shell, Messages.Error, ex));
+                }
+                return Status.OK_STATUS;
+            }
+        };
+        job.schedule();
+
+        return null;
+    }
+}

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/ResubmitScanHandler.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/ResubmitScanHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.scan.ui.scantree;
+
+import org.csstudio.scan.client.ScanClient;
+import org.csstudio.scan.server.ScanInfo;
+
+/** Command handler that fetches a scan from server and re-submits it
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class ResubmitScanHandler extends AbstractScanHandler
+{
+    @Override
+    protected void handleScan(final ScanClient client, final ScanInfo info, final String xml_commands) throws Exception
+    {
+        client.submitScan(info.getName(), xml_commands);
+    }
+}

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/ScanEditor.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/ScanEditor.java
@@ -748,7 +748,7 @@ public class ScanEditor extends EditorPart implements ScanInfoModelListener, Sca
     @Override
     public void doSaveAs()
     {
-        final IFile file = promptForFile(null);
+        final IFile file = promptForFile(getSite().getShell(), null);
         if (file == null)
             return;
         if (saveToFile(new NullProgressMonitor(), file))
@@ -759,12 +759,15 @@ public class ScanEditor extends EditorPart implements ScanInfoModelListener, Sca
     }
 
     /** Prompt for file name
+     *
+     *  <p>Asserts that it's a *.scn file
+     *
      *  @param old_file Old file name or <code>null</code>
      *  @return IFile for new file name
      */
-    private IFile promptForFile(final IFile old_file)
+    public static IFile promptForFile(final Shell shell, final IFile old_file)
     {
-        final SaveAsDialog dlg = new SaveAsDialog(getSite().getShell());
+        final SaveAsDialog dlg = new SaveAsDialog(shell);
         dlg.setBlockOnOpen(true);
         if (old_file != null)
             dlg.setOriginalFile(old_file);

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/gui/ScanTreeGUI.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scantree/src/org/csstudio/scan/ui/scantree/gui/ScanTreeGUI.java
@@ -98,9 +98,11 @@ public class ScanTreeGUI
         public void commandsChanged()
         {
             tree_view.refresh();
-            // When there are many commands, the tree expansion is expensive
             final List<ScanCommand> commands = model.getCommands();
-            if (commands.size() < 1000)
+            // When there are many commands, the tree expansion is expensive:
+            // For 1000 commands, it can block the UI thread for many seconds.
+            // --> Only do this if all commands "fit on one page".
+            if (commands.size() < 100)
                 tree_view.expandAll();
             updateAddresses();
         }

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
@@ -9,6 +9,13 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.scan.</p>
 
+<h2>Version 4.2.2 - 2015-08-13</h2>
+<ul>
+  <li>Scan Tree editor opens faster because it only tries to "expand"
+      commands if there's less than 100.
+  </li>
+</ul>
+
 <h2>Version 4.2.1 - 2015-04-24</h2>
 <ul>
   <li>"Log" command performs active read of device to obtain current value.

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
@@ -14,6 +14,7 @@
   <li>Scan Tree editor opens faster because it only tries to "expand"
       commands if there's less than 100.
   </li>
+  <li>New "Save as" and "Re-submit" actions in scan monitor context menu.</li>
 </ul>
 
 <h2>Version 4.2.1 - 2015-04-24</h2>

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scan UI support
 Bundle-SymbolicName: org.csstudio.scan.ui;singleton:=true
-Bundle-Version: 4.2.1.qualifier
+Bundle-Version: 4.2.2.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan.ui</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.2.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/scan/scan-plugins/org.csstudio.scan/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scan API
 Bundle-SymbolicName: org.csstudio.scan;singleton:=true
-Bundle-Version: 4.2.1.qualifier
+Bundle-Version: 4.2.2.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.csstudio.scan,

--- a/applications/scan/scan-plugins/org.csstudio.scan/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.2.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Scan Tree editor opens much faster for larger scan because it only tries to "expand" commands if there's less than 100.

New "Save as" and "Re-submit" actions in scan monitor context menu.

Fixes #1297

Would like to also submit a pull request for the 4.1.x branch