### PR TITLE
core feature: Add vtype.pv.ui

### DIFF
--- a/core/base/base-features/org.csstudio.core.base.feature/feature.xml
+++ b/core/base/base-features/org.csstudio.core.base.feature/feature.xml
@@ -35,4 +35,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.csstudio.vtype.pv.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
We deprecated o.c.platform.libs.epics.ui.
That functionality is now in o.c.vtype.pv.ui, which therefore needs to be listed in some feature to show up in the P2 repo.
Added it to the  org.csstudio.core.base.feature, since the plugin is under base-plugins/*.

Supports #1859 
