### PR TITLE
scan server: Log errors in httpd before trying to send error response

### DIFF
--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScanServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScanServlet.java
@@ -56,6 +56,7 @@ public class ScanServlet extends HttpServlet
         final String format = request.getContentType();
         if (! format.contains("/xml"))
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /scan got format '" + format + "'");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Expecting XML content with scan, got format '" + format + "'");
             return;
         }
@@ -94,6 +95,7 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /scan error", ex);
             response.resetBuffer();
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             out.println("<error>");
@@ -168,8 +170,8 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "PUT /scan error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
-            return;
         }
     }
 
@@ -192,8 +194,8 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "DELETE /scan error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
-            return;
         }
     }
 
@@ -220,6 +222,7 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scan error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
             return;
         }
@@ -270,8 +273,8 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scan error", ex);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex.getMessage());
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scan failed", ex);
         }
     }
 }

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScansServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScansServlet.java
@@ -9,6 +9,8 @@ package org.csstudio.scan.server.httpd;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -58,8 +60,8 @@ public class ScansServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scans error", ex);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex.getMessage());
-            ex.printStackTrace();
         }
     }
 
@@ -80,6 +82,7 @@ public class ScansServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "DELETE /scans/completed error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
             return;
         }

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ServerServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ServerServlet.java
@@ -8,6 +8,8 @@
 package org.csstudio.scan.server.httpd;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -48,6 +50,7 @@ public class ServerServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /server error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
             return;
         }
@@ -70,8 +73,8 @@ public class ServerServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /server error", ex);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex.getMessage());
-            ex.printStackTrace();
         }
     }
 }

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/SimulateServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/SimulateServlet.java
@@ -10,6 +10,8 @@ package org.csstudio.scan.server.httpd;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -46,6 +48,7 @@ public class SimulateServlet extends HttpServlet
         final String format = request.getContentType();
         if (! format.contains("/xml"))
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /simulate got format '" + format + "'");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Expecting XML content with scan, got format '" + format + "'");
             return;
         }
@@ -72,6 +75,7 @@ public class SimulateServlet extends HttpServlet
         }
         catch (Exception ex)
         {
+            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /simulate error", ex);
             response.resetBuffer();
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             out.println("<error>");

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
@@ -9,10 +9,11 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.scan.</p>
 
-<h2>Version 4.2.5 - 2015-11-02</h2>
+<h2>Version 4.2.5 - 2015-11-23</h2>
 <ul>
   <li>Scan Server supports "?queue=false" to execute scans as soon as possible, not queued.</li>
   <li>Scan Server supports "next" command to force transition to the next scan command.</li>
+  <li>Scan Server HTTPd logs errors before trying to send error response.</li>
 </ul>
 
 <h2>Version 4.2.4 - 2015-10-02</h2>


### PR DESCRIPTION
.. because sending the error response can fail, and then we see no error
detail.

Fixes #1462