### PR TITLE
Issue 1412 bytewidget

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
@@ -68,6 +68,8 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
         fig.setNumBits(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_NUM_BITS)) );
         fig.setHorizontal(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_HORIZONTAL)) );
         fig.setReverseBits(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_BIT_REVERSE)) );
+        fig.setLedBorderColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_COLOR)).getSWTColor());
+        fig.setLedSpacing(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_SPACING)) );
         fig.setSquareLED(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_LED)) );
         fig.setOnColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_ON_COLOR)).getSWTColor() );
         fig.setOffColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_OFF_COLOR)).getSWTColor() );
@@ -204,19 +206,9 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
             public boolean handleChange(Object oldValue, Object newValue,
                     IFigure refreshableFigure) {
                 ByteMonitorFigure figure = (ByteMonitorFigure)refreshableFigure;
-//                int maxBits = figure.getMAX_BITS();
-//                int numBits = figure.getNumBits();
-/*
- *                 if ((Integer)newValue < maxBits && ((Integer)newValue + numBits) < maxBits){
- */
-                    figure.setStartBit((Integer)newValue);
-/*                }
-                else {
-                    ((ByteMonitorFigure)figure).setInvalidBits();
-                }
-                */
+                figure.setStartBit((Integer)newValue);
                 figure.drawValue();
-                    return true;
+                return true;
             }
         };
 
@@ -248,6 +240,29 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
         };
         setPropertyChangeHandler(ByteMonitorModel.PROP_SQUARE_LED, squareLEDHandler);
 
+        //Square LED spacing
+        IWidgetPropertyChangeHandler squareLEDSpacingHandler = new IWidgetPropertyChangeHandler() {
+            public boolean handleChange(final Object oldValue,
+                    final Object newValue,
+                    final IFigure refreshableFigure) {
+                ByteMonitorFigure bm = (ByteMonitorFigure) refreshableFigure;
+                bm.setLedSpacing((int) newValue);
+                return true;
+            }
+        };
+        setPropertyChangeHandler(ByteMonitorModel.PROP_SQUARE_SPACING, squareLEDSpacingHandler);
+
+        //Square LED border colour
+        IWidgetPropertyChangeHandler squareLEDBorderHandler = new IWidgetPropertyChangeHandler() {
+            public boolean handleChange(final Object oldValue,
+                    final Object newValue,
+                    final IFigure refreshableFigure) {
+                ByteMonitorFigure bm = (ByteMonitorFigure) refreshableFigure;
+                bm.setLedBorderColor(((OPIColor) newValue).getSWTColor());
+                return true;
+            }
+        };
+        setPropertyChangeHandler(ByteMonitorModel.PROP_SQUARE_COLOR, squareLEDBorderHandler);
 
         //effect 3D
         IWidgetPropertyChangeHandler effect3DHandler = new IWidgetPropertyChangeHandler() {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
@@ -68,8 +68,8 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
         fig.setNumBits(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_NUM_BITS)) );
         fig.setHorizontal(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_HORIZONTAL)) );
         fig.setReverseBits(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_BIT_REVERSE)) );
-        fig.setLedBorderColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_COLOR)).getSWTColor());
-        fig.setLedSpacing(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_SPACING)) );
+        fig.setLedBorderColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_LED_BORDER_COLOR)).getSWTColor());
+        fig.setLedSpacing(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_LED_BORDER)) );
         fig.setSquareLED(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_LED)) );
         fig.setOnColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_ON_COLOR)).getSWTColor() );
         fig.setOffColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_OFF_COLOR)).getSWTColor() );
@@ -250,7 +250,7 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
                 return true;
             }
         };
-        setPropertyChangeHandler(ByteMonitorModel.PROP_SQUARE_SPACING, squareLEDSpacingHandler);
+        setPropertyChangeHandler(ByteMonitorModel.PROP_LED_BORDER, squareLEDSpacingHandler);
 
         //Square LED border colour
         IWidgetPropertyChangeHandler squareLEDBorderHandler = new IWidgetPropertyChangeHandler() {
@@ -262,7 +262,7 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
                 return true;
             }
         };
-        setPropertyChangeHandler(ByteMonitorModel.PROP_SQUARE_COLOR, squareLEDBorderHandler);
+        setPropertyChangeHandler(ByteMonitorModel.PROP_LED_BORDER_COLOR, squareLEDBorderHandler);
 
         //effect 3D
         IWidgetPropertyChangeHandler effect3DHandler = new IWidgetPropertyChangeHandler() {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
@@ -69,7 +69,7 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
         fig.setHorizontal(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_HORIZONTAL)) );
         fig.setReverseBits(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_BIT_REVERSE)) );
         fig.setLedBorderColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_LED_BORDER_COLOR)).getSWTColor());
-        fig.setLedSpacing(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_LED_BORDER)) );
+        fig.setLedBorderWidth(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_LED_BORDER)) );
         fig.setSquareLED(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_LED)) );
         fig.setOnColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_ON_COLOR)).getSWTColor() );
         fig.setOffColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_OFF_COLOR)).getSWTColor() );
@@ -228,7 +228,7 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
 
         setPropertyChangeHandler(ByteMonitorModel.PROP_NUM_BITS, numBitsHandler);
 
