### PR TITLE
Set download location to a configurable property (download.root)

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -19,7 +19,6 @@
     <tycho.version>0.23.1</tycho.version>
     <tycho-extras.version>0.23.1</tycho-extras.version>
     <cs-studio.version>4.3</cs-studio.version>
-    <cs-studio-central.url>http://download.controlsystemstudio.org/applications/${cs-studio.version}</cs-studio-central.url>
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
     <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>
     <orbit-site>${eclipse.mirror.url}/tools/orbit/downloads/drops/R20150519210750/repository/</orbit-site>
@@ -28,6 +27,8 @@
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
     <baselineMode>fail</baselineMode>
     <upload.root>s3://download.controlsystemstudio.org</upload.root>
+    <download.root>http://download.controlsystemstudio.org</download.root>
+    <cs-studio-central.url>${download.root}/applications/${cs-studio.version}</cs-studio-central.url>
     <skipTests>false</skipTests>
     <!-- SonarQube configuration -->
     <sonar.language>java</sonar.language>
@@ -163,23 +164,23 @@
         </repository>
         <repository>
           <id>csstudio-thirdparty</id>
-          <url>http://download.controlsystemstudio.org/thirdparty/${cs-studio.version}</url>
+          <url>${download.root}/thirdparty/${cs-studio.version}</url>
           <layout>p2</layout>
         </repository>
         <repository>
           <id>csstudio-maven-osgi-bundles</id>
-          <url>http://download.controlsystemstudio.org/maven-osgi-bundles/${cs-studio.version}</url>
+          <url>${download.root}/maven-osgi-bundles/${cs-studio.version}</url>
           <layout>p2</layout>
         </repository>
         <repository>
           <id>csstudio-core</id>
-          <url>http://download.controlsystemstudio.org/core/${cs-studio.version}</url>
+          <url>${download.root}/core/${cs-studio.version}</url>
           <layout>p2</layout>
         </repository>
         <!-- Adding the applications repositories to allows child modules to depend on each other -->
         <repository>
           <id>csstudio-applications</id>
-          <url>http://download.controlsystemstudio.org/applications/${cs-studio.version}</url>
+          <url>${download.root}/applications/${cs-studio.version}</url>
           <layout>p2</layout>
         </repository>
       </repositories>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,6 @@
     <tycho.version>0.23.1</tycho.version>
     <tycho-extras.version>0.23.1</tycho-extras.version>
     <cs-studio.version>4.3</cs-studio.version>
-    <cs-studio-central.url>http://download.controlsystemstudio.org/core/${cs-studio.version}</cs-studio-central.url>
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
     <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>
     <orbit-site>${eclipse.mirror.url}/tools/orbit/downloads/drops/R20150519210750/repository/</orbit-site>
@@ -28,6 +27,8 @@
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
     <baselineMode>fail</baselineMode>
     <upload.root>s3://download.controlsystemstudio.org</upload.root>
+    <download.root>http://download.controlsystemstudio.org</download.root>
+    <cs-studio-central.url>${download.root}/core/${cs-studio.version}</cs-studio-central.url>
     <skipTests>false</skipTests>
     <!-- SonarQube configuration -->
     <sonar.language>java</sonar.language>
@@ -163,18 +164,18 @@
         </repository>
         <repository>
           <id>csstudio-thirdparty</id>
-          <url>http://download.controlsystemstudio.org/thirdparty/${cs-studio.version}</url>
+          <url>${download.root}/thirdparty/${cs-studio.version}</url>
           <layout>p2</layout>
         </repository>
         <repository>
           <id>csstudio-maven-osgi-bundles</id>
-          <url>http://download.controlsystemstudio.org/maven-osgi-bundles/${cs-studio.version}</url>
+          <url>${download.root}/maven-osgi-bundles/${cs-studio.version}</url>
           <layout>p2</layout>
         </repository>
         <!-- Adding the core to enable building the individual child modules which might depend on each other -->
         <repository>
           <id>csstudio-core</id>
-          <url>http://download.controlsystemstudio.org/core/${cs-studio.version}</url>
+          <url>${download.root}/core/${cs-studio.version}</url>
           <layout>p2</layout>
         </repository>
       </repositories>


### PR DESCRIPTION
Update the pom to support a configurable download location. 
The implementation mirrors the upload.root property and there is no change of behaviour if this property is not overridden.

This resolves the issues seen in #1746 when running with a local p2 set for upload.root.

Same change has been made to the maven-osgi-bundles and thirdparty repositories.