### PR TITLE
Scan macros 1803

### DIFF
--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/LogCommandImpl.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/LogCommandImpl.java
@@ -15,8 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan.commandimpl;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.csstudio.scan.ScanSystemPreferences;
 import org.csstudio.scan.command.LogCommand;
@@ -64,7 +65,6 @@ public class LogCommandImpl extends ScanCommandImpl<LogCommand>
     @Override
     public void execute(final ScanContext context) throws Exception
     {
-        final Logger logger = Logger.getLogger(getClass().getName());
         final DataLog log = context.getDataLog().get();
         // Log all devices with the same serial
         final long serial = log.getNextScanDataSerial();

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/WaitCommandImpl.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/commandimpl/WaitCommandImpl.java
@@ -64,7 +64,7 @@ public class WaitCommandImpl extends ScanCommandImpl<WaitCommand>
     @Override
     public void simulate(final SimulationContext context) throws Exception
     {
-        final SimulatedDevice device = context.getDevice(command.getDeviceName());
+        final SimulatedDevice device = context.getDevice(context.getMacros().resolveMacros(command.getDeviceName()));
 
         // Estimate execution time
         final double time_estimate;
@@ -100,7 +100,7 @@ public class WaitCommandImpl extends ScanCommandImpl<WaitCommand>
 
         // Show command
         final StringBuilder buf = new StringBuilder();
-        buf.append(context.getMacros().resolveMacros(command.toString()));
+        buf.append(command.toString());
         if (! Double.isNaN(original))
             buf.append(" [was ").append(original).append("]");
         context.logExecutionStep(buf.toString(), time_estimate);

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/device/PVDevice.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/device/PVDevice.java
@@ -15,13 +15,14 @@
  ******************************************************************************/
 package org.csstudio.scan.device;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.csstudio.vtype.pv.PV;
 import org.csstudio.vtype.pv.PVListener;
@@ -44,8 +45,6 @@ import org.diirt.vtype.ValueUtil;
 @SuppressWarnings("nls")
 public class PVDevice extends Device
 {
-    final Logger logger = Logger.getLogger(getClass().getName());
-
     /** 'compile time' option to treat byte arrays as string */
     final private static boolean TREAT_BYTES_AS_STRING = true; // TODO Make configurable
 

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/JythonSupport.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/JythonSupport.java
@@ -7,13 +7,14 @@
  ******************************************************************************/
 package org.csstudio.scan.server;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.csstudio.scan.ScanSystemPreferences;
@@ -111,8 +112,7 @@ public class JythonSupport implements AutoCloseable
         }
         catch (Exception ex)
         {
-            Logger.getLogger(JythonSupport.class.getName()).
-                log(Level.SEVERE, "Once this worked OK, but now the Jython initialization failed. Don't you hate computers?", ex);
+            logger.log(Level.SEVERE, "Once this worked OK, but now the Jython initialization failed. Don't you hate computers?", ex);
             return false;
         }
         return true;
@@ -183,8 +183,7 @@ public class JythonSupport implements AutoCloseable
     {
         // Get package name
         final String pack_name = class_name.toLowerCase();
-        Logger.getLogger(getClass().getName()).log(Level.FINE,
-            "Loading Jython class {0} from {1}",
+        logger.log(Level.FINE, "Loading Jython class {0} from {1}",
             new Object[] { class_name, pack_name });
 
         try
@@ -197,11 +196,9 @@ public class JythonSupport implements AutoCloseable
         }
         catch (PyException ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING,
-                "Error loading Jython class {0} from {1}",
+            logger.log(Level.WARNING, "Error loading Jython class {0} from {1}",
                 new Object[] { class_name, pack_name });
-            Logger.getLogger(getClass().getName()).log(Level.WARNING,
-                    "Search path: {0}",interpreter.getSystemState().path);
+            logger.log(Level.WARNING, "Search path: {0}",interpreter.getSystemState().path);
 
             throw new Exception("Error loading Jython class " + class_name + ":" + getExceptionMessage(ex), ex);
         }

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/ScanCommandImpl.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/ScanCommandImpl.java
@@ -15,8 +15,9 @@
  ******************************************************************************/
 package org.csstudio.scan.server;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.csstudio.scan.command.ScanCommand;
 import org.csstudio.scan.command.ScanErrorHandler;
@@ -161,8 +162,7 @@ abstract public class ScanCommandImpl<C extends ScanCommand>
     public void next()
     {
         // Default implementation does not support this
-        Logger.getLogger(getClass().getName())
-              .log(Level.WARNING, "{0} does not support 'next'", command);
+        logger.log(Level.WARNING, "{0} does not support 'next'", command);
     }
 
     /** Invoke the command's error handler

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/WriteHelper.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/WriteHelper.java
@@ -7,8 +7,11 @@
  ******************************************************************************/
 package org.csstudio.scan.server;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
 
 import org.csstudio.scan.command.Comparison;
 import org.csstudio.scan.condition.DeviceCondition;
@@ -109,6 +112,7 @@ public class WriteHelper
         {
             thread = Thread.currentThread();
         }
+        logger.log(Level.FINE, "Writing " + device.getName() + " = " + value + (completion ? " with completion" : ""));
         try
         {
             // Perform write

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/app/Application.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/app/Application.java
@@ -39,6 +39,9 @@ import org.osgi.framework.BundleContext;
 @SuppressWarnings("nls")
 public class Application implements IApplication
 {
+    /** Suggested logger for all scan server code */
+    public static final Logger logger = Logger.getLogger("org.csstudio.scan.server");
+
     private static String bundle_version = "?";
     final private CountDownLatch run = new CountDownLatch(1);
 

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScanServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScanServlet.java
@@ -7,11 +7,12 @@
  ******************************************************************************/
 package org.csstudio.scan.server.httpd;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
@@ -56,7 +57,7 @@ public class ScanServlet extends HttpServlet
         final String format = request.getContentType();
         if (! format.contains("/xml"))
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /scan got format '" + format + "'");
+            logger.log(Level.WARNING, "POST /scan got format '" + format + "'");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Expecting XML content with scan, got format '" + format + "'");
             return;
         }
@@ -95,7 +96,7 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /scan error", ex);
+            logger.log(Level.WARNING, "POST /scan error", ex);
             response.resetBuffer();
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             out.println("<error>");
@@ -170,7 +171,7 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "PUT /scan error", ex);
+            logger.log(Level.WARNING, "PUT /scan error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
         }
     }
@@ -194,7 +195,7 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "DELETE /scan error", ex);
+            logger.log(Level.WARNING, "DELETE /scan error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
         }
     }
