### PR TITLE
#1467 Add 'pack' LEDs option to ByteWidget

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_ByteClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_ByteClass.java
@@ -34,8 +34,10 @@ public class Opi_ByteClass extends OpiWidget {
         //dimensions of the widget
         boolean horizontal = r.getW() > r.getH();
         new OpiBoolean(widgetContext, "horizontal", horizontal);
+
         new OpiBoolean(widgetContext, "effect_3d", false);
         new OpiBoolean(widgetContext, "square_led", true);
+        new OpiBoolean(widgetContext, "led_packed", true);
 
         // EDM line width is returned as '0' if unchanged from default '1'
         new OpiInt(widgetContext, "led_border", Math.max(1, r.getLineWidth()));

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ByteMonitorEditPart.java
@@ -68,6 +68,7 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
         fig.setNumBits(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_NUM_BITS)) );
         fig.setHorizontal(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_HORIZONTAL)) );
         fig.setReverseBits(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_BIT_REVERSE)) );
+        fig.setPackedLEDs(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_PACK_LEDS)) );
         fig.setLedBorderColor(((OPIColor)model.getPropertyValue(ByteMonitorModel.PROP_LED_BORDER_COLOR)).getSWTColor());
         fig.setLedBorderWidth(((Integer)model.getPropertyValue(ByteMonitorModel.PROP_LED_BORDER)) );
         fig.setSquareLED(((Boolean)model.getPropertyValue(ByteMonitorModel.PROP_SQUARE_LED)) );
@@ -288,6 +289,21 @@ public class ByteMonitorEditPart extends AbstractPVWidgetEditPart {
             }
         };
         setPropertyChangeHandler(ByteMonitorModel.PROP_LABELS, labelsHandler);
+
+
+        //Set the LED rendering style
+        IWidgetPropertyChangeHandler packHandler = new IWidgetPropertyChangeHandler() {
+
+            public boolean handleChange(Object oldValue, Object newValue,
+                    IFigure refreshableFigure) {
+                ByteMonitorFigure figure = (ByteMonitorFigure)refreshableFigure;
+                figure.setPackedLEDs((Boolean)newValue);
+                figure.drawValue();
+                return true;
+            }
+        };
+
+        setPropertyChangeHandler(ByteMonitorModel.PROP_PACK_LEDS, packHandler);
     }
 
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/ByteMonitorModel.java
@@ -69,6 +69,8 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
     /** Color of space between LEDs */
     public static final String PROP_LED_BORDER_COLOR = "led_border_color"; //$NON-NLS-1$
 
+    public static final String PROP_PACK_LEDS = "led_packed"; //$NON-NLS-1$
+
     public static final Integer DEFAULT_LED_BORDER = 3;
     public static final Color DEFAULT_LED_BORDER_COLOR = CustomMediaFactory.getInstance().getColor(
             CustomMediaFactory.COLOR_DARK_GRAY);
@@ -104,6 +106,8 @@ public class ByteMonitorModel extends AbstractPVWidgetModel {
                 WidgetPropertyCategory.Display, DEFAULT_LED_BORDER));
         addProperty(new ColorProperty(PROP_LED_BORDER_COLOR, "LED border color",
                 WidgetPropertyCategory.Display, DEFAULT_LED_BORDER_COLOR.getRGB()));
+        addProperty(new BooleanProperty(PROP_PACK_LEDS, "Pack LEDs",
+                WidgetPropertyCategory.Display, false));
     }
 
     /* (non-Javadoc)

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ByteMonitorFigure.java
@@ -49,6 +49,7 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
     /** Give the objects representing the bits a 3dEffect */
     private boolean effect3D = true;
     private boolean squareLED = false;
+    private boolean hasPackedLEDs = false;
     private int ledBorderWidth = 2;
     private Color ledBorderColor = CustomMediaFactory.getInstance().getColor(
             CustomMediaFactory.COLOR_DARK_GRAY);
@@ -187,6 +188,48 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         return squareLED;
     }
 
+    /**
+     * LEDs are sized to 'fill' the client area.
+     *
+     * If 'packed' borders around LEDs are overlapped giving a higher density.
+     * This gives an odd visual effect for 3d and round LEDs
+     *
+     * @param clientSize
+     * @param borderSize
+     * @return
+     */
+    private int calculateLedSize(int clientSize, int borderSize) {
+        int size;
+
+        if (hasPackedLEDs) {
+            size = (clientSize - borderSize) / numBits + borderSize;
+        }
+        else {
+            size = clientSize / numBits;
+        }
+        return size;
+    }
+
+    /**
+     * LEDs spacing is the offset between the corners of successive LEDs
+     *
+     * If 'packed' borders around LEDs are overlapped giving a higher density.
+     * This gives an odd visual effect for 3d and round LEDs
+     *
+     * @param ledSize
+     * @param borderSize
+     * @return
+     */
+    private int calculateLedSpacing(int ledSize, int borderSize) {
+        int spacing = ledSize;
+
+        if (hasPackedLEDs) {
+            spacing -= borderSize;
+        }
+
+        return spacing;
+    }
+
     /* (non-Javadoc)
      * @see org.eclipse.draw2d.Figure#layout()
      */
@@ -197,8 +240,8 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
         if(numBits >0){
             Rectangle clientArea = getClientArea();
             if (isHorizontal){
-                int ledWidth = ledBorderWidth + (clientArea.width - ledBorderWidth)/numBits;
-                int ledSpacing = ledWidth - ledBorderWidth;
+                int ledWidth = calculateLedSize(clientArea.width, ledBorderWidth);
+                int ledSpacing = calculateLedSpacing(ledWidth, ledBorderWidth);
                 int startX = clientArea.x;
 
                 int ledHeight = 0;
@@ -228,8 +271,8 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
                 }
             }
             else {
-                int ledHeight = ledBorderWidth + (clientArea.height - ledBorderWidth)/numBits;
-                int ledSpacing = ledHeight - ledBorderWidth;
+                int ledHeight = calculateLedSize(clientArea.height, ledBorderWidth);
+                int ledSpacing = calculateLedSpacing(ledHeight, ledBorderWidth);
                 int startY = clientArea.y;
 
                 int ledWidth = 0;
@@ -485,5 +528,14 @@ public class ByteMonitorFigure extends Figure implements Introspectable{
             }
             text.setVerticalAlignment(TextFigure.V_ALIGN.MIDDLE);
         }
+    }
+
+    public void setPackedLEDs(boolean packLEDs) {
+        if(this.hasPackedLEDs  == packLEDs)
+            return;
+
+        this.hasPackedLEDs = packLEDs;
+        revalidate();
+        repaint();
     }
 }


### PR DESCRIPTION
Revert behavior change introduced by fix to #1412.

Added new property that reproduces previous layout/spacing of LEDs inside a byte widget. Defaults to rendering with legacy layout.