### PR TITLE
Issue 1399 pvtree

### DIFF
--- a/applications/diag/diag-plugins/org.csstudio.diag.epics.pvmanager.pvtree/src/org/csstudio/diag/epics/pvtree/PVTreeItem.java
+++ b/applications/diag/diag-plugins/org.csstudio.diag.epics.pvmanager.pvtree/src/org/csstudio/diag/epics/pvtree/PVTreeItem.java
@@ -167,12 +167,14 @@ class PVTreeItem
                 @Override
                 public void handleText(final String text)
                 {
+                    // discard any alarm information, expect "xxx [alarm_data]"
+                    String type_text = text.split(" ")[0];
                     // type should be a text.
                     // If it starts with a number, it's probably not an
                     // EPICS record type but a simulated PV
-                    final char first_char = text.charAt(0);
+                    final char first_char = type_text.charAt(0);
                     if (first_char >= 'a' && first_char <= 'z')
-                        type = text;
+                        type = type_text;
                     else
                         type = Messages.UnknownPVType;
                     updateType();

--- a/applications/diag/diag-plugins/org.csstudio.diag.epics.pvmanager.pvtree/src/org/csstudio/diag/epics/pvtree/PVTreeItem.java
+++ b/applications/diag/diag-plugins/org.csstudio.diag.epics.pvmanager.pvtree/src/org/csstudio/diag/epics/pvtree/PVTreeItem.java
@@ -167,16 +167,23 @@ class PVTreeItem
                 @Override
                 public void handleText(final String text)
                 {
-                    // discard any alarm information, expect "xxx [alarm_data]"
-                    String type_text = text.split(" ")[0];
-                    // type should be a text.
                     // If it starts with a number, it's probably not an
                     // EPICS record type but a simulated PV
-                    final char first_char = type_text.charAt(0);
+                    final char first_char = text.charAt(0);
                     if (first_char >= 'a' && first_char <= 'z')
-                        type = type_text;
+                    {
+                        // discard any alarm information, the text may include
+                        // alarm data, i.e. "xxx [alarm_data]" not "xxx"
+                        final int spaceAt = text.indexOf(" ");
+                        if (spaceAt > -1)
+                            type = text.substring(0, spaceAt);
+                        else
+                            type = text;
+                    }
                     else
+                    {
                         type = Messages.UnknownPVType;
+                    }
                     updateType();
                 }
             };


### PR DESCRIPTION
Issue #1399 - strip alarm state information from record type string before processing links