### PR TITLE
Scan monitor: Preference to by default hide the 'memory' bar

### DIFF
--- a/applications/scan/scan-plugins/org.csstudio.scan.server/plugin_customization.ini
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/plugin_customization.ini
@@ -49,7 +49,7 @@ org.csstudio.platform.libs.epics/addr_list=127.0.0.1
 # CONFIG shows start of each scan
 # INFO shows each scan command
 # FINE shows PV details
-org.csstudio.logging/console_level=INFO
+org.csstudio.logging/console_level=CONFIG
 org.csstudio.logging/jms_url=
 
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = false

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/META-INF/MANIFEST.MF
@@ -3,13 +3,13 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Scan Monitor
 Bundle-SymbolicName: org.csstudio.scan.ui.scanmonitor;singleton:=true
 Bundle-Localization: plugin
-Bundle-Version: 4.2.5.qualifier
+Bundle-Version: 4.2.9.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Require-Bundle: org.junit;bundle-version="4.8.0",
  org.eclipse.ui,
  org.eclipse.core.runtime,
  org.csstudio.ui.util;bundle-version="4.0.0",
- org.csstudio.scan;bundle-version="1.0.0",
+ org.csstudio.scan;bundle-version="4.2.9",
  org.csstudio.scan.client;bundle-version="1.0.0",
  org.csstudio.scan.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan.ui.scanmonitor</artifactId>
-  <version>4.2.5-SNAPSHOT</version>
+  <version>4.2.9-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/src/org/csstudio/scan/ui/scanmonitor/Bar.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/src/org/csstudio/scan/ui/scanmonitor/Bar.java
@@ -25,7 +25,8 @@ import org.eclipse.swt.widgets.Composite;
 @SuppressWarnings("nls")
 public class Bar extends Canvas implements PaintListener
 {
-    final private static int CRITICAL_PERCENTAGE = 75;
+    final private static int WARNING_PERCENTAGE = 75;
+    final private static int CRITICAL_PERCENTAGE = 90;
     private float percentage = 0.0f;
     private String text = "";
     private GC gc;
@@ -74,6 +75,8 @@ public class Bar extends Canvas implements PaintListener
         gc.fillRectangle(area);
         if (percentage > CRITICAL_PERCENTAGE)
             gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_RED));
+        else if (percentage > WARNING_PERCENTAGE)
+            gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_DARK_YELLOW));
         else
             gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_GREEN));
         gc.fillRectangle(0, 0, Math.round((area.width-1) * percentage / 100), area.height-1);

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/src/org/csstudio/scan/ui/scanmonitor/GUI.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui.scanmonitor/src/org/csstudio/scan/ui/scanmonitor/GUI.java
@@ -18,6 +18,7 @@ package org.csstudio.scan.ui.scanmonitor;
 import java.util.Iterator;
 import java.util.List;
 
+import org.csstudio.scan.ScanSystemPreferences;
 import org.csstudio.scan.client.ScanInfoModel;
 import org.csstudio.scan.client.ScanInfoModelListener;
 import org.csstudio.scan.data.ScanSampleFormatter;
@@ -320,13 +321,15 @@ public class GUI implements ScanInfoModelListener
         ColumnViewerToolTipSupport.enableFor(table_viewer);
         table_viewer.setContentProvider(new ScanInfoModelContentProvider());
 
-        Label l = new Label(parent, 0);
-        l.setText(Messages.MemInfo);
-        l.setLayoutData(new GridData());
-
-        mem_info = new Bar(parent, 0);
-        mem_info.setLayoutData(new GridData(SWT.FILL, 0, true, false));
-        mem_info.setToolTipText(Messages.MemInfoTT);
+        if (ScanSystemPreferences.getShowMemoryUsage())
+        {
+            final Label l = new Label(parent, 0);
+            l.setText(Messages.MemInfo);
+            l.setLayoutData(new GridData());
+            mem_info = new Bar(parent, 0);
+            mem_info.setLayoutData(new GridData(SWT.FILL, 0, true, false));
+            mem_info.setToolTipText(Messages.MemInfoTT);
+        }
 
         // Publish current selection
         if (site != null)
@@ -383,7 +386,7 @@ public class GUI implements ScanInfoModelListener
             @Override
             public void doubleClick(final DoubleClickEvent event)
             {
-                final IHandlerService handler = (IHandlerService) site.getService(IHandlerService.class);
+                final IHandlerService handler = site.getService(IHandlerService.class);
                 try
                 {
                     handler.executeCommand("org.csstudio.scan.ui.scantree.open", null);
@@ -505,7 +508,7 @@ public class GUI implements ScanInfoModelListener
     @Override
     public void scanServerUpdate(final ScanServerInfo server_info)
     {
-        if (mem_info.isDisposed())
+        if (mem_info == null  ||  mem_info.isDisposed())
             return;
         mem_info.getDisplay().asyncExec(new Runnable()
         {

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
@@ -9,6 +9,11 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.scan.</p>
 
+<h2>Version 4.2.9 - 2016-04-14</h2>
+<ul>
+  <li>Preference to show/hide scan monitor 'memory' status (#1756).</li>
+</ul>
+
 <h2>Version 4.2.8 - 2016-03-31</h2>
 <ul>
   <li>Fix "Error loading Jython class.." errors (#1687).</li>

--- a/applications/scan/scan-plugins/org.csstudio.scan/META-INF/MANIFEST.MF
+++ b/applications/scan/scan-plugins/org.csstudio.scan/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scan API
 Bundle-SymbolicName: org.csstudio.scan;singleton:=true
-Bundle-Version: 4.2.7.qualifier
+Bundle-Version: 4.2.9.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.csstudio.scan,

--- a/applications/scan/scan-plugins/org.csstudio.scan/pom.xml
+++ b/applications/scan/scan-plugins/org.csstudio.scan/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.scan</artifactId>
-  <version>4.2.7-SNAPSHOT</version>
+  <version>4.2.9-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/scan/scan-plugins/org.csstudio.scan/preferences.ini
+++ b/applications/scan/scan-plugins/org.csstudio.scan/preferences.ini
@@ -91,3 +91,8 @@ log_command_read_timeout=20
 # This check, however, needs to read the current value of the PV,
 # so it also needs some timeout
 value_check_timeout=20
+
+# ---- Scan Monitor
+
+# Display the scan server memory status bar in the scan monitor?
+show_memory_usage=true

--- a/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/ScanSystemPreferences.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan/src/org/csstudio/scan/ScanSystemPreferences.java
@@ -176,6 +176,16 @@ public class ScanSystemPreferences extends SystemSettings
         return period;
     }
 
+    /** @return Show memory usage? */
+    public static boolean getShowMemoryUsage()
+    {
+        boolean show = false;
+        final IPreferencesService service = Platform.getPreferencesService();
+        if (service != null)
+            show = service.getBoolean(Activator.ID, "show_memory_usage", show, null);
+        return show;
+    }
+
     /** Set system properties (which are in the end what's actually used)
      *  from Eclipse preferences (which are more accessible for Eclipse tools
      *  with plugin_customization or preference GUI)


### PR DESCRIPTION
.. since most users are worried by the normal behavior of the JRE to use
all memory, then garbage collecting, in a sawtooth pattern over time.

Fixes #1756