### PR TITLE
o.c.o.converter: hard-code width of converted updown button

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeUpdownButtonClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeUpdownButtonClass.java
@@ -31,6 +31,9 @@ public class Opi_activeUpdownButtonClass extends OpiWidget {
         setTypeId(typeId);
         setName(name);
         setVersion(version);
+        // When converting an updown button into a spinner, the readback part of the spinner
+        // is generally not required.  This width makes the widget show only the buttons.
+        new OpiInt(widgetContext, "width", 22);
         if(r.getControlPv()!=null)
             new OpiString(widgetContext, "pv_name", convertPVName(r.getControlPv()));
         if(r.getCoarseValue()!=0)


### PR DESCRIPTION
When converting an updown button into a spinner, only the buttons
are relevant.  Hard-coding the width shows only the buttons.

An alternative option is to give the spinner widget the option not to show the readback, which we may do if everyone is happy with that change.

See #1494.