### PR TITLE
Diirt config

### DIFF
--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/META-INF/MANIFEST.MF
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Require-Bundle: org.eclipse.osgi,
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.csstudio.startup;bundle-version="3.2.1",
- org.csstudio.diirt.util;bundle-version="1.0.0"
+ org.csstudio.diirt.util;bundle-version="1.0.0",
+ org.eclipse.core.filesystem;bundle-version="1.5.0"
 Bundle-Vendor: Kunal Shroff <shroffk@bnl.gov>
 Import-Package: org.csstudio.utility.product

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/src/org/csstudio/diirt/util/preferences/DiirtPreferencePage.java
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/src/org/csstudio/diirt/util/preferences/DiirtPreferencePage.java
@@ -1,9 +1,9 @@
 package org.csstudio.diirt.util.preferences;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -18,7 +18,7 @@ public class DiirtPreferencePage extends FieldEditorPreferencePage implements
 
     @Override
     protected void createFieldEditors() {
-        addField(new DirectoryFieldEditor("diirt.home",
+        addField(new StringFieldEditor("diirt.home",
                 "&Diirt configuration directory:", getFieldEditorParent()));
     }
 

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/src/org/csstudio/diirt/util/preferences/DiirtPreferencePage.java
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/src/org/csstudio/diirt/util/preferences/DiirtPreferencePage.java
@@ -1,9 +1,9 @@
 package org.csstudio.diirt.util.preferences;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -18,8 +18,12 @@ public class DiirtPreferencePage extends FieldEditorPreferencePage implements
 
     @Override
     protected void createFieldEditors() {
-        addField(new StringFieldEditor("diirt.home",
-                "&Diirt configuration directory:", getFieldEditorParent()));
+        addField(new DirectoryFieldEditor("diirt.home",
+                "&Diirt configuration directory:", getFieldEditorParent()) {
+            public boolean doCheckState() {
+                return true;
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
This should understand the `platform:` URIs and also not complain if it doesn't recognise the contents as a directory.

Example configuration: `platform:/base/configuration/diirt_5064`.

As discussed in #1406.