-        //Sqaure LED
+        //Square LED
         IWidgetPropertyChangeHandler squareLEDHandler = new IWidgetPropertyChangeHandler() {
             public boolean handleChange(final Object oldValue,
                     final Object newValue,
@@ -240,20 +240,20 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
         };
         setPropertyChangeHandler(ByteMonitorModel.PROP_SQUARE_LED, squareLEDHandler);
 
-        //Square LED spacing
-        IWidgetPropertyChangeHandler squareLEDSpacingHandler = new IWidgetPropertyChangeHandler() {
+        //LED spacing
+        IWidgetPropertyChangeHandler ledBorderWidthHandler = new IWidgetPropertyChangeHandler() {
             public boolean handleChange(final Object oldValue,
                     final Object newValue,
                     final IFigure refreshableFigure) {
                 ByteMonitorFigure bm = (ByteMonitorFigure) refreshableFigure;
-                bm.setLedSpacing((int) newValue);
+                bm.setLedBorderWidth((int) newValue);
                 return true;
             }
         };
-        setPropertyChangeHandler(ByteMonitorModel.PROP_LED_BORDER, squareLEDSpacingHandler);
+        setPropertyChangeHandler(ByteMonitorModel.PROP_LED_BORDER, ledBorderWidthHandler);
 
-        //Square LED border colour
-        IWidgetPropertyChangeHandler squareLEDBorderHandler = new IWidgetPropertyChangeHandler() {
+        //LED border color
+        IWidgetPropertyChangeHandler ledBorderColorHandler = new IWidgetPropertyChangeHandler() {
             public boolean handleChange(final Object oldValue,
                     final Object newValue,
                     final IFigure refreshableFigure) {
@@ -262,7 +262,7 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
                 return true;
             }
         };
-        setPropertyChangeHandler(ByteMonitorModel.PROP_LED_BORDER_COLOR, squareLEDBorderHandler);
+        setPropertyChangeHandler(ByteMonitorModel.PROP_LED_BORDER_COLOR, ledBorderColorHandler);
 
         //effect 3D
         IWidgetPropertyChangeHandler effect3DHandler = new IWidgetPropertyChangeHandler() {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LEDEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LEDEditPart.java
@@ -129,6 +129,23 @@ public class LEDEditPart extends AbstractBoolEditPart{
         });
 
 
+        //bulbBorderWidth
+        getWidgetModel().getProperty(LEDModel.PROP_BULB_BORDER).addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                initializeStateBulbBorderWidth((Integer)evt.getNewValue(), (LEDFigure)getFigure(), getWidgetModel());
+            }
+        });
+
+
+        //bulbBorderColor
+        getWidgetModel().getProperty(LEDModel.PROP_BULB_BORDER_COLOR).addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                initializeStateBulbBorderColor(((OPIColor)evt.getNewValue()).getSWTColor(), (LEDFigure)getFigure(), getWidgetModel());
+            }
+        });
+
         for(int idx=0; idx<LEDFigure.MAX_NSTATES; idx++) {
             final int state = idx;
             //stateLabelN
@@ -163,6 +180,9 @@ public class LEDEditPart extends AbstractBoolEditPart{
 
         LEDModel model = (LEDModel)abstractModel;
         LEDFigure figure = (LEDFigure)abstractFigure;
+
+        initializeStateBulbBorderColor(model.getBulbBorderColor(), figure, model);
+        initializeStateBulbBorderWidth(model.getBulbBorderWidth(), figure, model);
 
         initializeNStatesProperties(LEDFigure.MAX_NSTATES, model.getNStates(), figure, model);
         initializeStateFallbackLabel(null, model.getStateFallbackLabel(), figure, model);
@@ -228,5 +248,14 @@ public class LEDEditPart extends AbstractBoolEditPart{
 
     protected void initializeStateValue(int state, double oldValue, double newValue, LEDFigure figure, LEDModel model) {
         figure.setStateValue(state, newValue);
+    }
+
+
+    protected void initializeStateBulbBorderWidth(int newWidth, LEDFigure figure, LEDModel model) {
+        figure.setBulbBorderWidth(newWidth);
+    }
+
+    protected void initializeStateBulbBorderColor(Color newColor, LEDFigure figure, LEDModel model) {
+        figure.setBulbBorderColor(newColor);
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
@@ -155,8 +155,6 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
         setPropertyValue(PROP_HORIZONTAL, !isHorizontal());
     }
 
-
-
     @Override
     public void rotate90(boolean clockwise, Point center) {
         super.rotate90(clockwise, center);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
@@ -64,8 +64,9 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
     /** Label of each bit */
     public static final String PROP_LABELS = "label"; //$NON-NLS-1$
 
-    /** Spacing between square LEDs */
+    /** Spacing between LEDs */
     public static final String PROP_LED_BORDER = "led_border"; //$NON-NLS-1$
+    /** Color of space between LEDs */
     public static final String PROP_LED_BORDER_COLOR = "led_border_color"; //$NON-NLS-1$
 
     public static final Integer DEFAULT_LED_BORDER = 3;

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
@@ -16,7 +16,9 @@ import org.csstudio.opibuilder.properties.ColorProperty;
 import org.csstudio.opibuilder.properties.IntegerProperty;
 import org.csstudio.opibuilder.properties.StringListProperty;
 import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
+import org.csstudio.ui.util.CustomMediaFactory;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 
 /**
@@ -62,6 +64,13 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
     /** Label of each bit */
     public static final String PROP_LABELS = "label"; //$NON-NLS-1$
 
+    /** Spacing between square LEDs */
+    public static final String PROP_SQUARE_SPACING = "square_led_border"; //$NON-NLS-1$
+    public static final String PROP_SQUARE_COLOR = "square_led_border_color"; //$NON-NLS-1$
+    public static final Integer DEFAULT_SQUARE_SPACING = 3;
+    public static final Color DEFAULT_SQUARE_SPACING_COLOR = CustomMediaFactory.getInstance().getColor(
+            CustomMediaFactory.COLOR_DARK_GRAY);
+
     public ByteMonitorModel() {
         setSize(292, 20);
     }
@@ -78,7 +87,7 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
         addProperty(new BooleanProperty(PROP_HORIZONTAL, "Horizontal",
                 WidgetPropertyCategory.Display, true));
         addProperty(new BooleanProperty(PROP_BIT_REVERSE, "Reverse Bits",
-        WidgetPropertyCategory.Display, false));
+                WidgetPropertyCategory.Display, false));
         addProperty(new ColorProperty(PROP_ON_COLOR, "On Color",
                 WidgetPropertyCategory.Display, DEFAULT_ON_COLOR));
         addProperty(new ColorProperty(PROP_OFF_COLOR, "Off Color",
@@ -89,6 +98,10 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
                 WidgetPropertyCategory.Display, true));
         addProperty(new StringListProperty(PROP_LABELS, "Labels",
                 WidgetPropertyCategory.Display, new ArrayList<String>()));
+        addProperty(new IntegerProperty(PROP_SQUARE_SPACING, "LED border",
+                WidgetPropertyCategory.Display, DEFAULT_SQUARE_SPACING));
+        addProperty(new ColorProperty(PROP_SQUARE_COLOR, "LED border color",
+                WidgetPropertyCategory.Display, DEFAULT_SQUARE_SPACING_COLOR.getRGB()));
     }
 
     /* (non-Javadoc)

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
@@ -65,10 +65,11 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
     public static final String PROP_LABELS = "label"; //$NON-NLS-1$
 
     /** Spacing between square LEDs */
-    public static final String PROP_SQUARE_SPACING = "square_led_border"; //$NON-NLS-1$
-    public static final String PROP_SQUARE_COLOR = "square_led_border_color"; //$NON-NLS-1$
-    public static final Integer DEFAULT_SQUARE_SPACING = 3;
-    public static final Color DEFAULT_SQUARE_SPACING_COLOR = CustomMediaFactory.getInstance().getColor(
+    public static final String PROP_LED_BORDER = "led_border"; //$NON-NLS-1$
+    public static final String PROP_LED_BORDER_COLOR = "led_border_color"; //$NON-NLS-1$
+
+    public static final Integer DEFAULT_LED_BORDER = 3;
+    public static final Color DEFAULT_LED_BORDER_COLOR = CustomMediaFactory.getInstance().getColor(
             CustomMediaFactory.COLOR_DARK_GRAY);
 
     public ByteMonitorModel() {
@@ -98,10 +99,10 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
                 WidgetPropertyCategory.Display, true));
         addProperty(new StringListProperty(PROP_LABELS, "Labels",
                 WidgetPropertyCategory.Display, new ArrayList<String>()));
-        addProperty(new IntegerProperty(PROP_SQUARE_SPACING, "LED border",
-                WidgetPropertyCategory.Display, DEFAULT_SQUARE_SPACING));
-        addProperty(new ColorProperty(PROP_SQUARE_COLOR, "LED border color",
-                WidgetPropertyCategory.Display, DEFAULT_SQUARE_SPACING_COLOR.getRGB()));
+        addProperty(new IntegerProperty(PROP_LED_BORDER, "LED border",
+                WidgetPropertyCategory.Display, DEFAULT_LED_BORDER));
+        addProperty(new ColorProperty(PROP_LED_BORDER_COLOR, "LED border color",
+                WidgetPropertyCategory.Display, DEFAULT_LED_BORDER_COLOR.getRGB()));
     }
 
     /* (non-Javadoc)

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
@@ -11,6 +11,7 @@ import org.csstudio.opibuilder.properties.BooleanProperty;
 import org.csstudio.opibuilder.properties.ColorProperty;
 import org.csstudio.opibuilder.properties.DoubleProperty;
 import org.csstudio.opibuilder.properties.IntegerProperty;
+import org.csstudio.opibuilder.properties.NameDefinedCategory;
 import org.csstudio.opibuilder.properties.StringProperty;
 import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
 import org.csstudio.swt.widgets.figures.LEDFigure;
@@ -24,18 +25,6 @@ import org.eclipse.swt.graphics.Color;
  */
 public class LEDModel extends AbstractBoolWidgetModel {
 
-
-    /** Generic category class. This could be used generally if the equivalent does not already exist. */
-    public class GenericCategory implements WidgetPropertyCategory {
-        public String label;
-        public GenericCategory(String label) {
-            this.label = label;
-        }
-        @Override
-        public String toString() {
-            return label;
-        }
-    }
 
     /** The ID of the effect 3D property. */
     public static final String PROP_EFFECT3D = "effect_3d"; //$NON-NLS-1$
@@ -96,7 +85,7 @@ public class LEDModel extends AbstractBoolWidgetModel {
                 "State Count", WidgetPropertyCategory.Behavior, 2, 2, LEDFigure.MAX_NSTATES));
         setPropertyVisibleAndSavable(PROP_NSTATES, true, false);
 
