### PR TITLE
o.c.opibuilder: add back incrementing unique display ID.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.csstudio.opibuilder.datadefinition.DisplayScaleData;
 import org.csstudio.opibuilder.properties.ActionsProperty;
@@ -98,6 +99,7 @@ public class DisplayModel extends AbstractContainerModel {
     private boolean FreshRateEnabled= false;
 
     private int displayID;
+    private static AtomicInteger displayIDCounter = new AtomicInteger(0);
 
     /**
      * Create a Display Model which is the root model for an OPI.
@@ -117,6 +119,7 @@ public class DisplayModel extends AbstractContainerModel {
         setLocation(NULL_LOCATION);
         setSize(800, 600);
         setOpiFilePath(opiFilePath);
+        displayID = displayIDCounter.incrementAndGet();
     }
 
     @Override


### PR DESCRIPTION
This was lost in a previous merge.

As discussed in #1317 .