@@ -222,7 +223,7 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scan error", ex);
+            logger.log(Level.WARNING, "GET /scan error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
             return;
         }
@@ -273,7 +274,7 @@ public class ScanServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scan error", ex);
+            logger.log(Level.WARNING, "GET /scan error", ex);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex.getMessage());
         }
     }

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScansServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ScansServlet.java
@@ -7,10 +7,11 @@
  ******************************************************************************/
 package org.csstudio.scan.server.httpd;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -60,7 +61,7 @@ public class ScansServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scans error", ex);
+            logger.log(Level.WARNING, "GET /scans error", ex);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex.getMessage());
             return;
         }
@@ -70,7 +71,7 @@ public class ScansServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /scans reply error", ex);
+            logger.log(Level.WARNING, "GET /scans reply error", ex);
             // Can't send error to client because sending to client is the problem
         }
     }
@@ -92,7 +93,7 @@ public class ScansServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "DELETE /scans/completed error", ex);
+            logger.log(Level.WARNING, "DELETE /scans/completed error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
             return;
         }

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ServerServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/ServerServlet.java
@@ -7,9 +7,10 @@
  ******************************************************************************/
 package org.csstudio.scan.server.httpd;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.io.IOException;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -50,7 +51,7 @@ public class ServerServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /server error", ex);
+            logger.log(Level.WARNING, "GET /server error", ex);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
             return;
         }
@@ -73,7 +74,7 @@ public class ServerServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /server error", ex);
+            logger.log(Level.WARNING, "GET /server error", ex);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex.getMessage());
             return;
         }
