### PR TITLE
Db time range 1931

### DIFF
--- a/applications/apputil/apputil-plugins/org.csstudio.apputil.test/src/org/csstudio/apputil/time/TimeParserUnitTest.java
+++ b/applications/apputil/apputil-plugins/org.csstudio.apputil.test/src/org/csstudio/apputil/time/TimeParserUnitTest.java
@@ -11,9 +11,9 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 /** JUnit tests of the TimeParser
  *
@@ -25,8 +25,7 @@ import org.junit.Test;
 @SuppressWarnings("nls")
 public class TimeParserUnitTest extends TestCase
 {
-    private final DateFormat format =
-                      new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+    private final DateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     @Test
     public void testAbsoluteTimeParser() throws Exception
@@ -34,7 +33,7 @@ public class TimeParserUnitTest extends TestCase
         Calendar cal;
 
         // Full time with nanoseconds
-        cal = AbsoluteTimeParser.parse("2007/06/01 14:00:24.156959772");
+        cal = AbsoluteTimeParser.parse("2007-06-01 14:00:24.156959772");
         System.out.println(cal.getTime());
         assertEquals(2007, cal.get(Calendar.YEAR));
         assertEquals( 6, cal.get(Calendar.MONTH) + 1); // Jan == 0
@@ -45,7 +44,7 @@ public class TimeParserUnitTest extends TestCase
         assertEquals(156, cal.get(Calendar.MILLISECOND));
 
         // Full time, with extra spaces
-        cal = AbsoluteTimeParser.parse("   2007/01/18    12:10:13.123     ");
+        cal = AbsoluteTimeParser.parse("   2007-01-18    12:10:13.123     ");
         System.out.println(cal.getTime());
         assertEquals(2007, cal.get(Calendar.YEAR));
         assertEquals( 1, cal.get(Calendar.MONTH) + 1); // Jan == 0
@@ -64,7 +63,7 @@ public class TimeParserUnitTest extends TestCase
         assertEquals(cal, cal3);
 
         // Only date, no time
-        cal = AbsoluteTimeParser.parse("2007/01/18");
+        cal = AbsoluteTimeParser.parse("2007-01-18");
         System.out.println(cal.getTime());
         assertEquals(2007, cal.get(Calendar.YEAR));
         assertEquals( 1, cal.get(Calendar.MONTH) + 1); // Jan == 0
@@ -101,7 +100,7 @@ public class TimeParserUnitTest extends TestCase
         assertEquals(156, cal2.get(Calendar.MILLISECOND));
 
         // Only month and day, but no year
-        cal = AbsoluteTimeParser.parse(cal, "02/15 13:45");
+        cal = AbsoluteTimeParser.parse(cal, "02-15 13:45");
         System.out.println(cal.getTime());
         assertEquals(2007, cal.get(Calendar.YEAR));
         assertEquals( 2, cal.get(Calendar.MONTH) + 1); // Jan == 0
@@ -170,8 +169,8 @@ public class TimeParserUnitTest extends TestCase
     public void testTimeParser() throws Exception
     {
         // abs, abs
-        String start = "2006/01/02 03:04:05";
-        String end = "2007/05/06 07:08:09";
+        String start = "2006-01-02 03:04:05";
+        String end = "2007-05-06 07:08:09";
         StartEndTimeParser start_end = new StartEndTimeParser(start, end);
         String start_time = format.format(start_end.getStart().getTime());
         String end_time = format.format(start_end.getEnd().getTime());
@@ -182,46 +181,46 @@ public class TimeParserUnitTest extends TestCase
 
         // rel, abs
         start = "-2 month +10 min";
-        end = "2007/05/06 23:45:09";
+        end = "2007-05-06 23:45:09";
         start_end = new StartEndTimeParser(start, end);
         start_time = format.format(start_end.getStart().getTime());
         end_time = format.format(start_end.getEnd().getTime());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
-        assertEquals("2007/03/06 23:55:09", start_time);
-        assertEquals("2007/05/06 23:45:09", end_time);
+        assertEquals("2007-03-06 23:55:09", start_time);
+        assertEquals("2007-05-06 23:45:09", end_time);
 
         // rel, abs with an absolute time in the relative part
         start = "-2 days 08:15";
-        end = "2007/05/06 23:45:09";
+        end = "2007-05-06 23:45:09";
         start_end = new StartEndTimeParser(start, end);
         start_time = format.format(start_end.getStart().getTime());
         end_time = format.format(start_end.getEnd().getTime());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
-        assertEquals("2007/05/04 08:15:00", start_time);
-        assertEquals("2007/05/06 23:45:09", end_time);
+        assertEquals("2007-05-04 08:15:00", start_time);
+        assertEquals("2007-05-06 23:45:09", end_time);
 
         // abs, rel. Also hours that roll over into next day.
-        start = "2006/01/29 12:00:00";
+        start = "2006-01-29 12:00:00";
         end = "6M 12h";
         start_end = new StartEndTimeParser(start, end);
         start_time = format.format(start_end.getStart().getTime());
         end_time = format.format(start_end.getEnd().getTime());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
-        assertEquals("2006/01/29 12:00:00", start_time);
-        assertEquals("2006/07/30 00:00:00", end_time);
+        assertEquals("2006-01-29 12:00:00", start_time);
+        assertEquals("2006-07-30 00:00:00", end_time);
 
         // abs, rel==now
-        start = "2006/01/29 12:00:00";
+        start = "2006-01-29 12:00:00";
         end = "now";
         start_end = new StartEndTimeParser(start, end);
         start_time = format.format(start_end.getStart().getTime());
         end_time = format.format(start_end.getEnd().getTime());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
-        assertEquals("2006/01/29 12:00:00", start_time);
+        assertEquals("2006-01-29 12:00:00", start_time);
         long now = Calendar.getInstance().getTimeInMillis() / 1000;
         double end_diff_sec = now - start_end.getEnd().getTimeInMillis()/1000;
         assertEquals(0.0, end_diff_sec, 10.0);

--- a/applications/apputil/apputil-plugins/org.csstudio.apputil.test/src/org/csstudio/apputil/time/TimeParserUnitTest.java
+++ b/applications/apputil/apputil-plugins/org.csstudio.apputil.test/src/org/csstudio/apputil/time/TimeParserUnitTest.java
@@ -7,10 +7,10 @@
  ******************************************************************************/
 package org.csstudio.apputil.time;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 