-        WidgetPropertyCategory category = new GenericCategory("State Fallback");
+        WidgetPropertyCategory category = new NameDefinedCategory("State Fallback");
 
         addProperty(new StringProperty(PROP_STATE_FALLBACK_LABEL,
                 "Label", category, LEDFigure.DEFAULT_STATE_FALLBACK_LABAL));
@@ -108,7 +97,7 @@ public class LEDModel extends AbstractBoolWidgetModel {
 
         for(int state=0; state<LEDFigure.MAX_NSTATES; state++) {
 
-            category = new GenericCategory(String.format("State %02d", state+1));
+            category = new NameDefinedCategory(String.format("State %02d", state+1));
 
             addProperty(new StringProperty(String.format(PROP_STATE_LABEL, state),
                     "Label", category, LEDFigure.DEFAULT_STATE_LABELS[state]));

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
@@ -64,6 +64,10 @@ public class LEDModel extends AbstractBoolWidgetModel {
 
     public static final int MINIMUM_SIZE = 10;
 
+    /** Border around the bulb -- this is a round border for round LEDs */
+    public static final String PROP_BULB_BORDER = "bulb_border"; //$NON-NLS-1$
+    /** Color of bulb border LEDs */
+    public static final String PROP_BULB_BORDER_COLOR = "bulb_border_color"; //$NON-NLS-1$
 
     public LEDModel() {
         setSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
@@ -94,6 +98,11 @@ public class LEDModel extends AbstractBoolWidgetModel {
         addProperty(new ColorProperty(PROP_STATE_FALLBACK_COLOR,
                 "Color", category, LEDFigure.DEFAULT_STATE_FALLBACK_COLOR.getRGB()));
         setPropertyVisibleAndSavable(PROP_STATE_FALLBACK_COLOR, false, false);
+
+        addProperty(new IntegerProperty(PROP_BULB_BORDER, "Bulb border",
+                WidgetPropertyCategory.Display, LEDFigure.DEFAULT_BULB_BORDER_WIDTH));
+        addProperty(new ColorProperty(PROP_BULB_BORDER_COLOR, "Bulb border color",
+                WidgetPropertyCategory.Display, LEDFigure.DEFAULT_BULB_BORDER_COLOR.getRGB()));
 
         for(int state=0; state<LEDFigure.MAX_NSTATES; state++) {
 
@@ -158,5 +167,13 @@ public class LEDModel extends AbstractBoolWidgetModel {
 
     public Color getStateFallbackColor() {
         return getSWTColorFromColorProperty(PROP_STATE_FALLBACK_COLOR);
+    }
+
+    public int getBulbBorderWidth() {
+        return (Integer) getProperty(PROP_BULB_BORDER).getPropertyValue();
+    }
+
+    public Color getBulbBorderColor() {
+        return getSWTColorFromColorProperty(PROP_BULB_BORDER_COLOR);
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
@@ -64,7 +64,11 @@ public class LEDModel extends AbstractBoolWidgetModel {
 
     public static final int MINIMUM_SIZE = 10;
 
-    /** Border around the bulb -- this is a round border for round LEDs */
+    /**
+     * Border around the bulb - this is drawn in addition to the 'widget border'
+     * set by the widget border style/color/width properties. For round LEDs this is a
+     * round border,
+     */
     public static final String PROP_BULB_BORDER = "bulb_border"; //$NON-NLS-1$
     /** Color of bulb border LEDs */
     public static final String PROP_BULB_BORDER_COLOR = "bulb_border_color"; //$NON-NLS-1$

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/LEDModel.java
@@ -81,8 +81,8 @@ public class LEDModel extends AbstractBoolWidgetModel {
                 WidgetPropertyCategory.Display, false));
         setPropertyVisible(PROP_BOOL_LABEL_POS, false);
 
-        addProperty(new IntegerProperty(PROP_NSTATES,
-                "State Count", WidgetPropertyCategory.Behavior, 2, 2, LEDFigure.MAX_NSTATES));
+        addProperty(new IntegerProperty(PROP_NSTATES, "State Count",
+                WidgetPropertyCategory.Behavior, 2, 2, LEDFigure.MAX_NSTATES));
         setPropertyVisibleAndSavable(PROP_NSTATES, true, false);
 
         WidgetPropertyCategory category = new NameDefinedCategory("State Fallback");

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
@@ -198,6 +198,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
             Rectangle clientArea = getClientArea();
             if (isHorizontal){
                 int ledWidth = ledBorderWidth + (clientArea.width - ledBorderWidth)/numBits;
+                int ledSpacing = ledWidth - ledBorderWidth;
                 int startX = clientArea.x;
 
                 int ledHeight = 0;
@@ -208,8 +209,10 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                 }
 
                 for (LEDFigure led : ledFigures) {
-                    led.setBounds(new Rectangle(startX, clientArea.y, ledWidth, ledHeight));
-                    startX += ledWidth - ledBorderWidth;
+                    // right and bottom edges of the rectangle are 'outside' and not painted
+                    // so inflate the size to compensate
+                    led.setBounds(new Rectangle(startX, clientArea.y, ledWidth + 1, ledHeight + 1));
+                    startX += ledSpacing;
                 }
 
                 startX = clientArea.x;
@@ -221,11 +224,12 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                         text.setBounds(new Rectangle(
                                 startX, clientArea.y + ledHeight, ledWidth, clientArea.height - ledHeight));
                     }
-                    startX += ledWidth - ledBorderWidth;
+                    startX += ledSpacing;
                 }
             }
             else {
                 int ledHeight = ledBorderWidth + (clientArea.height - ledBorderWidth)/numBits;
+                int ledSpacing = ledHeight - ledBorderWidth;
                 int startY = clientArea.y;
 
                 int ledWidth = 0;
@@ -236,9 +240,10 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                 }
 
                 for (LEDFigure led : ledFigures) {
-                    led.setBounds(new Rectangle(
-                            clientArea.x, startY, ledWidth, ledHeight));
-                    startY += ledHeight - ledBorderWidth;
+                    // right and bottom edges of the rectangle are 'outside' and not painted
+                    // so inflate the size to compensate
+                    led.setBounds(new Rectangle(clientArea.x, startY, ledWidth + 1, ledHeight + 1));
+                    startY += ledSpacing;
                 }
 
                 startY = clientArea.y;
@@ -250,7 +255,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                         text.setBounds(new Rectangle(
                                 clientArea.x + ledWidth, startY, clientArea.width - ledWidth, ledHeight));
                     }
-                    startY += ledHeight - ledBorderWidth;
+                    startY += ledSpacing;
                 }
             }
         }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
@@ -49,8 +49,8 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
     /** Give the objects representing the bits a 3dEffect */
     private boolean effect3D = true;
     private boolean squareLED = false;
-    private int squareBorderWidth = 2;
-    private Color squareBorderColor = CustomMediaFactory.getInstance().getColor(
+    private int ledBorderWidth = 2;
+    private Color ledBorderColor = CustomMediaFactory.getInstance().getColor(
             CustomMediaFactory.COLOR_DARK_GRAY);
 
     /** LEDs */
@@ -69,8 +69,8 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         led.setShowBooleanLabel(false);
         led.setOnColor(getOnColor());
         led.setOffColor(getOffColor());
-        led.setBulbBorderWidth(squareBorderWidth);
-        led.setBulbBorderColor(squareBorderColor);
+        led.setBulbBorderWidth(ledBorderWidth);
+        led.setBulbBorderColor(ledBorderColor);
         led.setSquareLED(squareLED);
         led.setEffect3D(effect3D);
         return led;
@@ -197,7 +197,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         if(numBits >0){
             Rectangle clientArea = getClientArea();
             if (isHorizontal){
-                int ledWidth = squareBorderWidth + (clientArea.width - squareBorderWidth)/numBits;
+                int ledWidth = ledBorderWidth + (clientArea.width - ledBorderWidth)/numBits;
                 int startX = clientArea.x;
 
                 int ledHeight = 0;
@@ -209,7 +209,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
 
                 for (LEDFigure led : ledFigures) {
                     led.setBounds(new Rectangle(startX, clientArea.y, ledWidth, ledHeight));
-                    startX += ledWidth - squareBorderWidth;
+                    startX += ledWidth - ledBorderWidth;
                 }
 
                 startX = clientArea.x;
@@ -221,11 +221,11 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                         text.setBounds(new Rectangle(
                                 startX, clientArea.y + ledHeight, ledWidth, clientArea.height - ledHeight));
                     }
-                    startX += ledWidth - squareBorderWidth;
+                    startX += ledWidth - ledBorderWidth;
                 }
             }
             else {
-                int ledHeight = squareBorderWidth + (clientArea.height - squareBorderWidth)/numBits;
+                int ledHeight = ledBorderWidth + (clientArea.height - ledBorderWidth)/numBits;
                 int startY = clientArea.y;
 
                 int ledWidth = 0;
@@ -238,7 +238,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                 for (LEDFigure led : ledFigures) {
                     led.setBounds(new Rectangle(
                             clientArea.x, startY, ledWidth, ledHeight));
-                    startY += ledHeight - squareBorderWidth;
+                    startY += ledHeight - ledBorderWidth;
                 }
 
                 startY = clientArea.y;
@@ -250,7 +250,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                         text.setBounds(new Rectangle(
                                 clientArea.x + ledWidth, startY, clientArea.width - ledWidth, ledHeight));
                     }
-                    startY += ledHeight - squareBorderWidth;
+                    startY += ledHeight - ledBorderWidth;
                 }
             }
         }
