### PR TITLE
o.c.vtype.pv.test: move integration tests to end *Demo.java

### DIFF
--- a/core/base/base-plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/JCAPVDemo.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/JCAPVDemo.java
@@ -37,7 +37,7 @@ import static org.hamcrest.CoreMatchers.*;
  *  and org.csstudio.vtype.pv.test/examples/test.db
  *  @author Kay Kasemir
  */
-public class JCAPVTest implements PVListener
+public class JCAPVDemo implements PVListener
 {
     private static final String NETWORK = "127.0.0.1 webopi.sns.gov:5066";
     private static final int MAX_ARRAY = 20000;

--- a/core/base/base-plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/PVAPVDemo.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv.test/src/org/csstudio/vtype/pv/PVAPVDemo.java
@@ -36,7 +36,7 @@ import org.junit.Test;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class PVA_PVTest
+public class PVAPVDemo
 {
     private static PVFactory factory;
 

--- a/core/base/base-plugins/pom.xml
+++ b/core/base/base-plugins/pom.xml
@@ -14,7 +14,7 @@
     <module>org.csstudio.csdata</module>
     <!--     <module>org.csstudio.csdata.test</module> -->
     <module>org.csstudio.vtype.pv</module>
-    <!--    <module>org.csstudio.vtype.pv.test</module>  BLOCKS EXECUTION -->
+    <module>org.csstudio.vtype.pv.test</module>
     <module>org.csstudio.workspace</module>
   </modules>
   <groupId>org.csstudio</groupId>


### PR DESCRIPTION
Add the plugin back into the pom as the unit tests now run.

As discussed in #766.