### PR TITLE
More problems with OPI paths

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RCP fragment of opibuilder
 Bundle-SymbolicName: org.csstudio.opibuilder.rcp;singleton:=true
-Bundle-Version: 3.2.2.qualifier
+Bundle-Version: 3.2.3.qualifier
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Fragment-Host: org.csstudio.opibuilder;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.rcp</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.2.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/DisplayLauncher.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/DisplayLauncher.java
@@ -10,7 +10,6 @@ package org.csstudio.opibuilder.runmode;
 import java.util.Optional;
 
 import org.csstudio.opibuilder.runmode.RunModeService.DisplayMode;
-import org.csstudio.opibuilder.util.ResourceUtilSSHelperImpl;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.IEditorLauncher;
 
@@ -28,7 +27,7 @@ public class DisplayLauncher implements IEditorLauncher
     @Override
     public void open(final IPath path)
     {
-        RunModeService.openDisplay(ResourceUtilSSHelperImpl.absoluteSystemPathToAbsoluteWorkspacePath(path),
-                Optional.empty(), DisplayMode.NEW_TAB, Optional.empty());
+        IPath workspacePath = LauncherHelper.systemPathToWorkspacePath(path);
+        RunModeService.openDisplay(workspacePath, Optional.empty(), DisplayMode.NEW_TAB, Optional.empty());
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/LauncherHelper.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/LauncherHelper.java
@@ -1,0 +1,63 @@
+package org.csstudio.opibuilder.runmode;
+
+import java.util.Iterator;
+
+import org.csstudio.opibuilder.util.ErrorHandlerUtil;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.ui.ISelectionService;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ *
+ * <code>LauncherHelper</code> is a utility class that provides common methods needed for launching the OPI from the
+ * resource navigator.
+ *
+ * @author <a href="mailto:jaka.bobnar@cosylab.com">Jaka Bobnar</a>
+ *
+ */
+public final class LauncherHelper {
+
+    private LauncherHelper() {}
+
+    /**
+     * Check the resources that are selected in the navigator and find the one that matches the given path. The returned
+     * path is always the path within the workspace whereas the parameter is an absolute system path.
+     *
+     * @param path the path for which we need a workspace resource path
+     * @return the workspace path if a match in the workspace was found or the same path if a match was not found
+     */
+    public static IPath systemPathToWorkspacePath(IPath path) {
+        //path is an absolute file location, which needs to be transformed into a workspace resource
+        //This method was triggered from the resource navigator, therefore the current selection should contain the
+        //resource that matches this path
+
+        ISelectionService service = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getSelectionService();
+        ISelection selection = service.getSelection();
+
+        if (selection instanceof IStructuredSelection) {
+            Iterator<?> elements = ((IStructuredSelection)selection).iterator();
+
+            //There might be multiple resources selected in the navigator. We need to find the one item that has the
+            //same path as provided as a parameter.
+
+            while(elements.hasNext()) {
+                Object e = elements.next();
+                //compare the resource location with the path. According the FileEditorInput, the path is the location
+                //of the selected file
+                if (e instanceof IResource && ((IResource)e).getLocation().equals(path)) {
+                    //TODO
+                    //There is a problem if the user opens more paths at the same time. If all opened paths point to the
+                    //the same physical location, this code below will always result to the first selected item. In
+                    //reality it is a very unlikely event.
+                    return ((IResource)e).getFullPath();
+                }
+            }
+        }
+        ErrorHandlerUtil.handleError(NLS.bind("A workspace match for {0} could not be found.", path), null);
+        return path;
+    }
+}

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/ShellLauncher.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/ShellLauncher.java
@@ -7,7 +7,6 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.runmode;
 
-import org.csstudio.opibuilder.util.ResourceUtilSSHelperImpl;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.IEditorLauncher;
 
@@ -20,13 +19,16 @@ import org.eclipse.ui.IEditorLauncher;
  *
  *  @author Kay Kasemir
  *  @author Will Rogers
+ *  @author Jaka Bobnar
  */
 public class ShellLauncher implements IEditorLauncher
 {
     @Override
     public void open(final IPath path)
     {
-        OPIShell.openOPIShell(ResourceUtilSSHelperImpl.absoluteSystemPathToAbsoluteWorkspacePath(path), null);
+        //The path is an absolute system path, which needs to be transformed to workspace path
+        IPath workspacePath = LauncherHelper.systemPathToWorkspacePath(path);
+        OPIShell.openOPIShell(workspacePath, null);
 
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ResourceUtilSSHelperImpl.java
@@ -20,7 +20,6 @@ import org.csstudio.opibuilder.OPIBuilderPlugin;
 import org.csstudio.ui.util.NoResourceEditorInput;
 import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -241,43 +240,5 @@ public class ResourceUtilSSHelperImpl extends ResourceUtilSSHelper {
         gc.copyArea(image, 0, 0);
         gc.dispose();
         return image;
-    }
-
-    /**
-     * Transform the path to an absolute path within the workspace. The path is expected to be an absolute system
-     * path. The returned value is an absolute path within the workspace, correctly resolved against the project
-     * name.
-     *
-     * @param path the path to transform
-     * @return the absolute path
-     */
-    public static IPath absoluteSystemPathToAbsoluteWorkspacePath(IPath path) {
-        //the OPIShell expects an absolute path within workspace, otherwise it doesn't find linked files
-        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        String absPath = path.toFile().getAbsolutePath();
-        IPath workspacePath = null;
-        if (absPath.startsWith(root.getLocation().toFile().getAbsolutePath())) {
-            //file is a descendant of the workspace folder - just transform to absolute path within workspace
-            workspacePath = path.makeRelativeTo(root.getLocation());
-            workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
-        } else {
-            IProject[] projects = root.getProjects();
-            IProject project = null;
-            for (IProject p : projects) {
-                IPath pp = p.getRawLocation();
-                if (pp == null) continue;
-                if (absPath.startsWith(pp.toFile().getAbsolutePath())) {
-                    project = p;
-                    break;
-                }
-            }
-            if (project == null) {
-                throw new RuntimeException("Cannot locate the source of file " + path);
-            }
-            String newPath = absPath.substring(project.getRawLocation().toFile().getAbsolutePath().length());
-            workspacePath = project.getFile(newPath).getFullPath();
-            workspacePath = workspacePath == null ? path : workspacePath.makeAbsolute();
-        }
-        return workspacePath;
     }
 }


### PR DESCRIPTION
Another attempt to fix this: #1293 
I think I finally understand what was going on with the paths, so I hope this is the final pull request for this.

The new opi launching messed up a few things. It worked fine when the launched file was self sufficient in its own environment. But, immediately when the file needed to access something from the workspace, there were problems if the file was not physically located in workspace. The reason being that the launcher approach is primarily intended for launching external editors.

This pull request introduces a middle step in the launching procedure. It initializes an editor which launches the content and then closes automatically. It is a workaround but it is the only way I know how to keep the paths "workspace aware" without having to do too much file system magic.