### PR TITLE
Pva 1796

### DIFF
--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVA_PV.java
@@ -13,6 +13,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.csstudio.vtype.pv.PV;
+import org.diirt.vtype.VEnum;
+import org.diirt.vtype.VType;
 import org.epics.pvaccess.client.Channel;
 import org.epics.pvaccess.client.Channel.ConnectionState;
 import org.epics.pvaccess.client.ChannelProvider;
@@ -25,8 +27,6 @@ import org.epics.pvdata.pv.MessageType;
 import org.epics.pvdata.pv.PVStructure;
 import org.epics.pvdata.pv.Status;
 import org.epics.pvdata.pv.Structure;
-import org.diirt.vtype.VEnum;
-import org.diirt.vtype.VType;
 
 /** pvAccess {@link PV}
  *
@@ -161,7 +161,7 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
         }
         else
             logger.log(Level.WARNING, "Channel {0} status {1}",
-                                   new Object[] { channel.getChannelName(), status.getMessage() });
+                                   new Object[] { getName(), status.getMessage() });
     }
 
     // ChannelRequester
@@ -232,8 +232,7 @@ class PVA_PV extends PV implements ChannelRequester, MonitorRequester
             }
             catch (Exception ex)
             {
-                logger.log(Level.WARNING,
-                    "Cannot handle update for " + channel.getChannelName(), ex);
+                logger.log(Level.WARNING, "Cannot handle update for " + getName(), ex);
             }
             monitor.release(update);
         }

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVNameHelper.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVNameHelper.java
@@ -36,16 +36,21 @@ public class PVNameHelper
      *  @throws Exception on error
      */
     public static PVNameHelper forName(final String pv_name) throws Exception
