### PR TITLE
Scan active 1851

### DIFF
--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/ScanServer.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/ScanServer.java
@@ -26,12 +26,8 @@ import org.csstudio.scan.device.DeviceInfo;
  *
  *  @author Kay Kasemir
  */
-@SuppressWarnings("nls")
 public interface ScanServer
 {
-    /** Version */
-    final public static String VERSION = "4.2";
-
     /** @return Info about the scan server
      *  @throws Exception on error
      */

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanEngine.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanEngine.java
@@ -128,6 +128,20 @@ public class ScanEngine
         scan_queue.add(scan);
     }
 
+    /** Check if there are any scans executing or waiting to be executed
+     *  @return Number of pending scans
+     */
+    public boolean hasPendingScans()
+    {
+        // Ideally, would check from _end_ because pending scans
+        // are added to end of queue.
+        // To be thread-safe, using plain COWList iteration.
+        for (LoggedScan scan : scan_queue)
+            if (! scan.getScanState().isDone())
+                return true;
+        return false;
+    }
+
     /** @return List of scans */
     public List<LoggedScan> getScans()
     {

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanServerImpl.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanServerImpl.java
@@ -78,7 +78,7 @@ public class ScanServerImpl implements ScanServer
     @Override
     public ScanServerInfo getInfo() throws Exception
     {
-        return new ScanServerInfo("V" + ScanServer.VERSION + " (" + Application.getBundleVersion() + ")",
+        return new ScanServerInfo(Application.getBundleVersion(),
                 start_time,
                 ScanSystemPreferences.getScanConfigPath(),
                 ScanSystemPreferences.getSimulationConfigPath(),

--- a/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanServerImpl.java
+++ b/applications/scan/scan-plugins/org.csstudio.scan.server/src/org/csstudio/scan/server/internal/ScanServerImpl.java
@@ -217,7 +217,7 @@ public class ScanServerImpl implements ScanServer
             final DeviceContext devices = new DeviceContext();
 
             // Submit scan to engine for execution
-            final ExecutableScan scan = new ExecutableScan(jython, scan_name, devices, pre_impl, main_impl, post_impl);
+            final ExecutableScan scan = new ExecutableScan(scan_engine, jython, scan_name, devices, pre_impl, main_impl, post_impl);
             scan_engine.submit(scan, queue);
             return scan.getId();
         }

--- a/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
+++ b/applications/scan/scan-plugins/org.csstudio.scan.ui/ChangeLog.html
@@ -9,8 +9,10 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.scan.</p>
 
-<h2>Version 4.3.0 - 2016-07-06</h2>
+<h2>Version 4.3.0 - 2016-08-11</h2>
 <ul>
+  <li>Scan:Active PV set as long as any scans are queued or running (#1851).</li>
+  <li>Scan simulation hook (#1847).</li>
   <li>Scan script context can write with completion (#1820).</li>
 </ul>
 

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/jca/JCAContext.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/jca/JCAContext.java
@@ -157,13 +157,12 @@ public class JCAContext implements ContextMessageListener, ContextExceptionListe
     public void contextException(final ContextExceptionEvent ev)
     {
         //Ignore warnings for DBE_PROPERTY from old CAJ.
-        if(ev != null && "event add req with mask=0X8\n".equals(ev.getMessage())){ //$NON-NLS-1$
-             logger.log(Level.FINE, "Ignored Message from {0}: {1}",
-                     new Object[] { ev.getSource(), ev.getMessage()});
-             return;
-        }
-        logger.log(Level.WARNING, "Channel Access Exception from {0}: {1}",
-                new Object[] { ev.getSource(), ev.getMessage() });
+        if(ev != null && "event add req with mask=0X8\n".equals(ev.getMessage()))
+            logger.log(Level.FINE, "Ignored Exception from {0} for channel {1}: {2}",
+                       new Object[] { ev.getSource(), ev.getChannel(), ev.getMessage() });
+        else
+            logger.log(Level.WARNING, "Channel Access Exception from {0} for channel {1}: {2}",
+                       new Object[] { ev.getSource(), ev.getChannel(), ev.getMessage() });
     }
 
     @Override


### PR DESCRIPTION
Keeps the Scan:Active PV set as long as there is any scan running or queued for running.

After the parallel scan support was added, this PV could be reset to idle by the first parallel scan that ended.

Also add log message when scan ends, which was previously just identified by no more log messages.

Fixes #1851