### PR TITLE
o.c.opibuilder: edit context menu items

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
@@ -76,7 +76,9 @@ public final class OPIRunnerContextMenuProvider extends ContextMenuProvider {
 
         IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 
-        if(!OPIBuilderPlugin.isRAP()){ //$NON-NLS-1$
+        // Only show 'full screen' and 'compact mode' options for OPIView,
+        // not for OPIShell.
+        if (!OPIBuilderPlugin.isRAP() && opiRuntime instanceof OPIView) {
             menu.appendToGroup(GEFActionConstants.GROUP_EDIT,
                 WorkbenchWindowService.getInstance().getFullScreenAction(activeWindow));
             menu.appendToGroup(GEFActionConstants.GROUP_EDIT,


### PR DESCRIPTION
Only show 'full screen' and 'compact mode' menu items for
OPIView, not OPIShell.

As discussed in #1354.  @kasemir @utzeln 

This is an ugly method and not a pretty part of OPIBuilder in general, but I believe this does what we want.