### PR TITLE
vtype.pv: Update versions of pvdata and pvaccess

### DIFF
--- a/core/base/base-plugins/org.csstudio.vtype.pv/META-INF/MANIFEST.MF
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Basic PV that provides VType data
 Bundle-SymbolicName: org.csstudio.vtype.pv;singleton:=true
-Bundle-Version: 4.0.2.qualifier
+Bundle-Version: 4.0.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>
 Require-Bundle: org.junit;bundle-version="4.8.2";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.7.0",
- org.csstudio.platform.libs.epics;bundle-version="3.2.0",
- org.epics.pvdata;bundle-version="4.0.3",
- org.epics.pvaccess;bundle-version="4.0.4",
+ org.csstudio.platform.libs.epics;bundle-version="4.3.0",
+ org.epics.pvDataJava;bundle-version="5.0.3",
+ org.epics.pvAccessJava;bundle-version="4.1.3",
  org.diirt.vtype;bundle-version="3.0.1",
  org.diirt.util;bundle-version="3.0.1"
 Export-Package: org.csstudio.vtype.pv,

--- a/core/base/base-plugins/org.csstudio.vtype.pv/pom.xml
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.vtype.pv</artifactId>
-  <version>4.0.2-SNAPSHOT</version>
+  <version>4.0.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Fixed vtype.pv compilation error after dirt & maven-osgi-bundles updated to new PVA libs
#1857 