### PR TITLE
pvtable: Fix time stamp parsing

### DIFF
--- a/applications/display/display-plugins/org.csstudio.display.pvtable.test/META-INF/MANIFEST.MF
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-SymbolicName: org.csstudio.display.pvtable.test
 Fragment-Host: org.csstudio.display.pvtable
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Version: 4.0.102.qualifier
+Bundle-Version: 4.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime;bundle-version="3.6.0"

--- a/applications/display/display-plugins/org.csstudio.display.pvtable.test/pom.xml
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable.test/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.display.pvtable.test</artifactId>
-  <version>4.0.102-SNAPSHOT</version>
+  <version>4.4.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/applications/display/display-plugins/org.csstudio.display.pvtable.test/src/org/csstudio/display/pvtable/TimestampHelperTest.java
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable.test/src/org/csstudio/display/pvtable/TimestampHelperTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.display.pvtable;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+
+import org.csstudio.display.pvtable.model.TimestampHelper;
+import org.junit.Test;
+
+/** JUnit test of {@link TimestampHelper}
+ *  @author Kay Kasemir
+ */
+@SuppressWarnings("nls")
+public class TimestampHelperTest
+{
+    @Test
+    public void testTimestampHelper() throws Exception
+    {
+        final String example = "2016-10-21 14:28:55.023605801";
+        Instant time = TimestampHelper.parse(example);
+        assertThat(time, not(nullValue()));
+
+        final String text = TimestampHelper.format(time);
+        assertThat(text, equalTo(example));
+
+        time = TimestampHelper.parse("2016-10-21 14:28:55");
+        assertThat(time, not(nullValue()));
+        System.out.println(TimestampHelper.format(time));
+    }
+}

--- a/applications/display/display-plugins/org.csstudio.display.pvtable/ChangeLog.html
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable/ChangeLog.html
@@ -9,6 +9,11 @@
 
 <p>Version numbers in here refer to the plugin org.csstudio.display.pvtable.</p>
 
+<h2>Version 4.4.0 - 2016-10-21</h2>
+<ul>
+  <li>Updated code from custom Timestamp to Java 8 Instant.</li>
+</ul>
+
 <h2>Version 4.3.2 - 2016-03-14</h2>
 <ul>
   <li>Handle writing "12 units" by stripping the units before value is written.</li>

--- a/applications/display/display-plugins/org.csstudio.display.pvtable/META-INF/MANIFEST.MF
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PVTable Plug-in
 Bundle-SymbolicName: org.csstudio.display.pvtable;singleton:=true
-Bundle-Version: 4.3.2.qualifier
+Bundle-Version: 4.4.0.qualifier
 Bundle-Activator: org.csstudio.display.pvtable.Plugin
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-Localization: plugin
@@ -20,5 +20,6 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.107.0",
  org.csstudio.apputil;bundle-version="3.0.2",
  org.csstudio.utility.singlesource;bundle-version="4.0.0",
  org.eclipse.core.runtime,
- org.apache.servicemix.bundles.poi;bundle-version="3.11.1"
+ org.apache.servicemix.bundles.poi;bundle-version="3.11.1",
+ org.csstudio.java;bundle-version="3.3.0"
 Export-Package: org.csstudio.display.pvtable

--- a/applications/display/display-plugins/org.csstudio.display.pvtable/pom.xml
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable/pom.xml
@@ -8,6 +8,6 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.display.pvtable</artifactId>
-  <version>4.3.2-SNAPSHOT</version>
+  <version>4.4.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/applications/display/display-plugins/org.csstudio.display.pvtable/src/org/csstudio/display/pvtable/model/TimestampHelper.java
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable/src/org/csstudio/display/pvtable/model/TimestampHelper.java
@@ -7,72 +7,59 @@
  ******************************************************************************/
 package org.csstudio.display.pvtable.model;
 
-import java.text.ParseException;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 
+import org.csstudio.java.time.TimestampFormats;
 
-/**
- * Time stamp gymnastics
+/** Time stamp gymnastics
  *
- * @author Kay Kasemir
+ *  <p>Shortcut for {@link TimestampFormats}
+ *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class TimestampHelper {
-    final public static String FORMAT_FULL = "yyyy-MM-dd HH:mm:ss.nnnnnnnnn";
-    final public static String FORMAT_PARSE = "yyyy-MM-dd HH:mm:ss.";
-
-    private static ZoneId zone = ZoneId.systemDefault();
-
-    private static final DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern(FORMAT_FULL);
-    private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern(FORMAT_PARSE);
-
-    /**
-     * @param timestamp
-     *            {@link Instant}, may be <code>null</code>
-     * @return Time stamp formatted as string
+public class TimestampHelper
+{
+    /** @param timestamp {@link Instant}, may be <code>null</code>
+     *  @return Time stamp formatted as string
      */
