### PR TITLE
Clean up of project poms - Issue 7

### DIFF
--- a/applications/alarm/alarm-repository/pom.xml
+++ b/applications/alarm/alarm-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/appunorganized/appunorganized-repository/pom.xml
+++ b/applications/appunorganized/appunorganized-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/apputil/apputil-repository/pom.xml
+++ b/applications/apputil/apputil-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/archive/archive-repository/pom.xml
+++ b/applications/archive/archive-repository/pom.xml
@@ -79,55 +79,6 @@
 
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/channel/channel-repository/pom.xml
+++ b/applications/channel/channel-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/databrowser/databrowser-repository/pom.xml
+++ b/applications/databrowser/databrowser-repository/pom.xml
@@ -79,55 +79,6 @@
 
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/diag/diag-repository/pom.xml
+++ b/applications/diag/diag-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/display/display-repository/pom.xml
+++ b/applications/display/display-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/logbook/logbook-repository/pom.xml
+++ b/applications/logbook/logbook-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/opibuilder/opibuilder-repository/pom.xml
+++ b/applications/opibuilder/opibuilder-repository/pom.xml
@@ -79,55 +79,6 @@
 
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -107,21 +107,6 @@
       </properties>
     </profile>
     <profile>
-      <id>csstudio-local-repo-enable</id>
-      <activation>
-        <file>
-          <exists>${csstudio.local.repo}/artifacts.jar</exists>
-        </file>
-      </activation>
-      <repositories>
-        <repository>
-          <id>csstudio-local-repo</id>
-          <url>file:${csstudio.local.repo}</url>
-          <layout>p2</layout>
-        </repository>
-      </repositories>
-    </profile>
-    <profile>
       <id>csstudio-composite-repo-enable</id>
       <activation>
         <property>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -73,40 +73,6 @@
       </properties>
     </profile>
     <profile>
-      <id>platform-luna</id>
-      <activation>
-        <property>
-          <name>platform-version-name</name>
-          <value>luna</value>
-        </property>
-      </activation>
-      <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/luna</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.4</eclipse-update-site>
-        <rap-site>${eclipse.mirror.url}/rt/rap/2.3</rap-site>
-        <rap-gef-site>${eclipse.mirror.url}/rt/rap/incubator/nightly/gef/20150122-1538</rap-gef-site>
-        <platform-version>[4.3,4.4)</platform-version>
-        <swtbot-site>${eclipse.central.url}/technology/swtbot/luna/dev-build/update-site</swtbot-site>
-      </properties>
-    </profile>
-    <profile>
-      <id>platform-kepler</id>
-      <activation>
-        <property>
-          <name>platform-version-name</name>
-          <value>kepler</value>
-        </property>
-      </activation>
-      <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/kepler</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.3</eclipse-update-site>
-        <rap-site>${eclipse.mirror.url}/rt/rap/2.2</rap-site>
-        <rap-gef-site>${eclipse.mirror.url}/rt/rap/incubator/2.2/gef</rap-gef-site>
-        <platform-version>[4.2,4.3)</platform-version>
-        <swtbot-site>${eclipse.central.url}/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
-      </properties>
-    </profile>
-    <profile>
       <id>csstudio-composite-repo-enable</id>
       <activation>
         <property>

--- a/applications/scan/scan-repository/pom.xml
+++ b/applications/scan/scan-repository/pom.xml
@@ -79,55 +79,6 @@
 
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/shift/shift-repository/pom.xml
+++ b/applications/shift/shift-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/applications/snl/snl-repository/pom.xml
+++ b/applications/snl/snl-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-applications-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-applications-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/core/base/base-repository/pom.xml
+++ b/core/base/base-repository/pom.xml
@@ -74,55 +74,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-core-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-core-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/core/diirt/diirt-repository/pom.xml
+++ b/core/diirt/diirt-repository/pom.xml
@@ -80,55 +80,6 @@
 
     <profiles>
         <profile>
-            <id>csstudio-local-repo-mirror</id>
-            <activation>
-                <property>
-                    <name>csstudio.local.repo</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.eclipse.tycho.extras</groupId>
-                        <artifactId>tycho-p2-extras-plugin</artifactId>
-                        <version>${tycho.version}</version>
-                        <executions>
-                            <execution>
-                                <id>mirror-build-to-local-repository</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>mirror</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                                    <source>
-                                        <repository>
-                                            <url>${project.baseUri}/target/repository</url>
-                                            <layout>p2</layout>
-                                        </repository>
-                                    </source>
-                                    <append>true</append>
-                                    <compress>true</compress>
-                                    <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                                    <destination>${csstudio.local.repo}</destination>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.eclipse.tycho</groupId>
-                        <artifactId>tycho-p2-repository-plugin</artifactId>
-                        <version>${tycho.version}</version>
-                        <configuration>
-                            <finalName>cs-studio-core-${project.parent.artifactId}-${project.version}</finalName>
-                            <repositoryName>cs-studio-core-${project.parent.artifactId}</repositoryName>
-                            <includeAllDependencies>true</includeAllDependencies>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>uploadRepo</id>
             <properties>
                 <!-- Properties relative to the distant host where to upload the repo -->

