### PR TITLE
Alarm table opi widget

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Alarm Table OPI Widget
 Bundle-SymbolicName: org.csstudio.alarm.beast.ui.alarmtable.opiwidget;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: ITER
 Bundle-Description: BEAST Alarm Table OPI Widget
 Require-Bundle: org.csstudio.alarm.beast.ui.alarmtable;bundle-version="4.1.0",

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/html/alarmtable.html
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/html/alarmtable.html
@@ -14,50 +14,49 @@
     Alarm Table lists active and acknowledged alarms in a table-like structure. The table is identical to the table that
     is available in the Alarm Perspective.
     </p>
-    <img src="table.png"alt="">
-    
+    <img src="table.png"alt=""/>
+
     <h3>Operations</h3>
     In OPI editing mode user is allowed to configure the alarm table to suit the requirements. It is possible to adjust
     the size of the table, columns, columns order, and many other properties common to BOY widgets. The filter item
-    also has to be set on the table in order to define the configuration (or its subsystem), which the table should 
+    also has to be set on the table in order to define the configuration (or its subsystem), which the table should
     display. In runtime mode, the table listens to live status obtained from the alarm server and displays the alarms
-    according to the defined policies. User is allowed to acknowledge and unacknowledge alarms and to do some minor 
-    layout tweaking (e.g. adjust the width of column, change sorting direction and criteria). All other properties 
+    according to the defined policies. User is allowed to acknowledge and unacknowledge alarms and to do some minor
+    layout tweaking (e.g. adjust the width of column, change sorting direction and criteria). All other properties
     are only accessible via rules and scripts.
-    
+
     <a name="AlarmTableProperties"></a>
     <h3>Special Properties</h3>
