### PR TITLE
Text widgets: always recalculate location if text has changed.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/TextFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/TextFigure.java
@@ -397,8 +397,7 @@ public class TextFigure extends Figure implements Introspectable, ITextFigure{
             s = "";//$NON-NLS-1$
         if (text.equals(s))
             return;
-        if(s.length() !=  text.length())
-            clearLocationSize();
+        clearLocationSize();
         text = s;
 
         repaint();


### PR DESCRIPTION
Because fonts are not necessarily monospace, if text has changed at all
the text location should be recalculated.

Discussed in #1561.