### PR TITLE
Scan set timeout 1301

### DIFF
--- a/applications/scan/scan-plugins/org.csstudio.scan.server/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scan Server
 Bundle-SymbolicName: org.csstudio.scan.server;singleton:=true
-Bundle-Version: 4.2.1.qualifier
+Bundle-Version: 4.2.3.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/plugin_customization.ini
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/plugin_customization.ini
@@ -46,7 +46,7 @@ org.csstudio.platform.libs.epics/use_pure_java=true
 org.csstudio.platform.libs.epics/addr_list=127.0.0.1
 
 # Logging preferences
-org.csstudio.logging/console_level=CONFIG
+org.csstudio.logging/console_level=INFO
 org.csstudio.logging/jms_url=
 
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = false

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan.server</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.2.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/LoopCommandImpl.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/LoopCommandImpl.java
@@ -185,10 +185,14 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
             //  Wait for the device to reach the value?
             final NumericValueCondition condition;
             if (command.getWait())
+            {
+                // When using completion, readback needs to match "right away"
+                final double check_timeout = command.getCompletion() ? 1.0 : command.getTimeout();
                 condition = new NumericValueCondition(readback, Comparison.EQUALS,
                             command.getStart(),
                             command.getTolerance(),
-                            TimeDuration.ofSeconds(command.getTimeout()));
+                            TimeDuration.ofSeconds(check_timeout));
+            }
             else
                 condition = null;
 

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/condition/NumericValueCondition.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/condition/NumericValueCondition.java
@@ -17,6 +17,7 @@ package org.csstudio.scan.condition;
 
 import java.util.concurrent.TimeoutException;
 
+import org.csstudio.scan.ScanSystemPreferences;
 import org.csstudio.scan.command.Comparison;
 import org.csstudio.scan.device.Device;
 import org.csstudio.scan.device.DeviceListener;
@@ -38,6 +39,8 @@ import org.epics.util.time.TimeDuration;
 @SuppressWarnings("nls")
 public class NumericValueCondition implements DeviceCondition, DeviceListener
 {
+    protected final static TimeDuration value_check_timeout = TimeDuration.ofSeconds(ScanSystemPreferences.getValueCheckTimeout());
+
     /** Device to monitor */
     final private Device device;
 
@@ -96,8 +99,8 @@ public class NumericValueCondition implements DeviceCondition, DeviceListener
     {
         final WaitWithTimeout timeout = new WaitWithTimeout(this.timeout);
 
-        // Fetch initial value with get-callback?
-        initial_value = VTypeHelper.toDouble(device.read(this.timeout));
+        // Fetch initial value with get-callback
+        initial_value = VTypeHelper.toDouble(device.read(value_check_timeout));
 
         device.addListener(this);
         try

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/condition/TextValueCondition.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/condition/TextValueCondition.java
@@ -17,6 +17,7 @@ package org.csstudio.scan.condition;
 
 import java.util.concurrent.TimeoutException;
 
+import org.csstudio.scan.ScanSystemPreferences;
 import org.csstudio.scan.command.Comparison;
 import org.csstudio.scan.device.Device;
 import org.csstudio.scan.device.DeviceListener;
@@ -33,6 +34,8 @@ import org.epics.util.time.TimeDuration;
 @SuppressWarnings("nls")
 public class TextValueCondition implements DeviceCondition, DeviceListener
 {
+    protected final static TimeDuration value_check_timeout = TimeDuration.ofSeconds(ScanSystemPreferences.getValueCheckTimeout());
+
     /** Device to monitor */
     final private Device device;
 
@@ -81,6 +84,10 @@ public class TextValueCondition implements DeviceCondition, DeviceListener
     public void await() throws TimeoutException, Exception
     {
         final WaitWithTimeout timeout = new WaitWithTimeout(this.timeout);
+
+        // Fetch initial value with get-callback
+        // (will be obtained by device.read() in listener)
+        device.read(value_check_timeout);
 
         device.addListener(this);
         try

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/ScanCommandUtil.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/ScanCommandUtil.java
@@ -85,16 +85,18 @@ public class ScanCommandUtil
         final DeviceCondition condition;
         if (wait)
         {
+            // When using completion, readback needs to match "right away"
+            final TimeDuration check_timeout = completion ? TimeDuration.ofSeconds(1) : timeout;
             if (value instanceof Number)
             {
                 final double desired = ((Number)value).doubleValue();
                 condition = new NumericValueCondition(readback, Comparison.EQUALS, desired,
-                        tolerance, timeout);
+                        tolerance, check_timeout);
             }
             else
             {
                 final String desired = value.toString();
-                condition = new TextValueCondition(readback, Comparison.EQUALS, desired, timeout);
+                condition = new TextValueCondition(readback, Comparison.EQUALS, desired, check_timeout);
             }
         }
         else

--- a/applications/scan/scan-plugins/org.csstudio.scan.test/src/org/csstudio/scan/CommandFormatUnitTest.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.test/src/org/csstudio/scan/CommandFormatUnitTest.java
@@ -15,7 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.csstudio.scan.command.LoopCommand;
@@ -49,6 +51,26 @@ public class CommandFormatUnitTest
     }
 
     @Test
+    public void testSetCommand()
+    {
+        SetCommand command = new SetCommand("device", 3.14, false, "nothing", false, 0.1, 0.0);
+        System.out.println(command);
+        assertThat(command.toString(), equalTo("Set 'device' = 3.14"));
+
+        command = new SetCommand("device", 3.14, false, "readback", true, 0.1, 10.0);
+        System.out.println(command);
+        assertThat(command.toString(), equalTo("Set 'device' = 3.14 (wait for 'readback' +-0.1, 10.0 sec timeout)"));
+
+        command = new SetCommand("device", 3.14, true, "nothing", false, 0.1, 10.0);
+        System.out.println(command);
+        assertThat(command.toString(), equalTo("Set 'device' = 3.14 with completion in 10.0 sec"));
+
+        command = new SetCommand("device", 3.14, true, "readback", true, 0.1, 10.0);
+        System.out.println(command);
+        assertThat(command.toString(), equalTo("Set 'device' = 3.14 with completion in 10.0 sec (check for 'readback' +-0.1)"));
+    }
+
+    @Test
     public void testLoopCommand()
     {
         final LoopCommand command = new LoopCommand("device", 1.0, 10.0, 0.5);
@@ -66,6 +88,13 @@ public class CommandFormatUnitTest
         command.setWait(false);
         System.out.println(command);
         assertFalse(command.toString().contains("wait"));
-    }
 
+        command.setCompletion(true);
+        System.out.println(command);
+        assertThat(command.toString(), equalTo("Loop 'device' = 1.0 ... 10.0, step 0.5 with completion in 2.0 sec"));
+
+        command.setWait(true);
+        System.out.println(command);
+        assertThat(command.toString(), equalTo("Loop 'device' = 1.0 ... 10.0, step 0.5 with completion in 2.0 sec (check for 'readback' +-0.05)"));
+    }
 }

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
@@ -9,6 +9,28 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.scan.</p>
 