-    public static String format(final Instant timestamp) {
-        if (timestamp == null) {
+    public static String format(final Instant timestamp)
+    {
+        if (timestamp == null)
             return "null";
-        }
-        return timeFormat.format(ZonedDateTime.ofInstant(timestamp, zone));
+        return TimestampFormats.FULL_FORMAT.format(timestamp);
     }
 
-    /**
-     * Take a String and return a Timestamp Should be implemented in
-     * TimestampFormat
+    /** Take a String and return a time stamp
      *
-     * @param sTimestamp
-     * @return
-     * @throws ParseException
-     * @author A.PHILIPPE, L.PHILIPPE GANIL/FRANCE
+     *  @param sTimestamp
+     *  @return
+     *  @throws Exception on error
+     *  @author A.PHILIPPE, L.PHILIPPE GANIL/FRANCE
      */
-    public static Instant parse(final String sTimestamp) throws ParseException {
-        if (sTimestamp == "" || sTimestamp == null) {
+    public static Instant parse(final String sTimestamp) throws Exception
+    {
+        if (sTimestamp == "" || sTimestamp == null)
             return null;
+
+        Exception error = null;
+        try
+        {
+            return Instant.from(TimestampFormats.FULL_FORMAT.parse(sTimestamp));
+        }
+        catch (Exception ex)
+        {
+            error = ex;
         }
 
-        Instant t = null;
-        try {
-            t = ZonedDateTime.parse(sTimestamp, timeFormat).toInstant();
+        try
+        {
+            return Instant.from(TimestampFormats.SECONDS_FORMAT.parse(sTimestamp));
         }
-        catch (DateTimeParseException ex) {
-            ex.printStackTrace();
+        catch (Exception ex)
+        {
+            error = ex;
         }
-
-        if (t == null) {
-            try {
-                t = ZonedDateTime.parse(sTimestamp, dateFormat).toInstant();
-            }
-            catch (DateTimeParseException ex) {
-                ex.printStackTrace();
-            }
-        }
-
-        return t;
+        // Reports the last error. Could also use the first one...
+        throw error;
     }
 }

--- a/applications/display/display-plugins/org.csstudio.display.pvtable/src/org/csstudio/display/pvtable/ui/ExportXLSAction.java
+++ b/applications/display/display-plugins/org.csstudio.display.pvtable/src/org/csstudio/display/pvtable/ui/ExportXLSAction.java
@@ -142,7 +142,7 @@ public class ExportXLSAction extends PVTableAction {
                         dateC = Date.from(timeC);
                         cellD.setCellValue(dateC);
                         cellD.setCellStyle(styleDate);
-                    } catch (ParseException e) {
+                    } catch (Exception e) {
                         timeS = measures.get(b).getItems().get(d).getTime_saved();
                         cellD.setCellValue(timeS);
                         cellD.setCellStyle(styleDate);
@@ -273,7 +273,7 @@ public class ExportXLSAction extends PVTableAction {
                             String timeS = null;
                             try {
                                 timeTS = TimestampHelper.parse(model.getItem(i).getTime_saved());
-                            } catch (ParseException e) {
+                            } catch (Exception e) {
                                 timeS = model.getItem(i).getTime_saved();
                             }
                             dateTS = Date.from(timeTS);
@@ -293,7 +293,7 @@ public class ExportXLSAction extends PVTableAction {
                                 timeTS = TimestampHelper.parse(model.getItem(i).getTime_saved());
                                 dateTS = Date.from(timeTS);
                                 savedTimestamp.setCellValue(dateTS);
-                            } catch (ParseException e) {
+                            } catch (Exception e) {
                                 timeS = model.getItem(i).getTime_saved();
                                 savedTimestamp.setCellValue(timeS);
                             }


### PR DESCRIPTION
Error had been introduced when all of CSS was updated from custom
Timestamp to Java 8 Instant.
Simplified code by using common .c.java.time.TimestampFormats.
Added unit test.

Fixes #1934