+import org.csstudio.java.time.TimestampFormats;
 import org.junit.Test;
 
 import junit.framework.TestCase;
@@ -25,7 +25,7 @@ import junit.framework.TestCase;
 @SuppressWarnings("nls")
 public class TimeParserUnitTest extends TestCase
 {
-    private final DateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private final DateTimeFormatter format = TimestampFormats.SECONDS_FORMAT;
 
     @Test
     public void testAbsoluteTimeParser() throws Exception
@@ -172,8 +172,8 @@ public class TimeParserUnitTest extends TestCase
         String start = "2006-01-02 03:04:05";
         String end = "2007-05-06 07:08:09";
         StartEndTimeParser start_end = new StartEndTimeParser(start, end);
-        String start_time = format.format(start_end.getStart().getTime());
-        String end_time = format.format(start_end.getEnd().getTime());
+        String start_time = format.format(start_end.getStart().toInstant());
+        String end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         assertEquals(start, start_time);
@@ -183,8 +183,8 @@ public class TimeParserUnitTest extends TestCase
         start = "-2 month +10 min";
         end = "2007-05-06 23:45:09";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         assertEquals("2007-03-06 23:55:09", start_time);
@@ -194,8 +194,8 @@ public class TimeParserUnitTest extends TestCase
         start = "-2 days 08:15";
         end = "2007-05-06 23:45:09";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         assertEquals("2007-05-04 08:15:00", start_time);
@@ -205,8 +205,8 @@ public class TimeParserUnitTest extends TestCase
         start = "2006-01-29 12:00:00";
         end = "6M 12h";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         assertEquals("2006-01-29 12:00:00", start_time);
@@ -216,8 +216,8 @@ public class TimeParserUnitTest extends TestCase
         start = "2006-01-29 12:00:00";
         end = "now";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         assertEquals("2006-01-29 12:00:00", start_time);
@@ -229,8 +229,8 @@ public class TimeParserUnitTest extends TestCase
         start = "-6h";
         end = "-2h";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         now = Calendar.getInstance().getTimeInMillis() / 1000;
@@ -244,8 +244,8 @@ public class TimeParserUnitTest extends TestCase
         start = "-60 days";
         end = "+60 days";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         now = Calendar.getInstance().getTimeInMillis() / 1000;
@@ -263,8 +263,8 @@ public class TimeParserUnitTest extends TestCase
         start = "-6h";
         end = "now";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         now = Calendar.getInstance().getTimeInMillis() / 1000;
@@ -278,8 +278,8 @@ public class TimeParserUnitTest extends TestCase
         start = "-6h";
         end = "";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         now = Calendar.getInstance().getTimeInMillis() / 1000;
@@ -293,8 +293,8 @@ public class TimeParserUnitTest extends TestCase
         start = "-30 days";
         end = "";
         start_end = new StartEndTimeParser(start, end);
-        start_time = format.format(start_end.getStart().getTime());
-        end_time = format.format(start_end.getEnd().getTime());
+        start_time = format.format(start_end.getStart().getTime().toInstant());
+        end_time = format.format(start_end.getEnd().getTime().toInstant());
         System.out.println("   " + start + " ... " + end + "\n-> " +
                            start_time + " ... " + end_time);
         now = Calendar.getInstance().getTimeInMillis() / 1000;

--- a/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/AbsoluteTimeParser.java
+++ b/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/AbsoluteTimeParser.java
@@ -25,11 +25,11 @@ public class AbsoluteTimeParser
     /** The accepted date formats for absolute times. */
     private static final DateFormat[] parsers = new SimpleDateFormat[]
     {   // Most complete version first
-        new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS"),
-        new SimpleDateFormat("yyyy/MM/dd HH:mm:ss"),
-        new SimpleDateFormat("yyyy/MM/dd HH:mm"),
-        new SimpleDateFormat("yyyy/MM/dd HH"),
-        new SimpleDateFormat("yyyy/MM/dd")
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS"),
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"),
+        new SimpleDateFormat("yyyy-MM-dd HH:mm"),
+        new SimpleDateFormat("yyyy-MM-dd HH"),
+        new SimpleDateFormat("yyyy-MM-dd")
     };
 
     /** Like parse(), using a base calendar of 'now', 'current time zone'.
@@ -76,19 +76,19 @@ public class AbsoluteTimeParser
         final Calendar result = Calendar.getInstance();
 
         // Provide missing year from given cal
-        int datesep = cooked.indexOf('/');
+        int datesep = cooked.indexOf('-');
         if (datesep < 0) // No date at all provided? Use the one from cal.
-            cooked = String.format("%04d/%02d/%02d %s",
+            cooked = String.format("%04d-%02d-%02d %s",
                                    cal.get(Calendar.YEAR),
                                    cal.get(Calendar.MONTH) + 1,
                                    cal.get(Calendar.DAY_OF_MONTH),
                                    cooked);
         else
         {   // Are there two date separators?
-            datesep = cooked.indexOf('/', datesep + 1);
-            // If not, assume that we have MM/DD, and add the YYYY.
+            datesep = cooked.indexOf('-', datesep + 1);
+            // If not, assume that we have MM-DD, and add the YYYY.
             if (datesep < 0)
-                cooked = String.format("%04d/%s",
+                cooked = String.format("%04d-%s",
                                        cal.get(Calendar.YEAR), cooked);
         }
         // In case the text includes the ITimestamp up to nanoseconds:

--- a/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/StartEndTimeParser.java
+++ b/applications/apputil/apputil-plugins/org.csstudio.apputil/src/org/csstudio/apputil/time/StartEndTimeParser.java
@@ -13,7 +13,7 @@ import java.util.Calendar;
  *  from strings.
  *  <p>
  *  The time strings can contain absolute date and time info according to
- *  the format <code>YYYY/MM/DD hh:mm:ss.sss</code> used by the
+ *  the format <code>YYYY-MM-DD hh:mm:ss.sss</code> used by the
  *  {@link AbsoluteTimeParser}.
  *  When only certain pieces of the full date and time are provided,
  *  the omitted information is obtained from the current wallclock.


### PR DESCRIPTION
Updates the org.csstudio.apputil.time.AbsoluteTimeParser to use the same YYYY-MM-DD formatting as the org.csstudio.java.time.TimestampFormats.

Fixes #1931 , where the databrowser sometimes still used used YYYY/MM/DD and then failed to properly parse time ranges.