+<h2>Version 4.2.3 - 2015-08-17</h2>
+<ul>
+  <li>Set and Loop commands only apply the 'timeout' once:
+      Write, then wait for readback to match;
+      Write, then wait for completion callback;
+      Write, then wait for completion callback and check readback.
+      <br>
+      It will no longer wait for completion callback with a timeout AND
+      then use the timeout again to wait for a readback.
+      <br>
+      This avoids problems with devices that properly support put-callback completion.
+      Temperature controller for example can require a timeout of hours to reach
+      a desired cryogenic temperature. Once they issue the callback, the temperature
+      is within the region.
+      Instead of again applying the long timeout, a failure should be noticed right away.
+      <br>
+      This update will require changes to scans that used completion for devices that do not
+      support command completion. Such scans must no longer use completion in the scan commands,
+      and instead rely on the timeout for the readback.
+  </li>
+</ul>
+
 <h2>Version 4.2.2 - 2015-08-13</h2>
 <ul>
   <li>Scan Tree editor opens faster because it only tries to "expand"

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scan UI support
 Bundle-SymbolicName: org.csstudio.scan.ui;singleton:=true
-Bundle-Version: 4.2.2.qualifier
+Bundle-Version: 4.2.3.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/doc/scansystem.html
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/doc/scansystem.html
@@ -106,7 +106,7 @@ to actually reach the desired value.
     Optionally, a different "read back" device can be used.</li>
 <li>Tolerance: Difference between the actual value of the device and the desired value
     that is considered "good enough".</li>
-<li>Timeout: Time in seconds that the command will use when waiting for the completion and/or the readback.</li>
+<li>Timeout: Time in seconds that the command will use when waiting for the completion or the readback.</li>
 </ul>
 <p>Example:</p>
 <p>
@@ -126,11 +126,14 @@ will write the value 1.0 to the "setpoint" device, and wait for the confirmation
 This can be useful for EPICS motor records, where it should indicate that the motor has finished moving.
 </p>
 <p>
-<code>Set 'setpoint' = 1.0 with completion in 10.0 sec (wait for 'readback' +-0.1, 10.0 sec timeout)</code>
+<code>Set 'setpoint' = 1.0 with completion in 10.0 sec (check for 'readback' +-0.1)</code>
 combines the last two examples:
 A value is written to the "setpoint" device, waiting for confirmation.
