### PR TITLE
Suggest changing perspective on opening OPIEditor (4.2.x)

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: org.eclipse.core.filesystem;bundle-version="1.2.0",
  org.eclipse.help;bundle-version="3.6.0",
  org.jdom,
  org.eclipse.ui.workbench;bundle-version="3.106.0",
- org.eclipse.ui.views;bundle-version="3.7.0"
+ org.eclipse.ui.views;bundle-version="3.7.0",
+ org.eclipse.ui
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.csstudio.opibuilder.editor.Activator

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/plugin.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/plugin.xml
@@ -299,4 +299,8 @@
             commandId="org.csstudio.opibuilder.commands.editopi">
       </handler>
    </extension>
+   <extension
+         point="org.eclipse.ui.startup">
+      <startup class="org.csstudio.opibuilder.editor.PerspectiveChecker"> </startup>
+   </extension>
 </plugin>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/editor/OPIEditor.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/editor/OPIEditor.java
@@ -257,8 +257,9 @@ public class OPIEditor extends GraphicalEditorWithFlyoutPalette {
             Display.getDefault().asyncExec(() -> getSite().getPage().closeEditor(OPIEditor.this, false));
 
         }
-        else
+        else {
             super.init(site, input instanceof NoResourceEditorInput ? input : new NoResourceEditorInput(input));
+        }
     }
 
     @Override

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/editor/PerspectiveChecker.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/editor/PerspectiveChecker.java
@@ -1,0 +1,171 @@
+package org.csstudio.opibuilder.editor;
+
+import java.util.logging.Logger;
+
+import org.csstudio.opibuilder.OPIBuilderPlugin;
+import org.csstudio.opibuilder.preferences.PreferencesHelper;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.IPageListener;
+import org.eclipse.ui.IPartListener;
+import org.eclipse.ui.IStartup;
+import org.eclipse.ui.IWindowListener;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.WorkbenchException;
+
+/**
+ * Attach relevant listeners to workbench components in order that perspective
+ * handling can be triggered when an OPIEditor is opened.
+ *
+ * This class could be converted into an abstract class with no dependency on
+ * OPIBuilder, then extended by different classes wanting similar behaviour
+ * that set up state in the constructor.
+ */
+public class PerspectiveChecker implements IStartup {
+
+    private static Logger log = Logger.getLogger(PerspectiveChecker.class.getName());
+
+    public final String perspectiveID;
+    public final IPreferenceStore prefs;
+    public final String preferenceKey;
+    public final String dialogTitle;
+    public final String dialogMessage;
+    public final String savePreferenceMessage;
+    public final String switchFailedMessage;
+
+    public PerspectiveChecker() {
+        perspectiveID = OPIEditorPerspective.ID;
+        prefs = OPIBuilderPlugin.getDefault().getPreferenceStore();
+        preferenceKey = PreferencesHelper.SWITCH_TO_OPI_EDITOR_PERSPECTIVE;
+        dialogTitle = "Switch to OPI Editor perspective?";
+        dialogMessage = "The OPI Editor perspective contains the tools needed for creating and editing OPIs."
+                + "Would you like to switch to this perspective?";
+        savePreferenceMessage = "Remember my decision";
+        switchFailedMessage = "Failed to change to OPI Editor perspective: ";
+    }
+
+    /**
+     * Add an EditorWindowListener to the workbench, and an EditorPageListener
+     * to any open workbench windows.
+     */
+    @Override
+    public void earlyStartup() {
+        IWorkbench bench = PlatformUI.getWorkbench();
+        bench.addWindowListener(new EditorWindowListener());
+        for (IWorkbenchWindow window : bench.getWorkbenchWindows()) {
+            for (IWorkbenchPage page : window.getPages()) {
+                page.addPartListener(new EditorPartListener());
+            }
+        }
+    }
+
+    /**
+     * Listener on workbench that takes action on new windows:
+     * <ul>
+     * <li>Adds an EditorPartListener to any pages
+     * <li>Adds an EditorPageListener to the new window
+     * </ul>
+     */
+    private class EditorWindowListener implements IWindowListener {
+        @Override
+        public void windowActivated(IWorkbenchWindow window) {}
+        @Override
+        public void windowClosed(IWorkbenchWindow window) {}
+        @Override
+        public void windowDeactivated(IWorkbenchWindow window) {}
+        @Override
+        public void windowOpened(IWorkbenchWindow window) {
+            window.addPageListener(new EditorPageListener());
+            for (IWorkbenchPage page : window.getPages()) {
+                page.addPartListener(new EditorPartListener());
+            }
+        }
+    }
+
+    /**
+     * Listener that adds EditorPartListener to any pages on the
+     * workbench window to which it is attached.
+     */
+    private class EditorPageListener implements IPageListener {
+        @Override
+        public void pageActivated(IWorkbenchPage page) {
+            page.addPartListener(new EditorPartListener());
+        }
+        @Override
+        public void pageClosed(IWorkbenchPage page) {}
+        @Override
+        public void pageOpened(IWorkbenchPage page) {}
+    }
+
+    /**
+     * Listener on workbench page that checks if a new part is an OPIEditor;
+     * if so prompts or changes perspective depending on preference.
+     */
+    private class EditorPartListener implements IPartListener {
+
+        /**
+         * If the part being opened is an OPIEditor, check the preferences to see
+         * what behaviour has been selected.  If relevant, prompt user and save
+         * associated setting.  Switch perspective depending on preference or user
+         * selection.
+         * @param part part that is being opened
+         */
+        @Override
+        public void partOpened(IWorkbenchPart part) {
+            if (part instanceof OPIEditor) {
+                IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+                if (activeWindow != null) {
+                    if (!activeWindow.getActivePage().getPerspective().getId().equals(perspectiveID)) {
+                        boolean switchPerspective = false;
+                        String preferenceSetting = prefs.getString(preferenceKey);
+                        switch (preferenceSetting) {
+                            case MessageDialogWithToggle.PROMPT:
+                                switchPerspective = promptForPerspectiveSwitch(prefs, activeWindow);
+                                break;
+                            case MessageDialogWithToggle.ALWAYS:
+                                switchPerspective = true;
+                                break;
+                            default:
+                                switchPerspective = false;
+                        }
+                        if (switchPerspective) {
+                            try {
+                                PlatformUI.getWorkbench().showPerspective(perspectiveID, activeWindow);
+                            } catch (WorkbenchException we) {
+                                log.warning(switchFailedMessage + we);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Opens dialog to ask user whether to change perspective.  If dialog is selected
+         * the preference will be saved to the specified preference store.
+         * @param prefs IPreferenceStore containing the setting
+         * @param window IWorkbenchWindow on which to centre the dialog
+         * @return whether to change perspective
+         */
+        private boolean promptForPerspectiveSwitch(IPreferenceStore prefs, IWorkbenchWindow window) {
+            MessageDialogWithToggle md = MessageDialogWithToggle.openYesNoQuestion(
+                    window.getShell(), dialogTitle, dialogMessage, savePreferenceMessage, false,
+                    prefs, preferenceKey);
+            return md.getReturnCode() == IDialogConstants.YES_ID;
+        }
+
+        @Override
+        public void partDeactivated(IWorkbenchPart part) {}
+        @Override
+        public void partClosed(IWorkbenchPart part) {}
+        @Override
+        public void partBroughtToTop(IWorkbenchPart part) {}
+        @Override
+        public void partActivated(IWorkbenchPart part) {}
+    }
+}

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/preferences/OPIEditorPreferencePage.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/src/org/csstudio/opibuilder/preferences/OPIEditorPreferencePage.java
@@ -8,8 +8,10 @@
 package org.csstudio.opibuilder.preferences;
 
 import org.csstudio.opibuilder.OPIBuilderPlugin;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.RadioGroupFieldEditor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -29,8 +31,6 @@ public class OPIEditorPreferencePage extends FieldEditorPreferencePage
         setPreferenceStore(OPIBuilderPlugin.getDefault().getPreferenceStore());
 
         setMessage("OPI Editor Preferences");
-
-
     }
 
     @Override
@@ -49,7 +49,14 @@ public class OPIEditorPreferencePage extends FieldEditorPreferencePage
                     "Automatically save file before running.", parent);
         addField(autoSaveEditor);
 
-
+        RadioGroupFieldEditor perspectiveEditor = new RadioGroupFieldEditor(
+                PreferencesHelper.SWITCH_TO_OPI_EDITOR_PERSPECTIVE,
+                "Switch to OPI Editor perspective when opening opi file?", 3,
+                new String[][] {{"Always", MessageDialogWithToggle.ALWAYS},
+                                {"Never", MessageDialogWithToggle.NEVER},
+                                {"Prompt", MessageDialogWithToggle.PROMPT}},
+                parent, true);
+        addField(perspectiveEditor);
 
     }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/preferences.ini
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/preferences.ini
@@ -85,6 +85,7 @@ default_to_classic_style=true
 # location.
 show_opi_runtime_stacks=false
 
+switch_to_opi_editor_perspective=prompt
 # There are more macros, see source code for
 # org.csstudio.opibuilder.preferences.PreferencesHelper
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/preferences/PreferencesHelper.java
@@ -66,6 +66,7 @@ public class PreferencesHelper {
     public static final String PV_CONNECTION_LAYER = "pv_connection_layer"; //$NON-NLS-1$
     public static final String DEFAULT_TO_CLASSIC_STYLE = "default_to_classic_style"; //$NON-NLS-1$
     public static final String SHOW_OPI_RUNTIME_STACKS = "show_opi_runtime_stacks"; //$NON-NLS-1$
+    public static final String SWITCH_TO_OPI_EDITOR_PERSPECTIVE = "switch_to_opi_editor_perspective"; //$NON-NLS-1$
 
     //The widgets that are hidden from palette.
     public static final String HIDDEN_WIDGETS="hidden_widgets"; //$NON-NLS-1$


### PR DESCRIPTION
Although this is a new feature, I would like this on 4.2.x so that it gets into our release and there's one less thing to train our users.

It is a squashed commit from the branch merged into master:

Tie to a preference so that choice can be remembered.  Set up listeners
on workbench components to ensure this is active for each new part.

Improve messages in perspective-switching dialog.

Improve logic in perspective checking.

Move OPIEditor-specific logic into constructor.

This shows how this functionality could be made more general by
providing an abstract class in a utility plugin and extending it
in specific plugins.

Remove author tag.

Handle possibility that active workbench window is null.

Fix logic error in PerspectiveChecker.

Always add EditorWindowListener to the current workbench.
Slight restructure to make logic more intuitive.  Add Javadoc comment.

Add default preference for perspective switching.