-    {   // Does name include "?request.."?
-        int pos = pv_name.indexOf('?');
+    {
+        // PV name that follow pvget/eget URL syntax can be
+        // "pva:///the_name" with 3 '///' to allow for a "pva://host:port/the_name".
+        // Strip the 3rd '/'
+        final String name = pv_name.startsWith("/") ? pv_name.substring(1) : pv_name;
+        // Does name include "?request.."?
+        int pos = name.indexOf('?');
         if (pos >= 0)
-            return PVNameHelper.forNameWithRequest(pv_name.substring(0, pos), pv_name.substring(pos));
+            return PVNameHelper.forNameWithRequest(name.substring(0, pos), name.substring(pos));
         // Does name include "/some/path"?
-        pos = pv_name.indexOf('/');
+        pos = name.indexOf('/');
         if (pos >= 0)
-            return PVNameHelper.forNameWithPath(pv_name.substring(0, pos), pv_name.substring(pos+1));
+            return PVNameHelper.forNameWithPath(name.substring(0, pos), name.substring(pos+1));
         // Plain channel name
-        return new PVNameHelper(pv_name, "field()", "field(value)");
+        return new PVNameHelper(name, "field()", "field(value)");
     }
 
     /** @param channel Channel name

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
@@ -22,14 +22,18 @@ import org.epics.pvdata.factory.ConvertFactory;
 import org.epics.pvdata.pv.Convert;
 import org.epics.pvdata.pv.Field;
 import org.epics.pvdata.pv.PVBoolean;
+import org.epics.pvdata.pv.PVByteArray;
 import org.epics.pvdata.pv.PVField;
 import org.epics.pvdata.pv.PVScalar;
 import org.epics.pvdata.pv.PVScalarArray;
 import org.epics.pvdata.pv.PVStringArray;
 import org.epics.pvdata.pv.PVStructure;
+import org.epics.pvdata.pv.PVStructureArray;
+import org.epics.pvdata.pv.PVUnion;
 import org.epics.pvdata.pv.Scalar;
 import org.epics.pvdata.pv.ScalarArray;
 import org.epics.pvdata.pv.ScalarType;
+import org.epics.pvdata.pv.StructureArrayData;
 
 /** Helper for reading & writing PVStructure
  *
@@ -83,6 +87,8 @@ class PVStructureHelper
             return new VTypeForEnum(struct);
         if (type.equals("epics:nt/NTScalarArray:1.0"))
             return decodeNTArray(struct);
+        if (type.equals("epics:nt/NTNDArray:1.0"))
+            return decodeNTNDArray(struct);
 
         // Handle data that contains a "value", even though not marked as NT*
         final Field value_field = struct.getStructure().getField("value");
@@ -287,6 +293,31 @@ class PVStructureHelper
                     ValueFactory.newAlarm(AlarmSeverity.UNDEFINED, "Unknown scalar type"),
                     ValueFactory.timeNow());
         }
+    }
+
+    private static VType decodeNTNDArray(final PVStructure struct) throws Exception
+    {
+        final PVStructureArray dim_field = struct.getSubField(PVStructureArray.class, "dimension");
+        if (dim_field.getLength() < 2)
+            throw new Exception("Need at least 2 dimensions, got " + dim_field.getLength());
+        StructureArrayData dim = new StructureArrayData();
+        dim_field.get(0, 2, dim);
+        final int width = dim.data[0].getIntField("size").get();
+        final int height = dim.data[1].getIntField("size").get();
+        final int size = width * height;
+
+        final PVUnion value_field = struct.getSubField(PVUnion.class, "value");
+        final PVField value = value_field.get();
+        if (! (value instanceof PVScalarArray))
+            throw new Exception("Expected array for NTNDArray 'value', got " + value);
+
+        final byte[] data = new byte[size];
+        if (value instanceof PVByteArray)
+            PVStructureHelper.convert.toByteArray((PVByteArray)value, 0, size, data, 0);
+        else
+            throw new Exception("Cannot extract byte[] from " + value);
+
+        return ValueFactory.newVImage(height, width, data);
     }
 
     /** @param structure {@link PVStructure} from which to read

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
@@ -105,25 +105,25 @@ class PVStructureHelper
         final ScalarType type = field.getScalar().getScalarType();
         switch (type)
         {
-        case pvLong:
-        case pvULong:
-            return ValueFactory.newVLong(convert.toLong(field), ValueFactory.alarmNone(),
-                                         ValueFactory.timeNow(), ValueFactory.displayNone());
         case pvDouble:
             return ValueFactory.newVDouble(convert.toDouble(field));
         case pvFloat:
             return ValueFactory.newVFloat(convert.toFloat(field), ValueFactory.alarmNone(),
+                    ValueFactory.timeNow(), ValueFactory.displayNone());
+        case pvLong:
+        case pvUInt: // Update UInt to Long
+        case pvULong: // Keep ULong as Long
+            return ValueFactory.newVLong(convert.toLong(field), ValueFactory.alarmNone(),
                                          ValueFactory.timeNow(), ValueFactory.displayNone());
+        case pvInt:
+        case pvUShort: // Update UShort to Int
+            return ValueFactory.newVInt(convert.toInt(field), ValueFactory.alarmNone(),
+                    ValueFactory.timeNow(), ValueFactory.displayNone());
         case pvShort:
-        case pvUShort:
+        case pvUByte: // Update UByte to Short
             return ValueFactory.newVShort(convert.toShort(field), ValueFactory.alarmNone(),
                                           ValueFactory.timeNow(), ValueFactory.displayNone());
-        case pvInt:
-        case pvUInt:
-            return ValueFactory.newVInt(convert.toInt(field), ValueFactory.alarmNone(),
-                                        ValueFactory.timeNow(), ValueFactory.displayNone());
         case pvByte:
-        case pvUByte:
             return ValueFactory.newVByte(convert.toByte(field), ValueFactory.alarmNone(),
                                          ValueFactory.timeNow(), ValueFactory.displayNone());
         case pvBoolean:
@@ -163,47 +163,40 @@ class PVStructureHelper
             return ValueFactory.newVDoubleArray(new ArrayDouble(data), ValueFactory.alarmNone(),
                                                 ValueFactory.timeNow(), ValueFactory.displayNone());
         }
+        case pvFloat:
+        {
+            final float[] data = new float[length];
+            PVStructureHelper.convert.toFloatArray(pv_array, 0, length, data, 0);
+            return ValueFactory.newVFloatArray(new ArrayFloat(data), ValueFactory.alarmNone(),
+                    ValueFactory.timeNow(), ValueFactory.displayNone());
+        }
         case pvLong:
         case pvULong:
+        case pvUInt:
         {
             final long[] data = new long[length];
             PVStructureHelper.convert.toLongArray(pv_array, 0, length, data, 0);
             return ValueFactory.newVLongArray(new ArrayLong(data), ValueFactory.alarmNone(),
                                               ValueFactory.timeNow(), ValueFactory.displayNone());
         }
-        case pvFloat:
+        case pvInt:
+        case pvUShort:
         {
-            final float[] data = new float[length];
-            PVStructureHelper.convert.toFloatArray(pv_array, 0, length, data, 0);
-            return ValueFactory.newVFloatArray(new ArrayFloat(data), ValueFactory.alarmNone(),
-                                               ValueFactory.timeNow(), ValueFactory.displayNone());
+            final int[] data = new int[length];
+            PVStructureHelper.convert.toIntArray(pv_array, 0, length, data, 0);
+            return ValueFactory.newVIntArray(new ArrayInt(data), ValueFactory.alarmNone(),
+                    ValueFactory.timeNow(), ValueFactory.displayNone());
         }
         case pvShort:
-        case pvUShort:
+        case pvByte: // There is no ValueFactory.newVByteArray, so upgrade to short
+        case pvUByte:
         {
             final short[] data = new short[length];
             PVStructureHelper.convert.toShortArray(pv_array, 0, length, data, 0);
             return ValueFactory.newVShortArray(new ArrayShort(data), ValueFactory.alarmNone(),
                                                ValueFactory.timeNow(), ValueFactory.displayNone());
         }
-        case pvInt:
-        case pvUInt:
-        {
-            final int[] data = new int[length];
-            PVStructureHelper.convert.toIntArray(pv_array, 0, length, data, 0);
-            return ValueFactory.newVIntArray(new ArrayInt(data), ValueFactory.alarmNone(),
-                                             ValueFactory.timeNow(), ValueFactory.displayNone());
-        }
-        // There is no ValueFactory.newVByteArray
-//        case pvByte:
-//        case pvUByte:
-//        {
-//            final byte[] data = new byte[length];
-//            PVStructureHelper.convert.toByteArray(pv_array, 0, length, data, 0);
-//            return ValueFactory.newVByteArray(new ArrayByte(data), ValueFactory.alarmNone(),
-//                                              ValueFactory.timeNow());
-//        }
-        // There is no  convert.toBoolArray()
+        // There is no convert.toBoolArray(), and pvaSrv example has no boolArray01 example to test
 //        case pvBoolean:
 //        {
 //            final boolean[] data = new boolean[length];

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/pva/PVStructureHelper.java
@@ -54,7 +54,14 @@ class PVStructureHelper
             struct = orig_struct;
         else
         {   // Extract field from struct
-            struct = orig_struct.getSubField(PVStructure.class, value_offset);
+            try
+            {
+                struct = orig_struct.getSubField(PVStructure.class, value_offset);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Cannot decode field offset " + value_offset + " in " + orig_struct, ex);
+            }
             if (struct == null)
             {
                 // Not a struct. Try to read plain field.


### PR DESCRIPTION
Fixes #1796:

Allows vtype.pv to read any pva://structure/substruct/field even if the 'field' is a plain scalar, scalar array, or union where current variant is scalar or scalar array. Before, 'field' had to be a normative type, at least a structure with 'value' field.

Decodes NTNDArray into VImage.
.. But note that VImage is limited to byte[] data. For NTNDArray with data other than byte[], read the value as above: "pva://image_pv/value" to get the value array, which can then be any data type.