@@ -394,16 +394,17 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
 
 
     /**
-     * Set the inter-LED spacing for SquareLEDs
+     * Set the LED border width, i.e. the spacing between
+     * the LEDs in the widget
      */
-    public void setLedSpacing(int value) {
-        if (value == squareBorderWidth)
+    public void setLedBorderWidth(int value) {
+        if (value == ledBorderWidth)
             return;
 
-        squareBorderWidth = value;
+        ledBorderWidth = value;
 
         for (LEDFigure bulb : ledFigures) {
-            bulb.setBulbBorderWidth(squareBorderWidth);
+            bulb.setBulbBorderWidth(ledBorderWidth);
         }
         revalidate();
         repaint();
@@ -411,16 +412,16 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
 
 
     /**
-     * Set the inter-LED color for SquareLEDs
+     * Set the LED border color
      */
     public void setLedBorderColor(Color value) {
-        if (squareBorderColor != null && value == squareBorderColor)
+        if (ledBorderColor != null && value == ledBorderColor)
             return;
 
-        squareBorderColor = value;
+        ledBorderColor = value;
 
         for (LEDFigure bulb : ledFigures) {
-            bulb.setBulbBorderColor(squareBorderColor);
+            bulb.setBulbBorderColor(ledBorderColor);
         }
         revalidate();
         repaint();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
@@ -69,8 +69,8 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         led.setShowBooleanLabel(false);
         led.setOnColor(getOnColor());
         led.setOffColor(getOffColor());
-        led.setLedBorderWidth(squareBorderWidth);
-        led.setBorderColor(squareBorderColor);
+        led.setBulbBorderWidth(squareBorderWidth);
+        led.setBulbBorderColor(squareBorderColor);
         led.setSquareLED(squareLED);
         led.setEffect3D(effect3D);
         return led;
@@ -403,7 +403,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         squareBorderWidth = value;
 
         for (LEDFigure bulb : ledFigures) {
-            bulb.setLedBorderWidth(squareBorderWidth);
+            bulb.setBulbBorderWidth(squareBorderWidth);
         }
         revalidate();
         repaint();
@@ -420,7 +420,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         squareBorderColor = value;
 
         for (LEDFigure bulb : ledFigures) {
-            bulb.setBorderColor(squareBorderColor);
+            bulb.setBulbBorderColor(squareBorderColor);
         }
         revalidate();
         repaint();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
@@ -15,10 +15,8 @@ import java.util.List;
 import org.csstudio.swt.widgets.introspection.DefaultWidgetIntrospector;
 import org.csstudio.swt.widgets.introspection.Introspectable;
 import org.csstudio.ui.util.CustomMediaFactory;
-import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Color;
 
@@ -71,9 +69,10 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         led.setShowBooleanLabel(false);
         led.setOnColor(getOnColor());
         led.setOffColor(getOffColor());
+        led.setLedBorderWidth(squareBorderWidth);
+        led.setBorderColor(squareBorderColor);
         led.setSquareLED(squareLED);
         led.setEffect3D(effect3D);
-        led.setBorder(createSquareBorder());
         return led;
     }
 
@@ -363,24 +362,12 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         this.squareLED = squareLED;
         for (LEDFigure bulb : ledFigures) {
             bulb.setSquareLED(this.squareLED);
-            bulb.setBorder(createSquareBorder());
         }
         for (TextFigure text : textFigures) {
             alignText(text);
         }
         revalidate();
         repaint();
-    }
-
-    /**
-     * Create a border for square LEDs
-     */
-    private Border createSquareBorder() {
-        Border ledBorder = null; // no border
-        if (squareBorderWidth > 0) {
-            ledBorder = new LineBorder(squareBorderColor, squareBorderWidth);
-        }
-        return ledBorder;
     }
 
     /**
@@ -415,13 +402,11 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
 
         squareBorderWidth = value;
 
-        if (squareLED) {
-            for (LEDFigure bulb : ledFigures) {
-                bulb.setBorder(createSquareBorder());
-            }
-            revalidate();
-            repaint();
+        for (LEDFigure bulb : ledFigures) {
+            bulb.setLedBorderWidth(squareBorderWidth);
         }
+        revalidate();
+        repaint();
     }
 
 
@@ -434,13 +419,11 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
 
         squareBorderColor = value;
 
-        if (squareLED) {
-            for (LEDFigure bulb : ledFigures) {
-                bulb.setBorder(createSquareBorder());
-            }
-            revalidate();
-            repaint();
+        for (LEDFigure bulb : ledFigures) {
+            bulb.setBorderColor(squareBorderColor);
         }
+        revalidate();
+        repaint();
     }
 
     /**

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
@@ -143,33 +143,8 @@ public class LEDFigure extends AbstractBoolFigure {
             fillColor = bulb.getBulbColor();
         }
 
-        //draw up border
         graphics.setBackgroundColor(borderColor);
-        graphics.fillPolygon(new int[]{
-                clientArea.x, clientArea.y,
-                clientArea.x + borderWidth, clientArea.y + borderWidth,
-                clientArea.x + clientArea.width - borderWidth, clientArea.y + borderWidth,
-                clientArea.x + clientArea.width, clientArea.y});
-
-        //draw left border
-        graphics.fillPolygon(new int[]{clientArea.x, clientArea.y,
-                clientArea.x + borderWidth, clientArea.y + borderWidth,
-                clientArea.x + borderWidth, clientArea.y + clientArea.height - borderWidth,
-                clientArea.x, clientArea.y + clientArea.height});
-
-        //draw bottom border
-        graphics.fillPolygon(new int[]{clientArea.x, clientArea.y + clientArea.height,
-            clientArea.x + borderWidth, clientArea.y + clientArea.height - borderWidth,
-            clientArea.x + clientArea.width - borderWidth, clientArea.y + clientArea.height - borderWidth,
-            clientArea.x + clientArea.width, clientArea.y + clientArea.height});
-
-        //draw right border
-        graphics.fillPolygon(new int[]{
-                clientArea.x + clientArea.width, clientArea.y,
-                clientArea.x + clientArea.width - borderWidth, clientArea.y + borderWidth,
-                clientArea.x + clientArea.width - borderWidth,
-                clientArea.y + clientArea.height - borderWidth,
-                clientArea.x + clientArea.width, clientArea.y + clientArea.height});
+        graphics.fillRectangle(clientArea);
 
         clientArea.shrink(borderWidth, borderWidth);
         graphics.setBackgroundColor(fillColor);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
@@ -12,9 +12,7 @@ import java.util.Arrays;
 import org.csstudio.swt.widgets.figureparts.Bulb;
 import org.csstudio.swt.widgets.util.GraphicsUtil;
 import org.csstudio.ui.util.CustomMediaFactory;
-import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -31,7 +29,6 @@ import org.eclipse.swt.widgets.Display;
 public class LEDFigure extends AbstractBoolFigure {
 
     Bulb bulb;
-    private final static int DEFAULT_BORDER_WIDTH = 3;
     private final static Color DARK_GRAY_COLOR = CustomMediaFactory.getInstance().getColor(
             CustomMediaFactory.COLOR_DARK_GRAY);
     private final static Color WHITE_COLOR = CustomMediaFactory.getInstance().getColor(
@@ -51,6 +48,8 @@ public class LEDFigure extends AbstractBoolFigure {
             new double[] { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0 };
     public final static String DEFAULT_STATE_FALLBACK_LABAL = "ERR";
     public final static Color DEFAULT_STATE_FALLBACK_COLOR = COLOR(100,100,100);
+    public static final int DEFAULT_BULB_BORDER_WIDTH = 3;
+    public static final Color DEFAULT_BULB_BORDER_COLOR = DARK_GRAY_COLOR;
 
 
     private boolean effect3D = true;
@@ -63,8 +62,8 @@ public class LEDFigure extends AbstractBoolFigure {
     private double[] stateValues = Arrays.copyOf(DEFAULT_STATE_VALUES, MAX_NSTATES);
     private Color stateFallbackColor = DEFAULT_STATE_FALLBACK_COLOR;
     private String stateFallbackLabel = DEFAULT_STATE_FALLBACK_LABAL;
-    private int borderWidth = DEFAULT_BORDER_WIDTH;
-    private Color borderColor = DARK_GRAY_COLOR;
+    private int borderWidth = DEFAULT_BULB_BORDER_WIDTH;
+    private Color borderColor = DEFAULT_BULB_BORDER_COLOR;
 
 
     public LEDFigure() {
@@ -149,11 +148,45 @@ public class LEDFigure extends AbstractBoolFigure {
         } else {
             fillColor = bulb.getBulbColor();
         }
+
+        //draw up border
+        graphics.setBackgroundColor(borderColor);
+        graphics.fillPolygon(new int[]{
+                clientArea.x, clientArea.y,
+                clientArea.x + borderWidth, clientArea.y + borderWidth,
+                clientArea.x + clientArea.width - borderWidth, clientArea.y + borderWidth,
+                clientArea.x + clientArea.width, clientArea.y});
+
+        //draw left border
+        graphics.fillPolygon(new int[]{clientArea.x, clientArea.y,
+                clientArea.x + borderWidth, clientArea.y + borderWidth,
+                clientArea.x + borderWidth, clientArea.y + clientArea.height - borderWidth,
+                clientArea.x, clientArea.y + clientArea.height});
+
+        //draw bottom border
+        graphics.fillPolygon(new int[]{clientArea.x, clientArea.y + clientArea.height,
+            clientArea.x + borderWidth, clientArea.y + clientArea.height - borderWidth,
+            clientArea.x + clientArea.width - borderWidth, clientArea.y + clientArea.height - borderWidth,
+            clientArea.x + clientArea.width, clientArea.y + clientArea.height});
+
+        //draw right border
+        graphics.fillPolygon(new int[]{
+                clientArea.x + clientArea.width, clientArea.y,
+                clientArea.x + clientArea.width - borderWidth, clientArea.y + borderWidth,
+                clientArea.x + clientArea.width - borderWidth,
+                clientArea.y + clientArea.height - borderWidth,
+                clientArea.x + clientArea.width, clientArea.y + clientArea.height});
+
+        clientArea.shrink(borderWidth, borderWidth);
         graphics.setBackgroundColor(fillColor);
         graphics.fillRectangle(clientArea);
     }
 
     private void drawSquare3d(Graphics graphics, Rectangle clientArea) {
+        // set the background
+        graphics.setBackgroundColor(borderColor);
+        graphics.fillRectangle(clientArea);
+
         //draw up border
         Pattern pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
                 clientArea.x, clientArea.y,
@@ -183,7 +216,7 @@ public class LEDFigure extends AbstractBoolFigure {
         pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
                 clientArea.x, clientArea.y + clientArea.height - borderWidth,
                 clientArea.x, clientArea.y + clientArea.height,
-                WHITE_COLOR, 20, WHITE_COLOR, 30);
+                WHITE_COLOR, 20, WHITE_COLOR, 100);
         graphics.setBackgroundPattern(pattern);
         graphics.fillPolygon(new int[]{clientArea.x, clientArea.y + clientArea.height,
             clientArea.x + borderWidth, clientArea.y + clientArea.height - borderWidth,
@@ -195,7 +228,7 @@ public class LEDFigure extends AbstractBoolFigure {
         pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
                 clientArea.x + clientArea.width - borderWidth, clientArea.y,
                 clientArea.x + clientArea.width, clientArea.y,
-                WHITE_COLOR, 20, WHITE_COLOR, 30);
+                WHITE_COLOR, 20, WHITE_COLOR, 100);
         graphics.setBackgroundPattern(pattern);
         graphics.fillPolygon(new int[]{
                 clientArea.x + clientArea.width, clientArea.y,
@@ -232,7 +265,7 @@ public class LEDFigure extends AbstractBoolFigure {
             return;
         this.effect3D = effect3D;
         bulb.setEffect3D(effect3D);
-        setBorder(createSquareBorder());
+        repaint();
     }
 
     @Override
@@ -258,7 +291,7 @@ public class LEDFigure extends AbstractBoolFigure {
 
         this.squareLED = squareLED;
         bulb.setVisible(!squareLED);
-        setBorder(createSquareBorder());
+        repaint();
     }
 
     @Override
@@ -393,32 +426,19 @@ public class LEDFigure extends AbstractBoolFigure {
         boolLabel.setText(label);
     }
 
-    public void setLedBorderWidth(int squareBorderWidth) {
-        if (squareBorderWidth == borderWidth)
+    public void setBulbBorderWidth(int bulbBorderWidth) {
+        if (bulbBorderWidth == borderWidth)
             return;
 
-        borderWidth = squareBorderWidth;
-        setBorder(createSquareBorder());
+        borderWidth = bulbBorderWidth;
+        repaint();
     }
 
-    public void setBorderColor(Color squareBorderColor) {
-        if (squareBorderColor == borderColor)
+    public void setBulbBorderColor(Color bulbBorderColor) {
+        if (bulbBorderColor == borderColor)
             return;
 
-        borderColor = squareBorderColor;
-        setBorder(createSquareBorder());
+        borderColor = bulbBorderColor;
+        repaint();
     }
-
-
-    /**
-     * Create a border for square, 2D LEDs
-     */
-    private Border createSquareBorder() {
-        Border ledBorder = null; // no border
-        if (borderWidth > 0 && squareLED && !effect3D) {
-            ledBorder = new LineBorder(borderColor, borderWidth);
-        }
-        return ledBorder;
-    }
-
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
@@ -12,7 +12,9 @@ import java.util.Arrays;
 import org.csstudio.swt.widgets.figureparts.Bulb;
 import org.csstudio.swt.widgets.util.GraphicsUtil;
 import org.csstudio.ui.util.CustomMediaFactory;
+import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -29,8 +31,7 @@ import org.eclipse.swt.widgets.Display;
 public class LEDFigure extends AbstractBoolFigure {
 
     Bulb bulb;
-    private final static int OUTLINE_WIDTH = 2;
-    private final static int SQURE_BORDER_WIDTH = 3;
+    private final static int DEFAULT_BORDER_WIDTH = 3;
     private final static Color DARK_GRAY_COLOR = CustomMediaFactory.getInstance().getColor(
             CustomMediaFactory.COLOR_DARK_GRAY);
     private final static Color WHITE_COLOR = CustomMediaFactory.getInstance().getColor(
@@ -62,6 +63,8 @@ public class LEDFigure extends AbstractBoolFigure {
     private double[] stateValues = Arrays.copyOf(DEFAULT_STATE_VALUES, MAX_NSTATES);
     private Color stateFallbackColor = DEFAULT_STATE_FALLBACK_COLOR;
     private String stateFallbackLabel = DEFAULT_STATE_FALLBACK_LABAL;
+    private int borderWidth = DEFAULT_BORDER_WIDTH;
+    private Color borderColor = DARK_GRAY_COLOR;
 
 
     public LEDFigure() {
@@ -91,7 +94,7 @@ public class LEDFigure extends AbstractBoolFigure {
     protected void layout() {
         Rectangle bulbBounds = getClientArea().getCopy();
         if(bulb.isVisible() && !squareLED){
-            bulbBounds.shrink(OUTLINE_WIDTH, OUTLINE_WIDTH);
+            bulbBounds.shrink(borderWidth, borderWidth);
             bulb.setBounds(bulbBounds);
         }
         if(boolLabel.isVisible()){
@@ -111,106 +114,114 @@ public class LEDFigure extends AbstractBoolFigure {
         boolean support3D = GraphicsUtil.testPatternSupported(graphics);
         if(squareLED){
             if(effect3D && support3D){
-                //draw up border
-                Pattern pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), clientArea.x, clientArea.y,
-                    clientArea.x, clientArea.y+SQURE_BORDER_WIDTH, BLACK_COLOR, 20, BLACK_COLOR, 100);
-                graphics.setBackgroundPattern(pattern);
-                graphics.fillPolygon(new int[]{clientArea.x, clientArea.y,
-                    clientArea.x+SQURE_BORDER_WIDTH,clientArea.y + SQURE_BORDER_WIDTH,
-                    clientArea.x + clientArea.width - SQURE_BORDER_WIDTH, clientArea.y + SQURE_BORDER_WIDTH,
-                    clientArea.x + clientArea.width, clientArea.y});
-                pattern.dispose();
-
-                //draw left border
-                pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), clientArea.x, clientArea.y,
-                    clientArea.x + SQURE_BORDER_WIDTH, clientArea.y, BLACK_COLOR, 20, BLACK_COLOR, 100);
-                graphics.setBackgroundPattern(pattern);
-                graphics.fillPolygon(new int[]{clientArea.x, clientArea.y,
-                        clientArea.x+SQURE_BORDER_WIDTH,clientArea.y + SQURE_BORDER_WIDTH,
-                        clientArea.x+SQURE_BORDER_WIDTH, clientArea.y + clientArea.height - SQURE_BORDER_WIDTH,
-                        clientArea.x, clientArea.y + clientArea.height});
-                pattern.dispose();
-
-                //draw bottom border
-                pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), clientArea.x,
-                    clientArea.y+ clientArea.height - SQURE_BORDER_WIDTH,
-                    clientArea.x, clientArea.y+clientArea.height,
-                    WHITE_COLOR, 20, WHITE_COLOR, 30);
-                graphics.setBackgroundPattern(pattern);
-                graphics.fillPolygon(new int[]{clientArea.x, clientArea.y + clientArea.height,
-                    clientArea.x+SQURE_BORDER_WIDTH,clientArea.y +clientArea.height - SQURE_BORDER_WIDTH,
-                    clientArea.x + clientArea.width - SQURE_BORDER_WIDTH,
-                    clientArea.y + clientArea.height - SQURE_BORDER_WIDTH,
-                    clientArea.x + clientArea.width, clientArea.y + clientArea.height});
-                pattern.dispose();
-
-                //draw right border
-                pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), clientArea.x + clientArea.width - SQURE_BORDER_WIDTH,
-                    clientArea.y,
-                    clientArea.x + clientArea.width, clientArea.y,
-                    WHITE_COLOR, 20, WHITE_COLOR, 30);
-                graphics.setBackgroundPattern(pattern);
-                graphics.fillPolygon(new int[]{clientArea.x + clientArea.width, clientArea.y,
-                    clientArea.x+ clientArea.width - SQURE_BORDER_WIDTH,clientArea.y + SQURE_BORDER_WIDTH,
-                    clientArea.x + clientArea.width - SQURE_BORDER_WIDTH,
-                    clientArea.y + clientArea.height - SQURE_BORDER_WIDTH,
-                    clientArea.x + clientArea.width, clientArea.y + clientArea.height});
-                pattern.dispose();
-
-                //draw light
-                clientArea.shrink(SQURE_BORDER_WIDTH, SQURE_BORDER_WIDTH);
-                Color fillColor;
-                if(nStates <= 2) {
-                    fillColor = booleanValue?onColor:offColor;
-                } else {
-                    fillColor = bulb.getBulbColor();
-                }
-                graphics.setBackgroundColor(fillColor);
-                graphics.fillRectangle(clientArea);
-                pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), clientArea.x,    clientArea.y,
-                        clientArea.x + clientArea.width, clientArea.y + clientArea.height,
-                        WHITE_COLOR, 200, fillColor, 0);
-                graphics.setBackgroundPattern(pattern);
-                   graphics.fillRectangle(clientArea);
-                   pattern.dispose();
-
+                drawSquare3d(graphics, clientArea);
             }else { //if not 3D
-                clientArea.shrink(SQURE_BORDER_WIDTH/2, SQURE_BORDER_WIDTH/2);
-                graphics.setForegroundColor(DARK_GRAY_COLOR);
-                graphics.setLineWidth(SQURE_BORDER_WIDTH);
-                graphics.drawRectangle(clientArea);
-
-                clientArea.shrink(SQURE_BORDER_WIDTH/2, SQURE_BORDER_WIDTH/2);
-                Color fillColor;
-                if(nStates <= 2) {
-                    fillColor = booleanValue?onColor:offColor;
-                } else {
-                    fillColor = bulb.getBulbColor();
-                }
-                graphics.setBackgroundColor(fillColor);
-                graphics.fillRectangle(clientArea);
+                drawSquare2d(graphics, clientArea);
             }