-    <ul>   
-		<li>Filter Item (filter_item)<dl><dd>The parent item, which defines the alarms to be displayed. Only the alarms that are direct
-	or indirect descendants of this item will be displayed. The filter item has to be a complete item name, including 
-	the configuration name (e.g. to display configuration "Demo", enter "/Demo"; to display a subsystem "RFQ" of 
-	configuration "Demo", enter "/Demo/RFQ".</dd></dl></li>
-		<li>Sort Ascending (sort_ascending)<dl><dd>Defines if default sorting of the alarms should be in ascending or descending order.</dd></dl></li>
-		<li>Sorting Column (sorting_column)<dl><dd>Defines the column used for default sorting criteria.</dd></dl></li>
-		<li>Time Format (time_format)<dl><dd>Specifies the time format used for the TIME column.</dd></dl></li>
-		<li>Unacknowledged Blink (unacknowledged_blink)<dl><dd>If true all unacknowledged alarms icons will blink.</dd></dl></li>
-		<li>Writable (writable)<dl><dd>Specifies is user is allowed to acknowledge and unacknowledged alarms with this table.</dd></dl></li>
-		<li>Columns (columns)<dl><dd>Allows to specify the list and order of the table columns.</dd></dl></li>
-		<li>Max Number of Alarms (max_number_of_alarms)<dl><dd>Defines the maximum number of alarms displayed in the table. If more alarms
-	exist for the selected filter item, they will be suppressed. Only the top N alarms that match the selected sorting
-	criteria are displayed.</dd></dl></li>
-		<li>Separate Tables (separate_tables)<dl><dd>Specifies whether the acknowledged and unacknowledged alarms tables should be 
-	separated or combined.</dd></dl></li>
-		<li>Table Weight Acknowledge (table_weight_acknowledge)<dl><dd>Defines the sash element weight of the acknowledged table.</dd></dl></li>
-		<li>Table Weight Unacknowledge (table_weight_unacknowledge)<dl><dd>Defines the sash element weight of the unacknowledged table.</dd></dl></li>
-		<li>Table Header Visible (table_header_visible)<dl><dd>Defines whether the header displaying the number of all active and acknowledged
-	alarms, as well as the filter combo and button are displayed or hidden. If hidden the table will take over the space
-	otherwise occupied by those widgets.</dd></dl></li>
-		<li>Columns Headers Visible (columns_header_visible)<dl><dd>Defines if the headers of the table columns are visible or not.</dd></dl></li>
-	</ul>
-        
-   <h3>See Also</h3>
-   <ul>
-   	  <li><a href="../../org.csstudio.opibuilder/html/widgets/PVWidgets.html">Properties Common to PV Widgets</a></li>
-      <li><a href="../../org.csstudio.opibuilder/html/Widget_Properties.html">Properties Common to All Widgets</a></li>
-   </ul>
-    
-<br>
+    <ul>
+        <li>Filter Item (filter_item)<dl><dd>The parent item, which defines the alarms to be displayed. Only the alarms that are direct
+    or indirect descendants of this item will be displayed. The filter item has to be a complete item name, including
+    the configuration name (e.g. to display configuration "Demo", enter "/Demo"; to display a subsystem "RFQ" of
+    configuration "Demo", enter "/Demo/RFQ".</dd></dl></li>
+        <li>Sort Ascending (sort_ascending)<dl><dd>Defines if default sorting of the alarms should be in ascending or descending order.</dd></dl></li>
+        <li>Sorting Column (sorting_column)<dl><dd>Defines the column used for default sorting criteria.</dd></dl></li>
+        <li>Time Format (time_format)<dl><dd>Specifies the time format used for the TIME column.</dd></dl></li>
+        <li>Unacknowledged Blink (unacknowledged_blink)<dl><dd>If true all unacknowledged alarms icons will blink.</dd></dl></li>
+        <li>Writable (writable)<dl><dd>Specifies is user is allowed to acknowledge and unacknowledged alarms with this table.</dd></dl></li>
+        <li>Columns (columns)<dl><dd>Allows to specify the list and order of the table columns.</dd></dl></li>
+        <li>Max Number of Alarms (max_number_of_alarms)<dl><dd>Defines the maximum number of alarms displayed in the table. If more alarms
+    exist for the selected filter item, they will be suppressed. Only the top N alarms that match the selected sorting
+    criteria are displayed.</dd></dl></li>
+        <li>Separate Tables (separate_tables)<dl><dd>Specifies whether the acknowledged and unacknowledged alarms tables should be
+    separated or combined.</dd></dl></li>
+        <li>Table Weight Acknowledge (table_weight_acknowledge)<dl><dd>Defines the sash element weight of the acknowledged table.</dd></dl></li>
+        <li>Table Weight Unacknowledge (table_weight_unacknowledge)<dl><dd>Defines the sash element weight of the unacknowledged table.</dd></dl></li>
+        <li>Table Header Visible (table_header_visible)<dl><dd>Defines whether the header displaying the number of all active and acknowledged
+    alarms, as well as the filter combo and button are displayed or hidden. If hidden the table will take over the space
+    otherwise occupied by those widgets.</dd></dl></li>
+        <li>Columns Headers Visible (columns_header_visible)<dl><dd>Defines if the headers of the table columns are visible or not.</dd></dl></li>
+    </ul>
 
+    <h3>See Also</h3>
+    <ul>
+        <li><a href="../../org.csstudio.opibuilder/html/widgets/PVWidgets.html">Properties Common to PV Widgets</a></li>
+        <li><a href="../../org.csstudio.opibuilder/html/Widget_Properties.html">Properties Common to All Widgets</a></li>
+   </ul>
+
+<br>
 </body>
 </html>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/html/alarmtable.html
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/html/alarmtable.html
@@ -15,7 +15,8 @@
     is available in the Alarm Perspective.
     </p>
     <img src="table.png"alt="">
-
+    
+    
     <h3>Operations</h3>
     In OPI editing mode user is allowed to configure the alarm table to suit the requirements. It is possible to adjust
     the size of the table, columns, columns order, and many other properties common to BOY widgets. The filter item
@@ -24,35 +25,39 @@
     according to the defined policies. User is allowed to acknowledge and unacknowledge alarms and to do some minor 
     layout tweaking (e.g. adjust the width of column, change sorting direction and criteria). All other properties 
     are only accessible via rules and scripts.
-
+    
     <a name="AlarmTableProperties"></a>
     <h3>Special Properties</h3>
     <ul>   
-        <li>Filter Item <dl><dd>The parent item, which defines the alarms to be displayed. Only the alarms that are direct
-    or indirect descendants of this item will be displayed. The filter item has to be a complete item name, including 
-    the configuration name (e.g. to display configuration "Demo", enter "/Demo"; to display a subsystem "RFQ" of 
-    configuration "Demo", enter "/Demo/RFQ".</dd></dl></li>
-        <li>Sort Ascending <dl><dd>Defines if default sorting of the alarms should be in ascending or descending order.</dd></dl></li>
-        <li>Sorting Column <dl><dd>Defines the column used for default sorting criteria.</dd></dl></li>
-        <li>Time Format <dl><dd>Specifies the time format used for the TIME column.</dd></dl></li>
-        <li>Unacknowledged Blink <dl><dd>If true all unacknowledged alarms icons will blink.</dd></dl></li>
-        <li>Writable <dl><dd>Specifies is user is allowed to acknowledge and unacknowledged alarms with this table.</dd></dl></li>
-        <li>Columns <dl><dd>Allows to specify the list and order of the table columns.</dd></dl></li>
-        <li>Max Number of Alarms <dl><dd>Defines the maximum number of alarms displayed in the table. If more alarms
-    exist for the selected filter item, they will be suppressed. Only the top N alarms that match the selected sorting
-    criteria are displayed.</dd></dl></li>
-        <li>Separate Tables <dl><dd>Specifies whether the acknowledged and unacknowledged alarms tables should be 
-    separated or combined.</dd></dl></li>
-        <li>Table Weight Acknowledge <dl><dd>Defines the sash element weight of the acknowledged table.</dd></dl></li>
-        <li>Table Weight Unacknowledge <dl><dd>Defines the sash element weight of the unacknowledged table.</dd></dl></li>
-    </ul>
-
+		<li>Filter Item <dl><dd>The parent item, which defines the alarms to be displayed. Only the alarms that are direct
+	or indirect descendants of this item will be displayed. The filter item has to be a complete item name, including 
+	the configuration name (e.g. to display configuration "Demo", enter "/Demo"; to display a subsystem "RFQ" of 
+	configuration "Demo", enter "/Demo/RFQ".</dd></dl></li>
+		<li>Sort Ascending <dl><dd>Defines if default sorting of the alarms should be in ascending or descending order.</dd></dl></li>
+		<li>Sorting Column <dl><dd>Defines the column used for default sorting criteria.</dd></dl></li>
+		<li>Time Format <dl><dd>Specifies the time format used for the TIME column.</dd></dl></li>
+		<li>Unacknowledged Blink <dl><dd>If true all unacknowledged alarms icons will blink.</dd></dl></li>
+		<li>Writable <dl><dd>Specifies is user is allowed to acknowledge and unacknowledged alarms with this table.</dd></dl></li>
+		<li>Columns <dl><dd>Allows to specify the list and order of the table columns.</dd></dl></li>
+		<li>Max Number of Alarms <dl><dd>Defines the maximum number of alarms displayed in the table. If more alarms
+	exist for the selected filter item, they will be suppressed. Only the top N alarms that match the selected sorting
+	criteria are displayed.</dd></dl></li>
+		<li>Separate Tables <dl><dd>Specifies whether the acknowledged and unacknowledged alarms tables should be 
+	separated or combined.</dd></dl></li>
+		<li>Table Weight Acknowledge <dl><dd>Defines the sash element weight of the acknowledged table.</dd></dl></li>
+		<li>Table Weight Unacknowledge <dl><dd>Defines the sash element weight of the unacknowledged table.</dd></dl></li>
+		<li>Table Header Visible <dl><dd>Defines whether the header displaying the number of all active and acknowledged
+	alarms, as well as the filter combo and button are displayed or hidden. If hidden the table will take over the space
+	otherwise occupied by those widgets.</dd></dl></li>
+		<li>Columns Headers Visible <dl><dd>Defines if the headers of the table columns are visible or not.</dd></dl></li>
+	</ul>
+        
    <h3>See Also</h3>
    <ul>
    <li><a href="PVWidgets.html">Properties Common to PV Widgets</a></li>
    <li><a href="../Widget_Properties.html">Properties Common to All Widgets</a></li>
    </ul>
-
+    
 <br>
 
 </body>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/html/alarmtable.html
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/html/alarmtable.html
@@ -16,7 +16,6 @@
     </p>
     <img src="table.png"alt="">
     
-    
     <h3>Operations</h3>
     In OPI editing mode user is allowed to configure the alarm table to suit the requirements. It is possible to adjust
     the size of the table, columns, columns order, and many other properties common to BOY widgets. The filter item
@@ -29,33 +28,33 @@
     <a name="AlarmTableProperties"></a>
     <h3>Special Properties</h3>
     <ul>   
-		<li>Filter Item <dl><dd>The parent item, which defines the alarms to be displayed. Only the alarms that are direct
+		<li>Filter Item (filter_item)<dl><dd>The parent item, which defines the alarms to be displayed. Only the alarms that are direct
 	or indirect descendants of this item will be displayed. The filter item has to be a complete item name, including 
 	the configuration name (e.g. to display configuration "Demo", enter "/Demo"; to display a subsystem "RFQ" of 
 	configuration "Demo", enter "/Demo/RFQ".</dd></dl></li>
-		<li>Sort Ascending <dl><dd>Defines if default sorting of the alarms should be in ascending or descending order.</dd></dl></li>
-		<li>Sorting Column <dl><dd>Defines the column used for default sorting criteria.</dd></dl></li>
-		<li>Time Format <dl><dd>Specifies the time format used for the TIME column.</dd></dl></li>
-		<li>Unacknowledged Blink <dl><dd>If true all unacknowledged alarms icons will blink.</dd></dl></li>
-		<li>Writable <dl><dd>Specifies is user is allowed to acknowledge and unacknowledged alarms with this table.</dd></dl></li>
-		<li>Columns <dl><dd>Allows to specify the list and order of the table columns.</dd></dl></li>
-		<li>Max Number of Alarms <dl><dd>Defines the maximum number of alarms displayed in the table. If more alarms
+		<li>Sort Ascending (sort_ascending)<dl><dd>Defines if default sorting of the alarms should be in ascending or descending order.</dd></dl></li>
+		<li>Sorting Column (sorting_column)<dl><dd>Defines the column used for default sorting criteria.</dd></dl></li>
+		<li>Time Format (time_format)<dl><dd>Specifies the time format used for the TIME column.</dd></dl></li>
+		<li>Unacknowledged Blink (unacknowledged_blink)<dl><dd>If true all unacknowledged alarms icons will blink.</dd></dl></li>
+		<li>Writable (writable)<dl><dd>Specifies is user is allowed to acknowledge and unacknowledged alarms with this table.</dd></dl></li>
+		<li>Columns (columns)<dl><dd>Allows to specify the list and order of the table columns.</dd></dl></li>
+		<li>Max Number of Alarms (max_number_of_alarms)<dl><dd>Defines the maximum number of alarms displayed in the table. If more alarms
 	exist for the selected filter item, they will be suppressed. Only the top N alarms that match the selected sorting
 	criteria are displayed.</dd></dl></li>
-		<li>Separate Tables <dl><dd>Specifies whether the acknowledged and unacknowledged alarms tables should be 
+		<li>Separate Tables (separate_tables)<dl><dd>Specifies whether the acknowledged and unacknowledged alarms tables should be 
 	separated or combined.</dd></dl></li>
-		<li>Table Weight Acknowledge <dl><dd>Defines the sash element weight of the acknowledged table.</dd></dl></li>
-		<li>Table Weight Unacknowledge <dl><dd>Defines the sash element weight of the unacknowledged table.</dd></dl></li>
-		<li>Table Header Visible <dl><dd>Defines whether the header displaying the number of all active and acknowledged
+		<li>Table Weight Acknowledge (table_weight_acknowledge)<dl><dd>Defines the sash element weight of the acknowledged table.</dd></dl></li>
+		<li>Table Weight Unacknowledge (table_weight_unacknowledge)<dl><dd>Defines the sash element weight of the unacknowledged table.</dd></dl></li>
+		<li>Table Header Visible (table_header_visible)<dl><dd>Defines whether the header displaying the number of all active and acknowledged
 	alarms, as well as the filter combo and button are displayed or hidden. If hidden the table will take over the space
 	otherwise occupied by those widgets.</dd></dl></li>
-		<li>Columns Headers Visible <dl><dd>Defines if the headers of the table columns are visible or not.</dd></dl></li>
+		<li>Columns Headers Visible (columns_header_visible)<dl><dd>Defines if the headers of the table columns are visible or not.</dd></dl></li>
 	</ul>
         
    <h3>See Also</h3>
    <ul>
-   <li><a href="PVWidgets.html">Properties Common to PV Widgets</a></li>
-   <li><a href="../Widget_Properties.html">Properties Common to All Widgets</a></li>
+   	  <li><a href="../../org.csstudio.opibuilder/html/widgets/PVWidgets.html">Properties Common to PV Widgets</a></li>
+      <li><a href="../../org.csstudio.opibuilder/html/Widget_Properties.html">Properties Common to All Widgets</a></li>
    </ul>
     
 <br>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.alarm.beast.ui.alarmtable.opiwidget</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetFigure.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetFigure.java
@@ -68,7 +68,7 @@ public class AlarmTableWidgetFigure extends AbstractSWTWidgetFigure<Composite> {
             AlarmTableWidgetModel model = ((AlarmTableWidgetEditPart) editPart).getWidgetModel();
 
             gui = new GUI(base, null, model.isWritable(), model.isSeparateTables(), model.getColumns(),
-                    model.getSortingColumn(), model.isSortAscending());
+                    model.getSortingColumn(), model.isSortAscending(),model.isTableHeaderVisible());
             gui.setNumberOfAlarmsLimit(model.getMaxNumberOfAlarms());
             gui.setBlinking(model.isUnacknowledgedBlinking());
             gui.setTimeFormat(model.getTimeFormat());
@@ -76,6 +76,7 @@ public class AlarmTableWidgetFigure extends AbstractSWTWidgetFigure<Composite> {
             int ack = model.getAcknowledgeTableWeight();
             int unack = model.getUnacknowledgeTableWeight();
             gui.setSashWeights(ack, unack);
+            gui.setTableColumnsHeadersVisible(model.isColumnsHeadersVisible());
             base.layout();
         }
     }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetModel.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetModel.java
@@ -39,6 +39,8 @@ public class AlarmTableWidgetModel extends AbstractWidgetModel {
     static final String PROP_MAX_NUMBER_OF_ALARMS = "max_number_of_alarms";
     static final String PROP_ACK_TABLE_WEIGHT = "table_weight_acknowledge";
     static final String PROP_UNACK_TABLE_WEIGHT = "table_weight_unacknowledge";
+    static final String PROP_TABLE_HEADER_VISIBLE = "table_header_visible";
+    static final String PROP_COLUMNS_HEADERS_VISIBLE = "column_headers_visible";
 
     /*
      * (non-Javadoc)
@@ -67,6 +69,10 @@ public class AlarmTableWidgetModel extends AbstractWidgetModel {
                 80));
         addProperty(new IntegerProperty(PROP_UNACK_TABLE_WEIGHT, Messages.UnAckTableWeight,
                 WidgetPropertyCategory.Display, 20));
+        addProperty(new BooleanProperty(PROP_TABLE_HEADER_VISIBLE, Messages.TableHeaderVisible,
+                WidgetPropertyCategory.Display, false));
+        addProperty(new BooleanProperty(PROP_COLUMNS_HEADERS_VISIBLE, Messages.ColumnsHeadersVisible,
+                WidgetPropertyCategory.Display, true));
     }
 
     /*
@@ -187,5 +193,21 @@ public class AlarmTableWidgetModel extends AbstractWidgetModel {
                 return;
             }
         }
+    }
+
+    /**
+     * @return true if the columns headers should be visible or false if hidden
+     */
+    public boolean isColumnsHeadersVisible() {
+        Boolean val = getCastedPropertyValue(PROP_COLUMNS_HEADERS_VISIBLE);
+        return val == null ? true : val;
+    }
+
+    /**
+     * @return true if the table header should be visible or false if hidden
+     */
+    public boolean isTableHeaderVisible() {
+        Boolean val = getCastedPropertyValue(PROP_TABLE_HEADER_VISIBLE);
+        return val == null ? true : val;
     }
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetModel.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetModel.java
@@ -40,7 +40,7 @@ public class AlarmTableWidgetModel extends AbstractWidgetModel {
     static final String PROP_ACK_TABLE_WEIGHT = "table_weight_acknowledge";
     static final String PROP_UNACK_TABLE_WEIGHT = "table_weight_unacknowledge";
     static final String PROP_TABLE_HEADER_VISIBLE = "table_header_visible";
-    static final String PROP_COLUMNS_HEADERS_VISIBLE = "column_headers_visible";
+    static final String PROP_COLUMNS_HEADERS_VISIBLE = "columns_headers_visible";
 
     /*
      * (non-Javadoc)

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/Messages.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/Messages.java
@@ -31,6 +31,8 @@ public final class Messages extends NLS {
     public static String MaxNumberOfAlarms;
     public static String AckTableWeight;
     public static String UnAckTableWeight;
+    public static String TableHeaderVisible;
+    public static String ColumnsHeadersVisible;
 
     static {
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/messages.properties
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/messages.properties
@@ -10,3 +10,5 @@ FilterItem=Filter Item
 MaxNumberOfAlarms=Max Number of Alarms
 AckTableWeight=Table Weight Acknowledge
 UnAckTableWeight=Table Weight Unacknowledge
+TableHeaderVisible=Table Header Visible
+ColumnsHeadersVisible=Columns Headers Visible

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Alarm Table UI
 Bundle-SymbolicName: org.csstudio.alarm.beast.ui.alarmtable;singleton:=true
-Bundle-Version: 4.1.1.qualifier
+Bundle-Version: 4.1.2.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen - SNS
 Bundle-Description: BEAST Alarm Table

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.alarm.beast.ui.alarmtable</artifactId>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>4.1.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable/src/org/csstudio/alarm/beast/ui/alarmtable/AlarmTableView.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable/src/org/csstudio/alarm/beast/ui/alarmtable/AlarmTableView.java
@@ -406,9 +406,10 @@ public class AlarmTableView extends ViewPart
             gui.dispose();
         }
         gui = new GUI(parent, getSite(), defaultModel.isWriteAllowed(),
-                !combinedTables, columns, sorting, sortUp);
+                !combinedTables, columns, sorting, sortUp,true);
         gui.setBlinking(blinkingIcons);
         gui.setTimeFormat(timeFormat);
+        gui.setTableColumnsHeadersVisible(true);
         setUpDrop(gui.getActiveAlarmTable().getTable());
         setUpDrop(gui.getAcknowledgedAlarmTable().getTable());
         updateFilterItem();


### PR DESCRIPTION
Two separate properties have been added to the alarm table opiwidget, which allow to hide/show the column headers (titles) and the table headers (number of alarms, filter dialog). This can only be configured in the opiwidget. The "standalone" alarmtable is non-configurable.

Let me know if I need to create an issue for this.