### PR TITLE
SCR Junit Test failure fix #1886

### DIFF
--- a/applications/saverestore/saverestore-plugins/org.csstudio.saverestore.git.test/src/org/csstudio/saverestore/git/GitManagerTest.java
+++ b/applications/saverestore/saverestore-plugins/org.csstudio.saverestore.git.test/src/org/csstudio/saverestore/git/GitManagerTest.java
@@ -294,13 +294,13 @@ public class GitManagerTest {
     public void testGetBaseLevels() throws GitAPIException, IOException {
         List<BaseLevel> baseLevels = manager.getBaseLevels(branch);
         assertEquals(2, baseLevels.size());
-        assertEquals(branchBase, baseLevels.get(0));
-        assertEquals(branchBase2, baseLevels.get(1));
+        assertTrue(baseLevels.contains(branchBase));
+        assertTrue(baseLevels.contains(branchBase2));
         baseLevels = manager.getBaseLevels(secondBranch);
         assertEquals(3, baseLevels.size());
-        assertEquals(new BaseLevel(secondBranch, branchBase), baseLevels.get(0));
-        assertEquals(new BaseLevel(secondBranch, branchBase2), baseLevels.get(1));
-        assertEquals(new BaseLevel(secondBranch, secondBase), baseLevels.get(2));
+        assertTrue(baseLevels.contains(new BaseLevel(secondBranch, branchBase)));
+        assertTrue(baseLevels.contains(new BaseLevel(secondBranch, branchBase2)));
+        assertTrue(baseLevels.contains(new BaseLevel(secondBranch, secondBase)));
     }
 
     @Test


### PR DESCRIPTION
Bugfix #1886 

There is no need for the base level to be in any predefined order. All that is required is that the returned list contains the particular base level. 