### PR TITLE
Update versions on opibuilder plugins and features.

### DIFF
--- a/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/feature.xml
+++ b/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.csstudio.applications.opibuilder.feature"
       label="Operator Interface Builder (BOY)"
-      version="4.0.107.qualifier"
+      version="5.0.0.qualifier"
       provider-name="Kay Kasemir &lt;kasemirk@ornl.gov&gt; - SNS">
 
    <description>

--- a/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/pom.xml
+++ b/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.feature/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.applications.opibuilder.feature</artifactId>
-  <version>4.0.107-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.rap.feature/pom.xml
+++ b/applications/opibuilder/opibuilder-features/org.csstudio.applications.opibuilder.rap.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-features</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.applications.opibuilder.rap.feature</artifactId>
   <version>1.1.1-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-features/pom.xml
+++ b/applications/opibuilder/opibuilder-features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opibuilder-features</artifactId>
   <packaging>pom</packaging>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.adl2boy/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.adl2boy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.adl2boy</artifactId>
   <version>1.0.5-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.alarm/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.alarm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.alarm</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter.test/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.csstudio.opibuilder.converter.test
-Bundle-Version: 0.0.1.qualifier
+Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.csstudio.opibuilder.converter;bundle-version="1.0.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter.test/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter.test/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.converter.test</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: EDM2BOY Converter
 Bundle-Description: EDM to BOY Converter
 Bundle-SymbolicName: org.csstudio.opibuilder.converter;singleton:=true
-Bundle-Version: 1.0.2.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-ClassPath: .
 Main-Class: org.csstudio.opibuilder.converter.EdmConverter
 Export-Package: org.csstudio.opibuilder.converter,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/pom.xml
@@ -5,10 +5,10 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.converter</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <profiles>
     <!-- run maven with -Dbuild.converter.jar to build the standalone jar file. -->

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BOY Editor Plugin
 Bundle-SymbolicName: org.csstudio.opibuilder.editor;singleton:=true
-Bundle-Version: 3.1.5.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.filesystem;bundle-version="1.2.0",
  org.eclipse.ui.editors,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.editor</artifactId>
-  <version>3.1.5-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.examples/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BOY Examples
 Bundle-SymbolicName: org.csstudio.opibuilder.examples;singleton:=true
-Bundle-Version: 4.0.101.qualifier
+Bundle-Version: 5.0.0.qualifier
 Bundle-Activator: org.csstudio.opibuilder.examples.Activator
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Require-Bundle: org.eclipse.ui,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.examples/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.examples/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.examples</artifactId>
-  <version>4.0.101-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.imagelib/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.imagelib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.imagelib</artifactId>
   <version>4.3.1-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rap/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rap/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RAP fragment for opibuilder
 Bundle-SymbolicName: org.csstudio.opibuilder.rap;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 5.0.0.qualifier
 Fragment-Host: org.csstudio.opibuilder;bundle-version="3.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.csstudio.rap.core;bundle-version="1.0.0",

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rap/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rap/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.rap</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RCP fragment of opibuilder
 Bundle-SymbolicName: org.csstudio.opibuilder.rcp;singleton:=true
-Bundle-Version: 3.2.3.qualifier
+Bundle-Version: 5.0.0.qualifier
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
-Fragment-Host: org.csstudio.opibuilder;bundle-version="2.0.0"
+Fragment-Host: org.csstudio.opibuilder;bundle-version="5.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.4.0",
  org.eclipse.core.filesystem;bundle-version="1.2.0",

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.rcp</artifactId>
-  <version>3.2.3-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.test/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test Fragment of opibuilder
 Bundle-SymbolicName: org.csstudio.opibuilder.test;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Fragment-Host: org.csstudio.opibuilder;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.test/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.test/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.test</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.tools/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.tools</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OPI Validation
 Bundle-SymbolicName: org.csstudio.opibuilder.validation;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: ITER
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.csstudio.opibuilder;bundle-version="4.0.0",

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.validation/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.validation/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.validation</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.extra/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.extra/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Extra widgets for BOY
 Bundle-SymbolicName: org.csstudio.opibuilder.widgets.extra;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime,
  org.csstudio.utility.pvmanager.widgets;bundle-version="3.2.0",

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.extra/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.extra/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.widgets.extra</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.rap/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.rap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.widgets.rap</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.rcp/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.rcp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.widgets.rcp</artifactId>
   <version>3.1.3-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY Symbol Widgets
 Bundle-Vendor: Fred Arnaud <frederic.arnaud@iter.org> - ITER
 Bundle-SymbolicName: org.csstudio.opibuilder.widgets.symbol;singleton:=true
-Bundle-Version: 4.5.0.qualifier
+Bundle-Version: 5.0.0.qualifier
 Bundle-Activator: org.csstudio.opibuilder.widgets.symbol.Activator
 Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.rap.ui;resolution:=optional,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.widgets.symbol</artifactId>
-  <version>4.5.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY Widgets Plug-in
 Bundle-Description: Widgets for BOY
 Bundle-SymbolicName: org.csstudio.opibuilder.widgets;singleton:=true
-Bundle-Version: 3.4.3.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.csstudio.opibuilder.widgets.Activator
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Require-Bundle: org.eclipse.core.runtime,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.widgets</artifactId>
-  <version>3.4.3-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY base plugin
 Bundle-Description: Base plugin of BOY
 Bundle-SymbolicName: org.csstudio.opibuilder;singleton:=true
-Bundle-Version: 4.0.104.qualifier
+Bundle-Version: 5.0.0.qualifier
 Bundle-Activator: org.csstudio.opibuilder.OPIBuilderPlugin
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-Localization: plugin

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder</artifactId>
-  <version>4.0.104-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.pvmanager.test/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.pvmanager.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.simplepv.pvmanager.test</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.pvmanager/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.pvmanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.simplepv.pvmanager</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.testutil/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.testutil/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.simplepv.testutil</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.vtypepv/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.vtypepv/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.simplepv.vtypepv</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.simplepv</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets.rcp/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets.rcp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.swt.widgets.rcp</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets.test/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.swt.widgets.test</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder-plugins</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.swt.widgets</artifactId>
   <version>2.1.3-SNAPSHOT</version>

--- a/applications/opibuilder/opibuilder-plugins/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>opibuilder-plugins</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>org.csstudio.simplepv</module>

--- a/applications/opibuilder/opibuilder-repository/pom.xml
+++ b/applications/opibuilder/opibuilder-repository/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.csstudio</groupId>
     <artifactId>opibuilder</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opibuilder-repository</artifactId>
   <packaging>eclipse-repository</packaging>

--- a/applications/opibuilder/pom.xml
+++ b/applications/opibuilder/pom.xml
@@ -7,7 +7,7 @@
     <version>4.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>opibuilder</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>opibuilder-plugins</module>


### PR DESCRIPTION
Someone needed to do this so I've given it a go.

I have updated opibuilder to 5.0.0.  I don't mind that it's not the same as the CSS version and it is definitely a major update.

I haven't changed rap plugins because I don't understand them.

If a plugin has changed I've updated the major version.  If a plugin hasn't changed I **haven't** updated the version.

I don't mind if people want to do this differently @kasemir @berryma4 @shroffk .

See #1510.