### PR TITLE
Update feature.xml

### DIFF
--- a/core/platform/platform-features/org.csstudio.core.platform.feature/feature.xml
+++ b/core/platform/platform-features/org.csstudio.core.platform.feature/feature.xml
@@ -29,13 +29,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.csstudio.platform.libs.epics.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.csstudio.platform.libs.hibernate.ui"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
#1390 updating the feature to exclude the now deprecated preference page for EPICS

I have checked that this plugin has no dependent plugins and therefore removing this should not affect the build.