### PR TITLE
o.c.opibuilder.rcp: adapt OPIShell to GraphicalViewer

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -311,9 +311,10 @@ public class OPIShell implements IOPIRuntime {
     @SuppressWarnings("rawtypes")
     @Override
     public Object getAdapter(Class adapter) {
-        if(adapter == ActionRegistry.class)
+        if (adapter == ActionRegistry.class)
             return this.actionRegistry;
-
+        if (adapter == GraphicalViewer.class)
+            return this.viewer;
         return null;
     }
 


### PR DESCRIPTION
This allows printing OPIs in shells.

As discussed in #1352.