### PR TITLE
o.c.java: Update test

### DIFF
--- a/core/platform/platform-plugins/org.csstudio.java.test/src/org/csstudio/java/time/TimestampFormatsTest.java
+++ b/core/platform/platform-plugins/org.csstudio.java.test/src/org/csstudio/java/time/TimestampFormatsTest.java
@@ -23,12 +23,12 @@ public class TimestampFormatsTest
     @Test
     public void testFormatter()
     {
-        final Instant time = Instant.from(TimestampFormats.SECONDS_FORMAT.parse("2015/02/25 08:42:00"));
+        final Instant time = Instant.from(TimestampFormats.SECONDS_FORMAT.parse("2015-02-25 08:42:00"));
         final String text = TimestampFormats.SECONDS_FORMAT.format(time);
         System.out.println(time);
         System.out.println(text);
-        assertThat(text, equalTo("2015/02/25 08:42:00"));
-        assertThat(TimestampFormats.FULL_FORMAT.format(time), equalTo("2015/02/25 08:42:00.000000000"));
+        assertThat(text, equalTo("2015-02-25 08:42:00"));
+        assertThat(TimestampFormats.FULL_FORMAT.format(time), equalTo("2015-02-25 08:42:00.000000000"));
     }
 
     @Test


### PR DESCRIPTION
Recent pull request  #1780 to fix #1779 requires this adjustment of test because Time stamp format (date part) has changed.

The pull request added about 20 tests from the o.c.scan.test plugin, but regrettably I missed this test in o.c.java. Shows that it's good to have the tests run automatically!

