### PR TITLE
alarm annunciator: Revert to platform.libs.jms

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.annunciator/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.annunciator/META-INF/MANIFEST.MF
@@ -11,11 +11,11 @@ Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.ui;bundle-version="3.5.0",
  org.csstudio.data;bundle-version="1.0.0",
  org.csstudio.logging;bundle-version="3.0.0",
+ org.csstudio.platform.libs.jms;bundle-version="1.0.0",
  org.csstudio.platform.utility.jms;bundle-version="1.1.2",
  org.csstudio.utility.speech;bundle-version="1.2.6",
  org.csstudio.apputil;bundle-version="1.0.11",
- org.csstudio.ui.util;bundle-version="4.0.0",
- javax.jms;bundle-version="1.1.0"
+ org.csstudio.ui.util;bundle-version="4.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Description: BEAST Voice annunciator, 'speaks' alarm messages from JMS to operators
 


### PR DESCRIPTION
Was changed to javax.jms, which would require more updates to for example SNS products

Fixes #1387