@@ -83,7 +84,7 @@ public class ServerServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "GET /server reply error", ex);
+            logger.log(Level.WARNING, "GET /server reply error", ex);
             // Can't send error to client because sending to client is the problem
         }
     }

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/SimulateServlet.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/httpd/SimulateServlet.java
@@ -7,11 +7,12 @@
  ******************************************************************************/
 package org.csstudio.scan.server.httpd;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -48,7 +49,7 @@ public class SimulateServlet extends HttpServlet
         final String format = request.getContentType();
         if (! format.contains("/xml"))
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /simulate got format '" + format + "'");
+            logger.log(Level.WARNING, "POST /simulate got format '" + format + "'");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Expecting XML content with scan, got format '" + format + "'");
             return;
         }
@@ -75,7 +76,7 @@ public class SimulateServlet extends HttpServlet
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "POST /simulate error", ex);
+            logger.log(Level.WARNING, "POST /simulate error", ex);
             response.resetBuffer();
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             out.println("<error>");

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ExecutableScan.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ExecutableScan.java
@@ -15,6 +15,8 @@
  ******************************************************************************/
 package org.csstudio.scan.server.internal;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -30,7 +32,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import org.csstudio.java.time.TimestampFormats;
@@ -68,8 +69,6 @@ import org.csstudio.scan.server.ScanState;
 @SuppressWarnings("nls")
 public class ExecutableScan extends LoggedScan implements ScanContext, Callable<Object>, AutoCloseable
 {
-    final private Logger logger = Logger.getLogger(getClass().getName());
-
     /** Pattern for "java.lang.Exception: ", "java...Exception: " */
     private final Pattern java_exception_pattern = Pattern.compile("java[.a-zA-Z]+Exception: ");
 

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanServerImpl.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanServerImpl.java
@@ -15,13 +15,14 @@
  ******************************************************************************/
 package org.csstudio.scan.server.internal;
 
+import static org.csstudio.scan.server.app.Application.logger;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.csstudio.scan.ScanSystemPreferences;
 import org.csstudio.scan.command.ScanCommand;
@@ -113,8 +114,7 @@ public class ScanServerImpl implements ScanServer
             }
             catch (Exception ex)
             {
-                Logger.getLogger(getClass().getName()).log(Level.WARNING,
-                        "Error reading device context", ex);
+                logger.log(Level.WARNING, "Error reading device context", ex);
             }
         }
         return new Device[0];
@@ -177,7 +177,7 @@ public class ScanServerImpl implements ScanServer
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "Scan simulation failed", ex);
+            logger.log(Level.WARNING, "Scan simulation failed", ex);
             throw ex;
         }
     }
@@ -223,7 +223,7 @@ public class ScanServerImpl implements ScanServer
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "Scan submission failed", ex);
+            logger.log(Level.WARNING, "Scan submission failed", ex);
             throw ex;
         }
     }
@@ -233,7 +233,6 @@ public class ScanServerImpl implements ScanServer
     {
         final double threshold = ScanSystemPreferences.getOldScanRemovalMemoryThreshold();
         int count = 0;
-        final Logger logger = Logger.getLogger(getClass().getName());
 
         MemoryInfo used = new MemoryInfo();
         while (used.getMemoryPercentage() > threshold && count < 10)
@@ -429,7 +428,7 @@ public class ScanServerImpl implements ScanServer
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "Error removing scan", ex);
+            logger.log(Level.WARNING, "Error removing scan", ex);
             throw new Exception("Error removing scan", ex);
         }
     }
@@ -444,7 +443,7 @@ public class ScanServerImpl implements ScanServer
         }
         catch (Exception ex)
         {
-            Logger.getLogger(getClass().getName()).log(Level.WARNING, "Error removing completed scans", ex);
+            logger.log(Level.WARNING, "Error removing completed scans", ex);
             throw new Exception("Error removing completed scans", ex);
         }
     }


### PR DESCRIPTION
Uses macros for the device of the 'Set' command.

Fixes #1803 

Also cleans up 'simulated' macro handling, logs the written value (with actual device name) at fine log level and changes N loggers into just one for the server code.