### PR TITLE
opibuilder: Fix ArrayIndexOOB when writing long strings w/ Format=String (4.3.x)

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/TextInputEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/TextInputEditpart.java
@@ -29,6 +29,11 @@ import org.csstudio.simplepv.VTypeHelper;
 import org.csstudio.swt.widgets.figures.TextFigure;
 import org.csstudio.swt.widgets.figures.TextInputFigure;
 import org.csstudio.swt.widgets.figures.TextInputFigure.SelectorType;
+import org.diirt.vtype.Array;
+import org.diirt.vtype.Scalar;
+import org.diirt.vtype.VEnum;
+import org.diirt.vtype.VNumberArray;
+import org.diirt.vtype.VType;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.DragTracker;
@@ -37,11 +42,6 @@ import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.tools.SelectEditPartTracker;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
-import org.diirt.vtype.Array;
-import org.diirt.vtype.Scalar;
-import org.diirt.vtype.VEnum;
-import org.diirt.vtype.VNumberArray;
-import org.diirt.vtype.VType;
 
 /**
  * The editpart for text input widget.)
@@ -136,6 +136,7 @@ public class TextInputEditpart extends TextUpdateEditPart {
                 if (pv != null) {
                     if (pvLoadLimitsListener == null)
                         pvLoadLimitsListener = new IPVListener.Stub() {
+                            @Override
                             public void valueChanged(IPV pv) {
                                 VType value = pv.getValue();
                                 if (value != null
@@ -417,13 +418,17 @@ public class TextInputEditpart extends TextUpdateEditPart {
 
 
     private int[] parseCharArray(final String text, int currentLength) {
-        int[] iString = new int[currentLength];
+        // Turn text into array of character codes,
+        // at least as long as the current value of the PV.
+        // New text may be longer (and IOC can then refuse the extra chars)
+        final int newLength = text.length();
+        int[] iString = new int[Math.max(newLength, currentLength)];
         char[] textChars = text.toCharArray();
 
-        for (int ii = 0; ii < text.length(); ii++) {
+        for (int ii = 0; ii < newLength; ii++) {
             iString[ii] = Integer.valueOf(textChars[ii]);
         }
-        for (int ii = text.length(); ii < currentLength; ii++) {
+        for (int ii = newLength; ii < currentLength; ii++) {
             iString[ii] = 0;
         }
         return iString;


### PR DESCRIPTION
Fixes #1834 on the 4.3 branch