### PR TITLE
RTPlot: Fix cursor labels that showed "0.0" when zooming way out

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/LinearTicks.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/LinearTicks.java
@@ -231,14 +231,24 @@ public class LinearTicks implements Ticks<Double>
     @Override
     public String format(final Double num)
     {
+        // Patch numbers that are "very close to zero"
+        // to avoid "-0.00" or "0.0e-22"
+        if (Math.abs(num) < distance/100000)
+            return num_fmt.format(0.0);
+        return formatDetailed(num);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String formatDetailed(final Double num)
+    {
+        // Do NOT patch numbers "very close to zero"
+        // in detailed format because that could
+        // hide what user wants to inspect
         if (num.isNaN())
             return "NaN";
         if (num.isInfinite())
             return "Inf";
-        // Patch numbers that are "very close to zero"
-        // to avoid "-0.00" or "0.0e-22"
-        if (Math.abs(num) < distance/1000)
-            return num_fmt.format(0.0);
         return num_fmt.format(num);
     }
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -271,7 +271,7 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                     final double value = sample.getValue();
                     if (Double.isFinite(value)  &&  axis.getValueRange().contains(value))
                     {
-                        String label = axis.getTicks().format(value);
+                        String label = axis.getTicks().formatDetailed(value);
                         final String units = trace.getUnits();
                         if (! units.isEmpty())
                             label += " " + units;

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Ticks.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Ticks.java
@@ -51,4 +51,7 @@ public interface Ticks<XTYPE>
 
     /** @return Returns the tick formatted as text. */
     public String format(XTYPE tick);
+
+    /** @return Returns the tick formatted as text. */
+    public String formatDetailed(XTYPE tick);
 }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TimeTicks.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TimeTicks.java
@@ -240,4 +240,11 @@ public class TimeTicks implements Ticks<Instant>
             return config.start_formatter.format(local);
         return config.formatter.format(local);
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public String formatDetailed(final Instant tick)
+    {
+        return format(tick);
+    }
 }


### PR DESCRIPTION
Use a different 'detailed' format for the cursor labels which don't get patched to zero.
#1920