### PR TITLE
Issue 1574

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/actions/EditOPIHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/actions/EditOPIHandler.java
@@ -140,12 +140,10 @@ public class EditOPIHandler extends AbstractHandler implements IHandler {
                 IPath path = null;
                 if (opiShell != null) {
                     path = opiShell.getDisplayModel().getOpiFilePath();
-                } else {
-                    if (part instanceof OPIView) {
-                        DisplayModel displayModel = ((OPIView) part).getDisplayModel();
-                        if (displayModel != null) {
-                            path = displayModel.getOpiFilePath();
-                        }
+                } else if (part instanceof OPIView) {
+                    DisplayModel displayModel = ((OPIView) part).getDisplayModel();
+                    if (displayModel != null) {
+                        path = displayModel.getOpiFilePath();
                     }
                 }
                 // We only support filesystem paths.

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/actions/EditOPIHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/actions/EditOPIHandler.java
@@ -1,4 +1,5 @@
 package org.csstudio.opibuilder.actions;
+import org.csstudio.opibuilder.model.DisplayModel;
 import org.csstudio.opibuilder.preferences.PreferencesHelper;
 import org.csstudio.opibuilder.runmode.IOPIRuntime;
 import org.csstudio.opibuilder.runmode.OPIView;
@@ -141,7 +142,10 @@ public class EditOPIHandler extends AbstractHandler implements IHandler {
                     path = opiShell.getDisplayModel().getOpiFilePath();
                 } else {
                     if (part instanceof OPIView) {
-                        path = ((IOPIRuntime)part).getDisplayModel().getOpiFilePath();
+                        DisplayModel displayModel = ((OPIView) part).getDisplayModel();
+                        if (displayModel != null) {
+                            path = displayModel.getOpiFilePath();
+                        }
                     }
                 }
                 // We only support filesystem paths.

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/SingleSourceHelperImpl.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/SingleSourceHelperImpl.java
@@ -146,8 +146,10 @@ public class SingleSourceHelperImpl extends SingleSourceHelper{
         action = actionRegistry.getAction(SendEMailAction.ID);
         if (action != null)
             menu.appendToGroup(GEFActionConstants.GROUP_EDIT, action);
-        menu.appendToGroup(GEFActionConstants.GROUP_EDIT,
-                actionRegistry.getAction(ActionFactory.PRINT.getId()));
+        action = actionRegistry.getAction(ActionFactory.PRINT.getId());
+        if (action != null) {
+            menu.appendToGroup(GEFActionConstants.GROUP_EDIT, action);
+        }
 
     }
 


### PR DESCRIPTION
Fixes exceptions thrown if an empty OPI view is right-clicked on.

Discussed in #1574 but doesn't fix the main problem in that ticket.