### PR TITLE
Time 1760

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.vtype.test/src/org/csstudio/archive/vtype/ArchiveVTypeTest.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.vtype.test/src/org/csstudio/archive/vtype/ArchiveVTypeTest.java
@@ -13,14 +13,13 @@ import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
+import org.diirt.util.text.NumberFormats;
 import org.diirt.vtype.AlarmSeverity;
 import org.diirt.vtype.Display;
 import org.diirt.vtype.VType;
 import org.diirt.vtype.ValueFactory;
-import org.diirt.util.text.NumberFormats;
 import org.junit.Test;
 
 /** JUnit test of Archive {@link VType}s

--- a/applications/archive/archive-plugins/org.csstudio.archive.vtype.test/src/org/csstudio/archive/vtype/TimestampHelperTest.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.vtype.test/src/org/csstudio/archive/vtype/TimestampHelperTest.java
@@ -11,10 +11,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
+import org.csstudio.java.time.TimestampFormats;
 import org.diirt.util.time.TimeDuration;
 import org.junit.Test;
 
@@ -27,9 +26,8 @@ public class TimestampHelperTest
     @Test
     public void testRoundUp() throws Exception
     {
-        final DateTimeFormatter format = DateTimeFormatter.ofPattern(TimestampHelper.FORMAT_SECONDS);
-        final Instant orig = ZonedDateTime.from(format.parse("2012/01/19 12:23:14")).toInstant();
-        String text = format.format(orig);
+        final Instant orig = Instant.from(TimestampFormats.SECONDS_FORMAT.parse("2012/01/19 12:23:14"));
+        String text = TimestampFormats.SECONDS_FORMAT.format(orig);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/19 12:23:14"));
 
@@ -37,29 +35,29 @@ public class TimestampHelperTest
 
         // Round within a few seconds
         time = TimestampHelper.roundUp(orig, 10);
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/19 12:23:20"));
 
         time = TimestampHelper.roundUp(orig, TimeDuration.ofSeconds(30));
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/19 12:23:30"));
 
         // .. to minute
         time = TimestampHelper.roundUp(orig, 60);
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/19 12:24:00"));
 
         // .. to hours
         time = TimestampHelper.roundUp(orig, TimeDuration.ofHours(1.0));
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/19 13:00:00"));
 
         time = TimestampHelper.roundUp(orig, 2L*60*60);
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/19 14:00:00"));
 
@@ -67,18 +65,18 @@ public class TimestampHelperTest
         assertThat(24L*60*60, equalTo(TimestampHelper.SECS_PER_DAY));
 
         time = TimestampHelper.roundUp(orig, TimestampHelper.SECS_PER_DAY);
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/20 00:00:00"));
 
         time = TimestampHelper.roundUp(orig, 3*TimestampHelper.SECS_PER_DAY);
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/22 00:00:00"));
 
         // Into next month
         time = TimestampHelper.roundUp(orig, 13*TimestampHelper.SECS_PER_DAY);
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/02/01 00:00:00"));
 
@@ -87,7 +85,7 @@ public class TimestampHelperTest
 
         // 1.5 days
         time = TimestampHelper.roundUp(orig, (3*TimestampHelper.SECS_PER_DAY)/2);
-        text = format.format(time);
+        text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(text);
         assertThat(text, equalTo("2012/01/20 12:00:00"));
     }

--- a/applications/archive/archive-plugins/org.csstudio.archive.vtype/META-INF/MANIFEST.MF
+++ b/applications/archive/archive-plugins/org.csstudio.archive.vtype/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.csstudio.archive.vtype
 Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.diirt.util;bundle-version="3.0.1",
+Require-Bundle: org.csstudio.java;bundle-version="3.2.0",
+ org.diirt.util;bundle-version="3.0.1",
  org.diirt.vtype;bundle-version="3.0.1"
 Export-Package: org.csstudio.archive.vtype

--- a/applications/archive/archive-plugins/org.csstudio.archive.vtype/src/org/csstudio/archive/vtype/TimestampHelper.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.vtype/src/org/csstudio/archive/vtype/TimestampHelper.java
@@ -9,12 +9,11 @@ package org.csstudio.archive.vtype;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
+import org.csstudio.java.time.TimestampFormats;
 
 /** Time stamp gymnastics
  *  @author Kay Kasemir
@@ -22,13 +21,6 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("nls")
 public class TimestampHelper
 {
-	final private static ZoneId zone = ZoneId.systemDefault();
-    final public static String FORMAT_FULL = "yyyy/MM/dd HH:mm:ss.nnnnnnnnn";
-    final public static String FORMAT_SECONDS = "yyyy/MM/dd HH:mm:ss";
-
-    /** Time stamp format */
-    final private static DateTimeFormatter time_format = DateTimeFormatter.ofPattern(FORMAT_FULL);
-    
     /** @param timestamp {@link Timestamp}, may be <code>null</code>
      *  @return Time stamp formatted as string
      */
