### PR TITLE
Edm converter minor changes

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activePipClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activePipClass.java
@@ -68,6 +68,8 @@ public class Opi_activePipClass extends OpiWidget {
                                     for (String s : StringSplitter.splitIgnoreInQuotes(symbols.get(), ',', true)) {
                                         String[] rs = StringSplitter.splitIgnoreInQuotes(s, '=', true);
                                         if (rs.length == 2) {
+                                            // EDM treats '' as an empty string.
+                                            rs[1] = rs[1] == "''" ? "" : rs[1];
                                             try {
                                                 sb.append("macroInput.put(\"" + rs[0] + "\", \"" + rs[1]+"\");\n");
                                             } catch (Exception e) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_relatedDisplayClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_relatedDisplayClass.java
@@ -82,6 +82,8 @@ public class Opi_relatedDisplayClass extends OpiWidget {
                         if (rs.length == 2) {
                             try {
                                 Element m = widgetContext.getDocument().createElement(rs[0]);
+                                // EDM treats '' as an empty string.
+                                rs[1] = rs[1] == "''" ? "" : rs[1];
                                 m.setTextContent(rs[1]);
                                 macrosNode.appendChild(m);
                             } catch (Exception e) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/PVNameConversion.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/PVNameConversion.java
@@ -38,11 +38,9 @@ public class PVNameConversion {
         operators.add("=");
     }
 
-
     private PVNameConversion() {
         // No instantiation.
     }
-
 
     /**
      * If pvName is a LOC or CALC EDM PV, attempt to convert it to a syntax
@@ -121,9 +119,10 @@ public class PVNameConversion {
      */
     private static List<String> parseExpression(String expr) {
         // expression contained within {}
-        assert (StringUtils.startsWith(expr, "\\{") &&
-                StringUtils.endsWith(expr, "\\}")):
-                    "Failed to parse CALC expression";
+        if  (!(StringUtils.startsWith(expr, "\\{") &&
+                StringUtils.endsWith(expr, "\\}"))) {
+            throw new IllegalArgumentException("Failed to parse CALC expression");
+        }
         expr = expr.substring(2, expr.length() - 2);
         List<String> parts = splitString(expr, operators, true);
         // The = in EDM expressions is == in CSS ones
@@ -204,7 +203,7 @@ public class PVNameConversion {
             }
             sb.append(")");
             return sb.toString();
-        } catch (AssertionError e) {
+        } catch (IllegalArgumentException e) {
             log.info("Failed to parse CALC PV: " + e);
             return pvName;
         }


### PR DESCRIPTION
Empty macros are handled differently in EDM and CS-Studio.
Fix use of assertions when converting PV names.

As discussed in #1335.
