### PR TITLE
o.c.opibuilder.rcp: remove OPIShellSummary from views category.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/fragment.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/fragment.xml
@@ -29,7 +29,6 @@
    <extension point="org.eclipse.ui.views">
       <view
             allowMultiple="false"
-            category="org.csstudio.opibuilder.views"
             class="org.csstudio.opibuilder.runmode.OPIShellSummary"
             fastViewWidthRatio="0.3"
             icon="icons/OPIRunner.png"


### PR DESCRIPTION
When the OPIShellSummary view is part of the
org.csstudio.opibuilder.views category, it appears to mess up the
OPIRunner perspective.  I don't know why this is.

As discussed in #1408.  I would rather understand, but right now we need this to be fixed.