@@ -36,13 +28,13 @@ public class TimestampHelper
     {
         if (timestamp == null)
             return "null";
-		return time_format.format(ZonedDateTime.ofInstant(timestamp, zone));
+		return TimestampFormats.FULL_FORMAT.format(timestamp);
     }
-    
+
     // May look like just     time_format.format(Instant)  works,
     // but results in runtime error " java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: YearOfEra"
     // because time for printing needs to be in local time
-//    public static void main(String[] args) 
+//    public static void main(String[] args)
 //    {
 //    	final Instant now = Instant.now();
 //    	System.out.println(format(now));
@@ -149,7 +141,7 @@ public class TimestampHelper
         // The addition of leap seconds can further confuse matters,
         // so perform computations that go beyond an hour in local time,
         // relative to midnight of the given time stamp.
-        
+
         // TODO Use new API, not Calendar
         final Calendar cal = Calendar.getInstance();
         cal.clear();

--- a/core/platform/platform-plugins/org.csstudio.java.test/src/org/csstudio/java/time/TimestampFormatsTest.java
+++ b/core/platform/platform-plugins/org.csstudio.java.test/src/org/csstudio/java/time/TimestampFormatsTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.java.time;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+/** JUnit test of TimestampFormats
+ *  @author Kay Kasemir
+ */
+public class TimestampFormatsTest
+{
+    @Test
+    public void testFormatter()
+    {
+        final Instant time = Instant.from(TimestampFormats.SECONDS_FORMAT.parse("2015/02/25 08:42:00"));
+        final String text = TimestampFormats.SECONDS_FORMAT.format(time);
+        System.out.println(time);
+        System.out.println(text);
+        assertThat(text, equalTo("2015/02/25 08:42:00"));
+        assertThat(TimestampFormats.FULL_FORMAT.format(time), equalTo("2015/02/25 08:42:00.000000000"));
+    }
+}

--- a/core/platform/platform-plugins/org.csstudio.java/META-INF/MANIFEST.MF
+++ b/core/platform/platform-plugins/org.csstudio.java/META-INF/MANIFEST.MF
@@ -2,9 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Java Utilities
 Bundle-SymbolicName: org.csstudio.java
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
+Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen - SNS
 Bundle-Description: Java Utilities, no dependencies to Eclipse
 Export-Package: org.csstudio.java.string,
- org.csstudio.java.thread
+ org.csstudio.java.thread,
+ org.csstudio.java.time

--- a/core/platform/platform-plugins/org.csstudio.java/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.java/pom.xml
@@ -8,6 +8,6 @@
     <artifactId>platform-plugins</artifactId>
   </parent>
   <artifactId>org.csstudio.java</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/platform/platform-plugins/org.csstudio.java/src/org/csstudio/java/time/TimestampFormats.java
+++ b/core/platform/platform-plugins/org.csstudio.java/src/org/csstudio/java/time/TimestampFormats.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.java.time;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/** Time stamp formats
+ *
+ *  <p>Java 8 introduced {@link Instant} which handles time stamps
+ *  with up to nanosecond detail, obsoleting custom classes
+ *  for wrapping control system time stamps.
+ *
+ *  <p>The {@link DateTimeFormatter} is immutable and thread-safe,
+ *  finally allowing re-use of common time stamp formatters.
+ *
+ *  <p>The formatters defined here are suggested for CS-Studio time stamps
+ *  because they can show the full detail of control system time stamps in a portable way,
+ *  independent from locale.
+ *
+ *  @author Kay Kasemir
+ */
+public class TimestampFormats
+{
+    final private static ZoneId zone = ZoneId.systemDefault();
+    final private static String FULL_PATTERN = "yyyy/MM/dd HH:mm:ss.nnnnnnnnn";
+    final private static String SECONDS_PATTERN = "yyyy/MM/dd HH:mm:ss";
+
+    /** Time stamp format for 'full' time stamp */
+    final public static DateTimeFormatter FULL_FORMAT= DateTimeFormatter.ofPattern(FULL_PATTERN).withZone(zone);
+
+    /** Time stamp format for time stamp up to seconds, but not nanoseconds */
+    final public static DateTimeFormatter SECONDS_FORMAT = DateTimeFormatter.ofPattern(SECONDS_PATTERN).withZone(zone);
+}


### PR DESCRIPTION
Fixes a failed test and as discussed on error ticket introduces a DateTimeFormatter that can be shared
(which wasn't possible with the pre-Java 8 'Instant' formats)

#1760