--- a/core/platform/platform-repository/pom.xml
+++ b/core/platform/platform-repository/pom.xml
@@ -74,55 +74,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-core-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-core-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,21 +107,6 @@
       </properties>
     </profile>
     <profile>
-      <id>csstudio-local-repo-enable</id>
-      <activation>
-        <file>
-          <exists>${csstudio.local.repo}/artifacts.jar</exists>
-        </file>
-      </activation>
-      <repositories>
-        <repository>
-          <id>csstudio-local-repo</id>
-          <url>file:${csstudio.local.repo}</url>
-          <layout>p2</layout>
-        </repository>
-      </repositories>
-    </profile>
-    <profile>
       <id>csstudio-composite-repo-enable</id>
       <activation>
         <property>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,40 +73,6 @@
       </properties>
     </profile>
     <profile>
-      <id>platform-luna</id>
-      <activation>
-        <property>
-          <name>platform-version-name</name>
-          <value>luna</value>
-        </property>
-      </activation>
-      <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/luna</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.4</eclipse-update-site>
-        <rap-site>${eclipse.mirror.url}/rt/rap/2.3</rap-site>
-        <rap-gef-site>${eclipse.mirror.url}/rt/rap/incubator/nightly/gef/20150122-1538</rap-gef-site>
-        <platform-version>[4.3,4.4)</platform-version>
-        <swtbot-site>${eclipse.central.url}/technology/swtbot/luna/dev-build/update-site</swtbot-site>
-      </properties>
-    </profile>
-    <profile>
-      <id>platform-kepler</id>
-      <activation>
-        <property>
-          <name>platform-version-name</name>
-          <value>kepler</value>
-        </property>
-      </activation>
-      <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/kepler</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.3</eclipse-update-site>
-        <rap-site>${eclipse.mirror.url}/rt/rap/2.2</rap-site>
-        <rap-gef-site>${eclipse.mirror.url}/rt/rap/incubator/2.2/gef</rap-gef-site>
-        <platform-version>[4.2,4.3)</platform-version>
-        <swtbot-site>${eclipse.central.url}/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
-      </properties>
-    </profile>
-    <profile>
       <id>csstudio-composite-repo-enable</id>
       <activation>
         <property>

--- a/core/ui/ui-repository/pom.xml
+++ b/core/ui/ui-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-core-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-core-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/core/unorganized/unorganized-repository/pom.xml
+++ b/core/unorganized/unorganized-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-core-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-core-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->

--- a/core/utility/utility-repository/pom.xml
+++ b/core/utility/utility-repository/pom.xml
@@ -73,55 +73,6 @@
   </build>
   <profiles>
     <profile>
-      <id>csstudio-local-repo-mirror</id>
-      <activation>
-        <property>
-          <name>csstudio.local.repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-p2-extras-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <executions>
-              <execution>
-                <id>mirror-build-to-local-repository</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>mirror</goal>
-                </goals>
-                <configuration>
-                  <!-- Details: https://www.eclipse.org/tycho/sitedocs-extras/tycho-p2-extras-plugin/mirror-mojo.html -->
-                  <source>
-                    <repository>
-                      <url>${project.baseUri}/target/repository</url>
-                      <layout>p2</layout>
-                    </repository>
-                  </source>
-                  <append>true</append>
-                  <compress>true</compress>
-                  <mirrorMetadataOnly>false</mirrorMetadataOnly>
-                  <destination>${csstudio.local.repo}</destination>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-p2-repository-plugin</artifactId>
-            <version>${tycho.version}</version>
-            <configuration>
-              <finalName>cs-studio-core-${project.parent.artifactId}-${project.version}</finalName>
-              <repositoryName>cs-studio-core-${project.parent.artifactId}</repositoryName>
-              <includeAllDependencies>true</includeAllDependencies>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>uploadRepo</id>
       <properties>
         <!-- Properties relative to the distant host where to upload the repo -->


### PR DESCRIPTION
Associated pull requests are:

https://github.com/ControlSystemStudio/maven-osgi-bundles/pull/18
https://github.com/ControlSystemStudio/cs-studio-thirdparty/pull/16

The primary goal is to standardize all the poms to an extent and also keep them small and manageable

The details are discussed here
https://github.com/ControlSystemStudio/cs-studio-thirdparty/issues/7

Since I am not sure who all are using the profiles being removed these pull requests should be merged after people can verify this change
 - [x] Diamond
 - [x] FRIB
 - [x] ORNL
 - [x] ITER
 - [x] NSLSII
 - [ ] ISIS (not the terrorist group)
 - [ ] ESS

@berryma4 @utzeln @kasemir @willrogers 