### PR TITLE
o.c.util.rdb: Import Oracle and Postgres packages

### DIFF
--- a/core/platform/platform-plugins/org.csstudio.platform.utility.rdb/META-INF/MANIFEST.MF
+++ b/core/platform/platform-plugins/org.csstudio.platform.utility.rdb/META-INF/MANIFEST.MF
@@ -8,4 +8,7 @@ Export-Package: org.csstudio.platform.utility.rdb
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Description: Helper for connecting to various RDB dialects
-Require-Bundle: com.mysql.jdbc;bundle-version="5.1.32"
+Import-Package: com.mysql.jdbc,
+ org.postgresql,
+ oracle.jdbc.driver,
+ oracle.jdbc


### PR DESCRIPTION
Fixes #1414 as long as product includes plugins that satisfy the JDBC imports.

One option is the existing o.c.platform.libs.jdbc.