### PR TITLE
o.c.diag: fix pvmanager pvtree packages.

### DIFF
--- a/applications/diag/diag-plugins/org.csstudio.diag.epics.pvmanager.pvtree/META-INF/MANIFEST.MF
+++ b/applications/diag/diag-plugins/org.csstudio.diag.epics.pvmanager.pvtree/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.diirt.datasource,
+ org.diirt.datasource.expression;version="3.0.1",
  org.diirt.datasource.vtype,
  org.diirt.util.time;version="3.0.1",
  org.diirt.vtype;version="3.0.1"


### PR DESCRIPTION
org.diirt.datasource.expression was missing.

See #1390.