### PR TITLE
o.c.alarm.beast.test: Re-enable tests

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.csstudio</groupId>
-    <artifactId>applications-plugins</artifactId>
+    <artifactId>alarm-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <groupId>org.csstudio</groupId>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/src/org/csstudio/alarm/beast/SeverityLevelHeadlessIT.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/src/org/csstudio/alarm/beast/SeverityLevelHeadlessIT.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class SeverityLevelHeadlessTest
+public class SeverityLevelHeadlessIT
 {
     @Test
     public void testPreferences()

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/src/org/csstudio/alarm/beast/WorkQueueUnitTest.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/src/org/csstudio/alarm/beast/WorkQueueUnitTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 /** Very simplistic WorkQueue JUnit test
@@ -62,7 +63,7 @@ public class WorkQueueUnitTest
                 }
                 catch (Throwable ex)
                 {
-                    System.out.println(ex.getMessage());
+                    System.out.println("Detected: " + ex.getMessage());
                     assertTrue(ex.getMessage().contains("WrongThread"));
                 }
             }
@@ -101,7 +102,7 @@ public class WorkQueueUnitTest
 
     // Meant to run in JProfiler, used to
     // determine queue performance
-    // @Ignore
+    @Ignore
     @Test
     public void profileQueuePerformance()
     {

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/src/org/csstudio/alarm/beast/client/AlarmTreeItemUnitTest.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/src/org/csstudio/alarm/beast/client/AlarmTreeItemUnitTest.java
@@ -9,11 +9,11 @@ package org.csstudio.alarm.beast.client;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.csstudio.alarm.beast.SeverityLevel;
-import org.diirt.util.time.Timestamp;
 import org.junit.Test;
 
 /** JUnit Test of AlarmTreeItem
@@ -99,7 +99,7 @@ public class AlarmTreeItemUnitTest
         assertEquals(SeverityLevel.OK, ccl.getSeverity());
         pv.setAlarmState(SeverityLevel.MINOR, "Nuissance",
                          SeverityLevel.MAJOR, "Problem",
-                         "Value", Timestamp.now());
+                         "Value", Instant.now());
         assertEquals(SeverityLevel.MINOR, ccl.getCurrentSeverity());
         assertEquals(SeverityLevel.MAJOR, ccl.getSeverity());
         assertEquals("Problem", ccl.getMessage());
@@ -108,7 +108,7 @@ public class AlarmTreeItemUnitTest
         // Check propagation of alarm that clears
         pv.setAlarmState(SeverityLevel.OK, "Nuissance",
                 SeverityLevel.MAJOR_ACK, "Problem2",
-                "Value2", Timestamp.now());
+                "Value2", Instant.now());
         assertEquals(SeverityLevel.OK, ccl.getCurrentSeverity());
         assertEquals(SeverityLevel.MAJOR_ACK, ccl.getSeverity());
         assertEquals("Problem2", ccl.getMessage());

--- a/applications/alarm/alarm-plugins/pom.xml
+++ b/applications/alarm/alarm-plugins/pom.xml
@@ -22,8 +22,7 @@
     <module>org.csstudio.alarm.beast.notifier.intro</module>
     <module>org.csstudio.alarm.beast.notifier.logbook</module>
     <module>org.csstudio.alarm.beast.notifier.test</module>
-    <!--module>org.csstudio.alarm.beast.test</module-->
-    <!-- Error in threading. Test failes to end. -->
+    <module>org.csstudio.alarm.beast.test</module>
     <module>org.csstudio.alarm.beast.server</module>
     <module>org.csstudio.alarm.beast.server.test</module>
     <module>org.csstudio.alarm.beast.ui</module>


### PR DESCRIPTION
Was found disabled in #1770.
Needed to be updated to Instant and new location of alarm plugins.