### PR TITLE
Properly resolve paths to files, which are not physically located in the workspace

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RCP fragment of opibuilder
 Bundle-SymbolicName: org.csstudio.opibuilder.rcp;singleton:=true
-Bundle-Version: 3.2.1.qualifier
+Bundle-Version: 3.2.2.qualifier
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Fragment-Host: org.csstudio.opibuilder;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.rcp</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/DisplayLauncher.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/DisplayLauncher.java
@@ -10,8 +10,7 @@ package org.csstudio.opibuilder.runmode;
 import java.util.Optional;
 
 import org.csstudio.opibuilder.runmode.RunModeService.DisplayMode;
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
+import org.csstudio.opibuilder.util.ResourceUtilSSHelperImpl;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.IEditorLauncher;
 
@@ -29,10 +28,7 @@ public class DisplayLauncher implements IEditorLauncher
     @Override
     public void open(final IPath path)
     {
-        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        IPath workspacePath = path.makeRelativeTo(root.getLocation());
-        workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
-        //the view expects an absolute path within workspace, otherwise it doesn't find linked files
-        RunModeService.openDisplay(workspacePath, Optional.empty(), DisplayMode.NEW_TAB, Optional.empty());
+        RunModeService.openDisplay(ResourceUtilSSHelperImpl.absoluteSystemPathToAbsoluteWorkspacePath(path),
+                Optional.empty(), DisplayMode.NEW_TAB, Optional.empty());
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/ShellLauncher.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/ShellLauncher.java
@@ -7,8 +7,7 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.runmode;
 
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
+import org.csstudio.opibuilder.util.ResourceUtilSSHelperImpl;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.IEditorLauncher;
 
@@ -27,10 +26,7 @@ public class ShellLauncher implements IEditorLauncher
     @Override
     public void open(final IPath path)
     {
-        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        IPath workspacePath = path.makeRelativeTo(root.getLocation());
-        workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
-        //the OPIShell expects an absolute path within workspace, otherwise it doesn't find linked files
-        OPIShell.openOPIShell(workspacePath, null);
+        OPIShell.openOPIShell(ResourceUtilSSHelperImpl.absoluteSystemPathToAbsoluteWorkspacePath(path), null);
+
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
@@ -20,6 +20,7 @@ import org.csstudio.opibuilder.OPIBuilderPlugin;
 import org.csstudio.ui.util.NoResourceEditorInput;
 import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -240,5 +241,43 @@ public class ResourceUtilSSHelperImpl extends ResourceUtilSSHelper {
         gc.copyArea(image, 0, 0);
         gc.dispose();
         return image;
+    }
+
+    /**
+     * Transform the path to an absolute path within the workspace. The path is expected to be an absolute system
+     * path. The returned value is an absolute path within the workspace, correctly resolved against the project
+     * name.
+     *
+     * @param path the path to transform
+     * @return the absolute path
+     */
+    public static IPath absoluteSystemPathToAbsoluteWorkspacePath(IPath path) {
+        //the OPIShell expects an absolute path within workspace, otherwise it doesn't find linked files
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        String absPath = path.toFile().getAbsolutePath();
+        IPath workspacePath = null;
+        if (absPath.startsWith(root.getLocation().toFile().getAbsolutePath())) {
+            //file is a descendant of the workspace folder - just transform to absolute path within workspace
+            workspacePath = path.makeRelativeTo(root.getLocation());
+            workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
+        } else {
+            IProject[] projects = root.getProjects();
+            IProject project = null;
+            for (IProject p : projects) {
+                IPath pp = p.getRawLocation();
+                if (pp == null) continue;
+                if (absPath.startsWith(pp.toFile().getAbsolutePath())) {
+                    project = p;
+                    break;
+                }
+            }
+            if (project == null) {
+                throw new RuntimeException("Cannot locate the source of file " + path);
+            }
+            String newPath = absPath.substring(project.getRawLocation().toFile().getAbsolutePath().length());
+            workspacePath = project.getFile(newPath).getFullPath();
+            workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
+        }
+        return workspacePath;
     }
 }


### PR DESCRIPTION
Another fix for #1293.
It turned out that if a project is imported into workspace (and resources are not copied into workspace), the paths were not resolved correctly. 