### PR TITLE
Bug in CSS-1854: Panning databrowser with multiple axis fails

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -1090,7 +1090,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         {
             mouseMove(e);
             final YAxisImpl<XTYPE> y_axis = y_axes.get(mouse_y_axis);
-            List<Boolean> new_autoscales = Arrays.asList(new Boolean[y_axes.size()]);
+            List<Boolean> new_autoscales = Arrays.asList(new Boolean[1]);
             Collections.fill(new_autoscales, Boolean.FALSE);
             undo.add(new ChangeAxisRanges<XTYPE>(this, Messages.Pan_Y,
                     Arrays.asList(y_axis),


### PR DESCRIPTION
A bug was introudced in https://github.com/ControlSystemStudio/cs-studio/issues/1854, when using multiple axis and trying to pan them this did not perform correctly. This fixes the issue by sending the correct length of autoscale axis values to the undoable action ChangeAxisRanges constructor.