### PR TITLE
Data Browser: Add 'opacity'; font fixes

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.rap.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.rap.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
@@ -140,6 +140,13 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
         plot.setBackground(Objects.requireNonNull(color));
     }
 
+    /** Opacity (0 .. 100 %) of 'area' */
+    public void setOpacity(final int opacity)
+    {
+        // TODO Not implemented, only added API to match SWT version
+        // plot.setOpacity(opacity);
+    }
+
     /** @param title Title text */
     public void setTitle(final Optional<String> title)
     {

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/META-INF/MANIFEST.MF
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Real Time Plot
 Bundle-SymbolicName: org.csstudio.swt.rtplot
-Bundle-Version: 1.5.2.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.osgi;bundle-version="3.10.1",

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.rtplot</artifactId>
-  <version>1.5.2-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
@@ -140,6 +140,12 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
         plot.setBackground(Objects.requireNonNull(color));
     }
 
+    /** Opacity (0 .. 100 %) of 'area' */
+    public void setOpacity(final int opacity)
+    {
+        plot.setOpacity(opacity);
+    }
+
     /** @param title Title text */
     public void setTitle(final Optional<String> title)
     {

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -581,8 +581,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         legend.setBounds(0,  bounds.height-legend_height, bounds.width, legend_height);
 
         // X Axis as high as desired. Width will depend on Y axes.
-//        x_axis.setLabelFont(label_font.getFontData()[0]);
-//        x_axis.setScaleFont(scale_font);
+        x_axis.setLabelFont(label_font.getFontData()[0]);
+        x_axis.setScaleFont(scale_font.getFontData()[0]);
         final int x_axis_height = x_axis.getDesiredPixelSize(bounds, gc);
         final int y_axis_height = bounds.height - title_height - x_axis_height - legend_height;
 
@@ -597,8 +597,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             if (! axis.isOnRight())
             {
                 final Rectangle axis_region = new Rectangle(total_left_axes_width, title_height, plot_width, y_axis_height);
-//                axis.setLabelFont(label_font);
-//                axis.setScaleFont(scale_font);
+                axis.setLabelFont(label_font.getFontData()[0]);
+                axis.setScaleFont(scale_font.getFontData()[0]);
                 axis_region.width = axis.getDesiredPixelSize(axis_region, gc);
                 axis.setBounds(axis_region);
                 total_left_axes_width += axis_region.width;
@@ -609,8 +609,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             if (axis.isOnRight())
             {
                 final Rectangle axis_region = new Rectangle(total_left_axes_width, title_height, plot_width, y_axis_height);
-//                axis.setLabelFont(label_font);
-//                axis.setScaleFont(scale_font);
+                axis.setLabelFont(label_font.getFontData()[0]);
+                axis.setScaleFont(scale_font.getFontData()[0]);
                 axis_region.width = axis.getDesiredPixelSize(axis_region, gc);
                 total_right_axes_width += axis_region.width;
                 axis_region.x = bounds.width - total_right_axes_width;

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -85,6 +85,9 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
     /** Background color */
     private volatile RGB background = new RGB(255, 255, 255);
 
+    /** Opacity (0 .. 100 %) of 'area' */
+    private volatile int opacity = 20;
+
     /** Font to use for, well, title */
     private volatile Font title_font;
 
@@ -281,6 +284,12 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
     public void setBackground(final RGB color)
     {
         background = color;
+    }
+
+    /** Opacity (0 .. 100 %) of 'area' */
+    public void setOpacity(final int opacity)
+    {
+        this.opacity = opacity;
     }
 
     /** @param title Title */
@@ -654,7 +663,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
 
         for (YAxisImpl<XTYPE> y_axis : y_axes)
             for (Trace<XTYPE> trace : y_axis.getTraces())
-                trace_painter.paint(gc, media, plot_area.getBounds(), x_transform, y_axis, trace);
+                trace_painter.paint(gc, media, plot_area.getBounds(), opacity, x_transform, y_axis, trace);
 
         // Annotations use label font
         gc.setFont(label_font);

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TitlePart.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TitlePart.java
@@ -17,7 +17,6 @@ import org.eclipse.swt.graphics.Rectangle;
 /** Part for plot title
  *  @author Kay Kasemir
  */
-@SuppressWarnings("nls")
 public class TitlePart extends PlotPart
 {
     /** @param name Part name

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
@@ -69,10 +69,12 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
     /** @param gc GC
      *  @param media
      *  @param bounds Clipping bounds within which to paint
+     *  @param opacity Opacity (0 .. 100 %) of 'area'
      *  @param x_transform Coordinate transform used by the x axis
      *  @param trace Trace, has reference to its value axis
      */
-    final public void paint(final GC gc, final SWTMediaPool media, final Rectangle bounds, final ScreenTransform<XTYPE> x_transform, final YAxisImpl<XTYPE> y_axis, final Trace<XTYPE> trace)
+    final public void paint(final GC gc, final SWTMediaPool media, final Rectangle bounds, final int opacity,
+                            final ScreenTransform<XTYPE> x_transform, final YAxisImpl<XTYPE> y_axis, final Trace<XTYPE> trace)
     {
         x_min = bounds.x - OUTSIDE;
         x_max = bounds.x + bounds.width + OUTSIDE;
@@ -82,6 +84,8 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
         final Color old_color = gc.getForeground();
         final Color old_bg = gc.getBackground();
         final int old_width = gc.getLineWidth();
+
+        final int alpha = (opacity * 255) / 100;
 
         final Color color = media.get(trace.getColor());
         gc.setBackground(color);
@@ -110,14 +114,14 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
             case NONE:
                 break;
             case AREA:
-                gc.setAlpha(50);
+                gc.setAlpha(alpha);
                 drawMinMaxArea(gc, x_transform, y_axis, data);
                 gc.setAlpha(255);
                 drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
                 drawValueStaircase(gc, x_transform, y_axis, data, trace.getWidth());
                 break;
             case AREA_DIRECT:
-                gc.setAlpha(50);
+                gc.setAlpha(alpha);
                 drawMinMaxArea(gc, x_transform, y_axis, data);
                 gc.setAlpha(255);
                 drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
@@ -125,14 +129,14 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
                 break;
             case LINES:
                 drawMinMaxLines(gc, x_transform, y_axis, data, trace.getWidth());
-                gc.setAlpha(50);
+                gc.setAlpha(alpha);
                 drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
                 gc.setAlpha(255);
                 drawValueStaircase(gc, x_transform, y_axis, data, trace.getWidth());
                 break;
             case LINES_DIRECT:
                 drawMinMaxLines(gc, x_transform, y_axis, data, trace.getWidth());
-                gc.setAlpha(50);
+                gc.setAlpha(alpha);
                 drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
                 gc.setAlpha(255);
                 drawValueLines(gc, x_transform, y_axis, data, trace.getWidth());

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/ChangeLog.html
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/ChangeLog.html
@@ -11,8 +11,8 @@
 
 <h2>Version 4.2.2 - 2016-04-12</h2>
 <ul>
-  <li>Opacity of "Area" is configurable via preference.
-  </li>
+  <li>Opacity of "Area" is configurable via preference.</li>
+  <li>Enable fonts for axis labels and scale.</li>
 </ul>
 
 

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/ChangeLog.html
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/ChangeLog.html
@@ -9,6 +9,13 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.trends.databrowser2.</p>
 
+<h2>Version 4.2.2 - 2016-04-12</h2>
+<ul>
+  <li>Opacity of "Area" is configurable via preference.
+  </li>
+</ul>
+
+
 <h2>Version 4.2.0 - 2015-12-17</h2>
 <ul>
   <li>When adding PVs from archive search via drag/drop,

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/META-INF/MANIFEST.MF
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Data Browser
 Bundle-SymbolicName: org.csstudio.trends.databrowser2;singleton:=true
-Bundle-Version: 4.2.1.qualifier
+Bundle-Version: 4.2.2.qualifier
 Bundle-Description: Strip chart type display of live and historic data
 Bundle-Activator: org.csstudio.trends.databrowser2.Activator
 Bundle-Localization: plugin
@@ -24,7 +24,7 @@ Require-Bundle: org.csstudio.utility.test;resolution:=optional,
  org.csstudio.apputil.ui;bundle-version="3.2.0",
  org.csstudio.ui.util;bundle-version="4.0.0";resolution:=optional,
  org.csstudio.rap.ui.util;bundle-version="1.0.0";resolution:=optional,
- org.csstudio.swt.rtplot;bundle-version="1.5.1";resolution:=optional,
+ org.csstudio.swt.rtplot;bundle-version="1.6.0";resolution:=optional,
  org.csstudio.rap.rtplot;bundle-version="1.2.0";resolution:=optional,
  org.csstudio.archive.reader;bundle-version="4.2.0",
  org.csstudio.logbook;bundle-version="1.0.2",

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/pom.xml
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.trends.databrowser2</artifactId>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>4.2.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/preferences.ini
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/preferences.ini
@@ -21,6 +21,12 @@ live_buffer_size=5000
 # Default line width
 line_width=2
 
+# Opacity of 'area'
+#   0%: Area totally transparent
+#  20%: Area quite transparent (default value)
+# 100%: Area uses  solid color
+opacity=20
+
 # Default trace type for newly created traces.
 # Allowed values are defined by org.csstudio.trends.databrowser2.model.TraceType:
 # AREA, ERROR_BARS, SINGLE_LINE, AREA_DIRECT, SINGLE_LINE_DIRECT, SQUARES, ...

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/Messages.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/Messages.java
@@ -206,6 +206,7 @@ public class Messages extends NLS
     public static String PrefPage_TimeRange;
     public static String PrefPage_Title;
     public static String PrefPage_TraceLineWidth;
+    public static String PrefPage_TraceOpacity;
     public static String PrefPage_UpdatePeriod;
     public static String PrintSnapshot;
     public static String PromptForErrors_Label;

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/messages.properties
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/messages.properties
@@ -185,6 +185,7 @@ PrefPage_ScanPeriod=Default Scan Period [seconds]:
 PrefPage_TimeRange=Default Time Range [seconds]:
 PrefPage_Title=Data Browser Settings
 PrefPage_TraceLineWidth=Default Trace Line Width [pixel]:
+PrefPage_TraceOpacity=Opacity of 'Area' [0..100%]:
 PrefPage_UpdatePeriod=Default Plot Refresh/Scan Period [seconds]:
 PrintSnapshot=Print...
 PromptForErrors_Label=Display archive errors in dialog (or simply log)?

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/ModelItem.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/ModelItem.java
@@ -58,13 +58,13 @@ abstract public class ModelItem
     private volatile TraceType trace_type = Preferences.getTraceType();
 
     /** Line width [pixel] */
-    private volatile int line_width = Preferences.getLineWidths();
+    private volatile int line_width = Preferences.getLineWidth();
 
     /** How to display the points of the trace */
     private volatile PointType point_type = PointType.NONE;
 
     /** Point size [pixel] */
-    private volatile int point_size = Preferences.getLineWidths();
+    private volatile int point_size = Preferences.getLineWidth();
 
     /** Y-Axis */
     private volatile AxisConfig axis = null;

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/preferences/PreferencePage.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/preferences/PreferencePage.java
@@ -132,6 +132,12 @@ public class PreferencePage extends FieldEditorPreferencePage
         linewidth.setValidRange(0, 100);
         addField(linewidth);
 
+        // Opacity: 0..100%
+        final IntegerFieldEditor opacity = new IntegerFieldEditor(Preferences.OPACITY,
+                Messages.PrefPage_TraceOpacity, parent);
+        opacity.setValidRange(0, 100);
+        addField(opacity);
+
         // Trace type options
         final TraceType trace_values[] = TraceType.values();
         final String trace_labels_and_values[][] = new String[trace_values.length][2];

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/preferences/Preferences.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/preferences/Preferences.java
@@ -51,6 +51,7 @@ public class Preferences
     final public static String TIME_SPAN = "time_span",
             SCAN_PERIOD = "scan_period", BUFFER_SIZE = "live_buffer_size",
             UPDATE_PERIOD = "update_period", LINE_WIDTH = "line_width",
+            OPACITY = "opacity",
             TRACE_TYPE = "trace_type",
             ARCHIVE_FETCH_DELAY = "archive_fetch_delay",
             PLOT_BINS = "plot_bins", URLS = "urls", ARCHIVES = "archives",
@@ -117,12 +118,20 @@ public class Preferences
         return prefs.getDouble(Activator.PLUGIN_ID, UPDATE_PERIOD, 1.0, null);
     }
 
-    public static int getLineWidths()
+    public static int getLineWidth()
     {
         final IPreferencesService prefs = Platform.getPreferencesService();
         if (prefs == null)
             return 2;
         return prefs.getInt(Activator.PLUGIN_ID, LINE_WIDTH, 2, null);
+    }
+
+    public static int getOpacity()
+    {
+        final IPreferencesService prefs = Platform.getPreferencesService();
+        if (prefs == null)
+            return 20;
+        return prefs.getInt(Activator.PLUGIN_ID, OPACITY, 20, null);
     }
 
     public static TraceType getTraceType()
@@ -335,4 +344,5 @@ public class Preferences
             return Boolean.TRUE;
         return prefs.getBoolean(Activator.PLUGIN_ID, USE_TRACE_NAMES, Boolean.TRUE, null);
     }
+
 }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -31,6 +31,7 @@ import org.csstudio.trends.databrowser2.model.AxisConfig;
 import org.csstudio.trends.databrowser2.model.ChannelInfo;
 import org.csstudio.trends.databrowser2.model.Model;
 import org.csstudio.trends.databrowser2.model.ModelItem;
+import org.csstudio.trends.databrowser2.preferences.Preferences;
 import org.csstudio.ui.util.dialogs.ExceptionDetailsErrorDialog;
 import org.csstudio.ui.util.dnd.ControlSystemDropTarget;
 import org.eclipse.osgi.util.NLS;
@@ -69,6 +70,8 @@ public class ModelBasedPlot
     {
         this.display = parent.getDisplay();
         plot = new RTTimePlot(parent);
+
+        plot.setOpacity(Preferences.getOpacity());
 
         final ToolItem time_config_button =
                 plot.addToolItem(SWT.PUSH, Activator.getDefault().getImage("icons/time_range.png"), Messages.StartEndDialogTT);


### PR DESCRIPTION
Adds 'opacity' to allow configuring the area as requested in #1729

Noted that the label and scale fonts weren't actually used, so enabled them.