### PR TITLE
o.c.o.converter: avoid unnecessary alarm sensitivity

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/model/EdmWidget.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/model/EdmWidget.java
@@ -46,8 +46,18 @@ public class EdmWidget extends EdmEntity {
         super(genericEntity);
     }
 
+    /**
+     * Return PV to use for alarm sensitivity.
+     * @return alarmPv if present; else colorPv if present; else null
+     */
     public final String getAlarmPv() {
-        return alarmPv==null?colorPv:alarmPv;
+        String pv = null;
+        if ((alarmPv != null) && (!alarmPv.equals(""))) {
+            pv = alarmPv;
+        } else if ((colorPv != null) && (!colorPv.equals(""))) {
+            pv = colorPv;
+        }
+        return pv;
     }
 
     public int getMajor() {


### PR DESCRIPTION
The converter converts alarm sensitivity even if no PV is specified.
This presents a disconnected widget in CSS where in EDM it was ignored.
Better not to convert the alarm sensitivity in this case.

Discussed in #1545.
