### PR TITLE
o.c.utility.pvmanager.ui: remove reference to preference page.

### DIFF
--- a/core/utility/utility-plugins/org.csstudio.utility.pvmanager.ui/plugin.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.pvmanager.ui/plugin.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension
-         point="org.eclipse.ui.preferencePages">
-      <page
-            category="org.csstudio.platform.ui.css.platform"
-            class="org.csstudio.utility.pvmanager.ui.PreferencePage"
-            id="org.csstudio.utility.pvmanager.ui.PreferencePage"
-            name="%PrefName">
-      </page>
-   </extension>
 
    <extension
          point="org.eclipse.help.toc">


### PR DESCRIPTION
This was removed in 2f835679b63ad925bf96529c1e23d6ac24480554.

See #1470.