### PR TITLE
EDM converter: handle invalid PVs in symbol widget

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeSymbolClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeSymbolClass.java
@@ -43,14 +43,19 @@ public class Opi_activeSymbolClass extends OpiWidget {
         }
         new OpiInt(widgetContext, "border_style", 0);
         new OpiString(widgetContext, "group_name", "1");
-        //single pv, no truth table
+        // Single pv, no truth table
         if (!r.isTruthTable() && r.getNumPvs() == 1 && r.getControlPvs()!=null) {
             LinkedHashMap<String, Element> expressions = new LinkedHashMap<String, Element>();
+            // Invalid PV always displays symbol zero in EDM.
+            Element valueNode = widgetContext.getDocument().createElement("value");
+            valueNode.setTextContent("0");
+            expressions.put("pvSev0==-1", valueNode);
+
             Map<String, EdmDouble> minMap = r.getMinValues().getEdmAttributesMap();
             Map<String, EdmDouble> maxMap = r.getMaxValues().getEdmAttributesMap();
 
             for (int i = 0; i < r.getNumStates(); i++) {
-                Element valueNode = widgetContext.getDocument().createElement("value");
+                valueNode = widgetContext.getDocument().createElement("value");
                 double min = 0;
                 double max = 0;
                 if (minMap.get("" + i) != null)
@@ -60,9 +65,11 @@ public class Opi_activeSymbolClass extends OpiWidget {
                 valueNode.setTextContent("" + i);
                 expressions.put("pv0>=" + min + "&&pv0<" + max, valueNode);
             }
-            Element valueNode = widgetContext.getDocument().createElement("value");
+            // Final catch-all
+            valueNode = widgetContext.getDocument().createElement("value");
             valueNode.setTextContent("0");
             expressions.put("true", valueNode);
+
 
             new OpiRule(widgetContext, "symbol_single_pv", "group_name", false, Arrays.asList(convertPVName(r
                     .getControlPvs().getEdmAttributesMap().get("0").get())), expressions);


### PR DESCRIPTION
EDM always shows image zero if the PV is invalid.  The converter rule
doesn't treat invalid PVs differently, so a symbol attached to an
invalid PV will often show a different symbol.

#1576 