### PR TITLE
o.c.security.ui: ControlContribution workaround #1485 eclipse #471313

### DIFF
--- a/core/utility/utility-plugins/org.csstudio.security.ui/plugin.xml
+++ b/core/utility/utility-plugins/org.csstudio.security.ui/plugin.xml
@@ -38,6 +38,11 @@
             locationURI="toolbar:org.eclipse.ui.trim.status">
          <toolbar
                id="org.csstudio.security.ui.infobar">
+            <command
+                  commandId="org.csstudio.security.ui.dummycommand"
+                  label="-"
+                  style="push">
+            </command>
             <control
                   class="org.csstudio.security.ui.internal.StatusBarInfo">
             </control>

--- a/core/utility/utility-plugins/org.csstudio.security.ui/plugin.xml
+++ b/core/utility/utility-plugins/org.csstudio.security.ui/plugin.xml
@@ -38,6 +38,7 @@
             locationURI="toolbar:org.eclipse.ui.trim.status">
          <toolbar
                id="org.csstudio.security.ui.infobar">
+            <!-- Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=471313 -->
             <command
                   commandId="org.csstudio.security.ui.dummycommand"
                   label="-"


### PR DESCRIPTION
#1485

This is a workaround until the eclipse issue is fixed:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=471313