### PR TITLE
Honour OPI file location when opening OPI shell.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -182,6 +182,9 @@ public final class OPIShell implements IOPIRuntime {
          * default. Related to Eclipse bug 96700.
          */
         shell.setSize(displayModel.getSize().width + WINDOW_BORDER_X, displayModel.getSize().height + WINDOW_BORDER_Y);
+        if (!displayModel.getLocation().equals(DisplayModel.NULL_LOCATION)) {
+            shell.setLocation(displayModel.getLocation().getSWTPoint());
+        }
         shell.setVisible(true);
 
     }


### PR DESCRIPTION
This feature was lost during a refactor.

See #1613.