### PR TITLE
Workbench 1499

### DIFF
--- a/core/utility/utility-plugins/org.csstudio.utility.product/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Shared
 Bundle-SymbolicName: org.csstudio.utility.product;singleton:=true
-Bundle-Version: 1.2.2.qualifier
+Bundle-Version: 1.3.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.6",

--- a/core/utility/utility-plugins/org.csstudio.utility.product/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/pom.xml
@@ -8,6 +8,6 @@
     <version>4.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.utility.product</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/StartupParameters.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/StartupParameters.java
@@ -74,6 +74,12 @@ public class StartupParameters implements StartupParametersExtPoint
     /** Parameter tag defines the shared link. The value is stored in the returned map. */
     public static final String SHARE_LINK_PARAM = "css.shareLink"; //$NON-NLS-1$
 
+    /** Command-line switch to install workbench.xmi */
+    private static final String WORKBENCH_XMI = "-workbench_xmi"; //$NON-NLS-1$
+
+    /** Parameter tag for WORKBENCH_XMI. Map value contains path to workbench.xmi. */
+    public static final String WORKBENCH_XMI_PARAM = "css.workbench.xmi"; //$NON-NLS-1$
+
     /** {@inheritDoc} */
     @SuppressWarnings("nls")
     @Override
@@ -120,6 +126,29 @@ public class StartupParameters implements StartupParametersExtPoint
                         default_workspace = new URL("file:" + next); //$NON-NLS-1$
                         ++i;
                     }
+                }
+            }
+            else if (arg.equalsIgnoreCase(WORKBENCH_XMI))
+            {
+                String template = null;
+                if ((i + 1) < args.length)
+                {
+                    final String next = args[i+1];
+                    if (!next.startsWith("-")) //$NON-NLS-1$
+                    {
+                        template = next;
+                        ++i;
+                    }
+                }
+                if (template != null)
+                    parameters.put(WORKBENCH_XMI_PARAM, template);
+                else
+                {
+                    System.out.println("Error: Missing /path/to/workspace.xmi"); //$NON-NLS-1$
+                    showHelp();
+                    // Exit ASAP, see comment below.
+                    parameters.put(EXIT_CODE, IApplication.EXIT_OK);
+                    System.exit(0);
                 }
             }
             else if (arg.equalsIgnoreCase(SHARE_LINK))
@@ -240,6 +269,8 @@ public class StartupParameters implements StartupParametersExtPoint
                 WORKSPACE_PROMPT);
         System.out.format("  %-40s : Present workspace dialog with given default\n",
                 WORKSPACE_PROMPT + " /some/workspace");
+        System.out.format("  %-40s : Initialize workbench.xmi with a given template\n",
+                WORKBENCH_XMI + " /path/to/workbench.xmi");
         System.out.format("  %-40s : Log all messages to the console\n",
                 "-consoleLog");
         System.out.format("  %-40s : Select workspace on command-line, no prompt\n",

--- a/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/WorkspacePrompt.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/WorkspacePrompt.java
@@ -3,7 +3,11 @@ package org.csstudio.utility.product;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.csstudio.platform.workspace.WorkspaceIndependentStore;
 import org.csstudio.platform.workspace.WorkspaceInfo;
@@ -68,6 +72,29 @@ public class WorkspacePrompt implements WorkspaceExtPoint {
             //Platform.endSplash();
             return IApplication.EXIT_OK;
         }
+
+        o = parameters.get(StartupParameters.WORKBENCH_XMI_PARAM);
+        if (o != null)
+        {   // Install predefined workbench.xmi
+            final File template = new File((String)o);
+            try
+            {   // Another way to get the workbench.xmi location,
+                // but depends on hardcoded knowledge of ".metadata/.plugins":
+                // ResourcesPlugin.getWorkspace().getRoot().getLocation().append(".metadata/.plugins/org.eclipse.e4.workbench/workbench.xmi");
+                final URL uri = Platform.getInstanceLocation().getDataArea("org.eclipse.e4.workbench/workbench.xmi");
+                final File file = new File(uri.getFile());
+                if (! file.isAbsolute())
+                    throw new Exception("Cannot obtain absolute workbench.xmi location, got " + file);
+                Files.createDirectories(file.toPath().getParent());
+                Files.copy(template.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            catch (Exception ex)
+            {
+                Logger.getLogger(getClass().getName())
+                      .log(Level.SEVERE, "Cannot install workbench.xmi template " + template, ex);
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Adds "-workbench_xmi" command line option for installing a workbench.xmi file into the workspace.
Can be used to assert known initial display layout and predefined perspectives.
Fixes #1499