### PR TITLE
RAP fix

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/META-INF/MANIFEST.MF
@@ -35,7 +35,7 @@ Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.python.jython;bundle-version="2.5.2",
  org.csstudio.swt.widgets;bundle-version="2.1.0",
  org.csstudio.swt.xygraph;bundle-version="2.0.4",
- org.eclipse.e4.ui.workbench;bundle-version="1.3.0"
+ org.eclipse.e4.ui.workbench
 Eclipse-RegisterBuddy: org.python.jython
 Bundle-ActivationPolicy: lazy
 Export-Package: org.csstudio.opibuilder,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIView.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIView.java
@@ -199,10 +199,11 @@ public class OPIView extends ViewPart implements IOPIRuntime
      */
     private MPlaceholder findPlaceholder()
     {
-        final IEclipseContext localContext = getViewSite().getService(IEclipseContext.class);
+        //do not remove casting - RAP 3.0 still needs it
+        final IEclipseContext localContext = (IEclipseContext)getViewSite().getService(IEclipseContext.class);
         final MPart part = localContext.get(MPart.class);
-        final EModelService service = PlatformUI.getWorkbench().getService(EModelService.class);
-        final IEclipseContext globalContext = PlatformUI.getWorkbench().getService(IEclipseContext.class);
+        final EModelService service = (EModelService)PlatformUI.getWorkbench().getService(EModelService.class);
+        final IEclipseContext globalContext = (IEclipseContext)PlatformUI.getWorkbench().getService(IEclipseContext.class);
         final MApplication app = globalContext.get(MApplication.class);
         final List<MPlaceholder> phs = service.findElements(app, null, MPlaceholder.class, null);
         for (MPlaceholder ph : phs)


### PR DESCRIPTION
The RAP version does not have the org.eclipse.e4.ui.workbench version 1.3.0. It is still on 1.2.x. Therefore we should not enforce the version number in the opibuilder manifest. This should not have any effect on your build, as tycho will always take the latest version of the plugin from the p2repo.

RAP version also requires some casts, because it doesn't use generic types.