-
-        }else { // if round LED
+        } else { // if round LED
             int width = Math.min(clientArea.width, clientArea.height);
             Rectangle outRect = new Rectangle(getClientArea().x, getClientArea().y,
                 width, width);
             if(effect3D && support3D){
                 graphics.setBackgroundColor(WHITE_COLOR);
                 graphics.fillOval(outRect);
-                Pattern pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), outRect.x, outRect.y,
-                    outRect.x+width, outRect.y+width, DARK_GRAY_COLOR, 255, DARK_GRAY_COLOR, 0);
+                Pattern pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
+                        outRect.x, outRect.y,
+                        outRect.x + width, outRect.y + width,
+                        borderColor, 255, borderColor, 0);
                 graphics.setBackgroundPattern(pattern);
                 graphics.fillOval(outRect);
                 pattern.dispose();
             }else {
-                graphics.setBackgroundColor(DARK_GRAY_COLOR);
+                graphics.setBackgroundColor(borderColor);
                 graphics.fillOval(outRect);
             }
         }
 
         graphics.popState();
         super.paintClientArea(graphics);
+    }
+
+    private void drawSquare2d(Graphics graphics, Rectangle clientArea) {
+        Color fillColor;
+        if(nStates <= 2) {
+            fillColor = booleanValue ? onColor : offColor;
+        } else {
+            fillColor = bulb.getBulbColor();
+        }
+        graphics.setBackgroundColor(fillColor);
+        graphics.fillRectangle(clientArea);
+    }
+
+    private void drawSquare3d(Graphics graphics, Rectangle clientArea) {
+        //draw up border
+        Pattern pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
+                clientArea.x, clientArea.y,
+                clientArea.x, clientArea.y + borderWidth,
+                BLACK_COLOR, 20, BLACK_COLOR, 100);
+        graphics.setBackgroundPattern(pattern);
+        graphics.fillPolygon(new int[]{
+                clientArea.x, clientArea.y,
+                clientArea.x + borderWidth, clientArea.y + borderWidth,
+                clientArea.x + clientArea.width - borderWidth, clientArea.y + borderWidth,
+                clientArea.x + clientArea.width, clientArea.y});
+        pattern.dispose();
+
+        //draw left border
+        pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
+                clientArea.x, clientArea.y,
+                clientArea.x + borderWidth, clientArea.y,
+                BLACK_COLOR, 20, BLACK_COLOR, 100);
+        graphics.setBackgroundPattern(pattern);
+        graphics.fillPolygon(new int[]{clientArea.x, clientArea.y,
+                clientArea.x + borderWidth, clientArea.y + borderWidth,
+                clientArea.x + borderWidth, clientArea.y + clientArea.height - borderWidth,
+                clientArea.x, clientArea.y + clientArea.height});
+        pattern.dispose();
+
+        //draw bottom border
+        pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
+                clientArea.x, clientArea.y + clientArea.height - borderWidth,
+                clientArea.x, clientArea.y + clientArea.height,
+                WHITE_COLOR, 20, WHITE_COLOR, 30);
+        graphics.setBackgroundPattern(pattern);
+        graphics.fillPolygon(new int[]{clientArea.x, clientArea.y + clientArea.height,
+            clientArea.x + borderWidth, clientArea.y + clientArea.height - borderWidth,
+            clientArea.x + clientArea.width - borderWidth, clientArea.y + clientArea.height - borderWidth,
+            clientArea.x + clientArea.width, clientArea.y + clientArea.height});
+        pattern.dispose();
+
+        //draw right border
+        pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
+                clientArea.x + clientArea.width - borderWidth, clientArea.y,
+                clientArea.x + clientArea.width, clientArea.y,
+                WHITE_COLOR, 20, WHITE_COLOR, 30);
+        graphics.setBackgroundPattern(pattern);
+        graphics.fillPolygon(new int[]{
+                clientArea.x + clientArea.width, clientArea.y,
+                clientArea.x + clientArea.width - borderWidth, clientArea.y + borderWidth,
+                clientArea.x + clientArea.width - borderWidth,
+                clientArea.y + clientArea.height - borderWidth,
+                clientArea.x + clientArea.width, clientArea.y + clientArea.height});
+        pattern.dispose();
+
+        //draw light
+        clientArea.shrink(borderWidth, borderWidth);
+        Color fillColor;
+        if(nStates <= 2) {
+            fillColor = booleanValue ? onColor : offColor;
+        } else {
+            fillColor = bulb.getBulbColor();
+        }
+        graphics.setBackgroundColor(fillColor);
+        graphics.fillRectangle(clientArea);
+        pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(),
+                clientArea.x, clientArea.y,
+                clientArea.x + clientArea.width, clientArea.y + clientArea.height,
+                WHITE_COLOR, 200, fillColor, 0);
+        graphics.setBackgroundPattern(pattern);
+        graphics.fillRectangle(clientArea);
+        pattern.dispose();
     }
 
     /**
@@ -221,6 +232,7 @@ public class LEDFigure extends AbstractBoolFigure {
             return;
         this.effect3D = effect3D;
         bulb.setEffect3D(effect3D);
+        setBorder(createSquareBorder());
     }
 
     @Override
@@ -243,8 +255,10 @@ public class LEDFigure extends AbstractBoolFigure {
     public void setSquareLED(boolean squareLED) {
         if(this.squareLED == squareLED)
             return;
+
         this.squareLED = squareLED;
         bulb.setVisible(!squareLED);
+        setBorder(createSquareBorder());
     }
 
     @Override
@@ -378,4 +392,33 @@ public class LEDFigure extends AbstractBoolFigure {
         bulb.setBulbColor(color);
         boolLabel.setText(label);
     }
+
+    public void setLedBorderWidth(int squareBorderWidth) {
+        if (squareBorderWidth == borderWidth)
+            return;
+
+        borderWidth = squareBorderWidth;
+        setBorder(createSquareBorder());
+    }
+
+    public void setBorderColor(Color squareBorderColor) {
+        if (squareBorderColor == borderColor)
+            return;
+
+        borderColor = squareBorderColor;
+        setBorder(createSquareBorder());
+    }
+
+
+    /**
+     * Create a border for square, 2D LEDs
+     */
+    private Border createSquareBorder() {
+        Border ledBorder = null; // no border
+        if (borderWidth > 0 && squareLED && !effect3D) {
+            ledBorder = new LineBorder(borderColor, borderWidth);
+        }
+        return ledBorder;
+    }
+
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/LEDFigure.java
@@ -75,16 +75,10 @@ public class LEDFigure extends AbstractBoolFigure {
         bulb.setBulbColor(booleanValue ? onColor : offColor);
     }
 
-    /**
-     * @return the effect3D
-     */
     public boolean isEffect3D() {
         return effect3D;
     }
 
-    /**
-     * @return the squareLED
-     */
     public boolean isSquareLED() {
         return squareLED;
     }
@@ -282,9 +276,6 @@ public class LEDFigure extends AbstractBoolFigure {
             bulb.setBulbColor(onColor);
     }
 
-    /**
-     * @param squareLED the squareLED to set
-     */
     public void setSquareLED(boolean squareLED) {
         if(this.squareLED == squareLED)
             return;


### PR DESCRIPTION
Extended LED widget to have configurable 'borders', in addition to the widget's regular draw2d 'Border', which is square for round LEDs. This replaces a fixed 3px grey border.

The byte widget exposes the LED 'border' width and color allowing it to be configured to display bits at a higher density.