-Then, the command waits for the associated "readback" to match.
-The timeout is applied to both steps, so the today time out in this case could be 20 seconds.
+Then, the command checks if the associated "readback" matches the written value.
+Note that the timeout is only used when awaiting the completion.
+After the device confirms completion, the command expects the readback to match "right away".
+The command will fetch the current value from the device and compare that it to the desired value.
+In case of a mismatch, the command will not wait for further value updates but instead raise an error.
 </p>
 
 
@@ -208,6 +211,11 @@ It is at the core of most scans.
 <code>Loop 'xpos' = 0.0 ... 5.0, step 1.0</code>
 will set the "xpos" device to 0.0, then 1.0, 2.0, 3.0, 4.0, 5.0.
 At each step it will execute the "body" of the loop.
+</p>
+<p>
+As with the <a href="#SetCommand">Set</a> command,
+the loop can wait for completion, or wait for a readback to match,
+or wait for completion and then check for the readback to match.
 </p>
 <p>Loops can count "up" as well as "down".
 A loop from 0 to 5 in steps of 1 will operate as just mentioned.

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan.ui</artifactId>
-  <version>4.2.2-SNAPSHOT</version>
+  <version>4.2.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/scan/scan-plugins/org.csstudio.scan/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scan API
 Bundle-SymbolicName: org.csstudio.scan;singleton:=true
-Bundle-Version: 4.2.2.qualifier
+Bundle-Version: 4.2.3.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.csstudio.scan,

--- a/applications/scan/scan-plugins/org.csstudio.scan/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan</artifactId>
-  <version>4.2.2-SNAPSHOT</version>
+  <version>4.2.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/scan/scan-plugins/org.csstudio.scan/preferences.ini
+++ b/applications/scan/scan-plugins/org.csstudio.scan/preferences.ini
@@ -80,3 +80,14 @@ macros=DemoDevice=motor_x
 # The value applies to each device, i.e. a Log command for logging the values
 # of 5 devices could overall consume 5 times the timeout.
 log_command_read_timeout=20
+
+# Value check timeout [seconds]
+# Set and Loop commands have a timeout that is used
+# to wait for completion or
+# to wait for the readback to match.
+# When using completion _and_ checking a readback,
+# the readback check does not use the full timeout but instead
+# checks if the value matches "right away" after completion has been confirmed.
+# This check, however, needs to read the current value of the PV,
+# so it also needs some timeout
+value_check_timeout=20

--- a/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/ScanSystemPreferences.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/ScanSystemPreferences.java
@@ -166,6 +166,16 @@ public class ScanSystemPreferences extends SystemSettings
         return period;
     }
 
+    /** @return Value check timeout [seconds] */
+    public static double getValueCheckTimeout()
+    {
+        double period = 20.0;
+        final IPreferencesService service = Platform.getPreferencesService();
+        if (service != null)
+            period = service.getDouble(Activator.ID, "value_check_timeout", period, null);
+        return period;
+    }
+
     /** Set system properties (which are in the end what's actually used)
      *  from Eclipse preferences (which are more accessible for Eclipse tools
      *  with plugin_customization or preference GUI)

--- a/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/command/LoopCommand.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/command/LoopCommand.java
@@ -338,14 +338,17 @@ public class LoopCommand extends ScanCommandWithBody
         }
         if (wait)
         {
-            buf.append(" (wait for '");
+            if (completion)
+                buf.append(" (check for '");
+            else
+                buf.append(" (wait for '");
             if (readback.isEmpty())
                 buf.append(device_name);
             else
                 buf.append(readback);
             if (tolerance > 0)
                 buf.append("' +-").append(tolerance);
-            if (timeout > 0)
+            if (timeout > 0  &&  !completion)
                 buf.append(", ").append(timeout).append(" sec timeout");
             buf.append(")");
         }

--- a/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/command/SetCommand.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/command/SetCommand.java
@@ -275,14 +275,17 @@ public class SetCommand extends ScanCommand
         }
         if (wait)
         {
-            buf.append(" (wait for '");
+            if (completion)
+                buf.append(" (check for '");
+            else
+                buf.append(" (wait for '");
             if (readback.isEmpty())
                 buf.append(device_name);
             else
                 buf.append(readback);
             if (tolerance > 0)
                 buf.append("' +-").append(tolerance);
-            if (timeout > 0)
+            if (timeout > 0  &&  !completion)
                 buf.append(", ").append(timeout).append(" sec timeout");
             buf.append(")");
         }


### PR DESCRIPTION
When using both completion (put-callback) and a readback check for Set and Loop commands, the timeout is used for the completion (as before), but _not_ used again for the readback test because after the put-callback is received, the value needs to match right away.

#1301 

Would also like to get this onto 4.1.x