### PR TITLE
databrowser/rtplot: Fix erroneous gap after 'archive off'

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
@@ -195,7 +195,10 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
                 last_x = x;
             }
             if (Double.isNaN(value))
+            {
                 flushPolyLine(gc, value_poly, line_width);
+                last_x = last_y = -1;
+            }
             else
             {
                 final int y = clipY(y_axis.getScreenCoord(value));
@@ -230,7 +233,10 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
             final int x = clipX(Math.round(x_transform.transform(item.getPosition())));
             final double value = item.getValue();
             if (Double.isNaN(value))
+            {
                 flushPolyLine(gc, value_poly, line_width);
+                last_x = last_y = -1;
+            }
             else
             {
                 final int y = clipY(y_axis.getScreenCoord(value));

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/ChangeLog.html
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/ChangeLog.html
@@ -9,12 +9,15 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.trends.databrowser2.</p>
 
-<h2>Version 4.2.0 - 2015-08-04</h2>
+<h2>Version 4.2.0 - 2015-11-13</h2>
 <ul>
   <li>"Search" view closes underlying archive reader.</li>
   <li>RDB archive reader caches JDBC connection when fetching updates for multiple traces.</li>
   <li>Plot's "Zoom In" requires a rubberband rectangle of at least 20 pixels to avoid
       accidentally click-jerk-zooming into a few pixels.
+  </li>
+  <li>Fix erroneous gap in trace if 'Archive Off' was closely followed by an initial new sample,
+      then no changes for a while.
   </li>
 </ul>
 


### PR DESCRIPTION
Fixes #1443