### PR TITLE
Save Restore null pointer fixed

### DIFF
--- a/applications/saverestore/saverestore-plugins/org.csstudio.saverestore.ui.browser/src/org/csstudio/saverestore/ui/browser/DefaultBaseLevelBrowser.java
+++ b/applications/saverestore/saverestore-plugins/org.csstudio.saverestore.ui.browser/src/org/csstudio/saverestore/ui/browser/DefaultBaseLevelBrowser.java
@@ -118,7 +118,7 @@ public class DefaultBaseLevelBrowser extends GridPane implements BaseLevelBrowse
 
     private void confirmSelectBaseLevel() {
         BaseLevel bl = internalBaseLevelProperty().getValue();
-        if (bl != null && !availableBaseLevelsProperty.get().contains(bl)) {
+        if (bl != null && !availableBaseLevelsProperty().get().contains(bl)) {
             String message = Selector.validateBaseLevelName(bl.getStorageName());
             if (message != null && !FXMessageDialog.openQuestion(parent.getShell(), "Invalid Name",
                 message + "\n Do you still want to continue?")) {


### PR DESCRIPTION
Bug fix for #1965.

It was a "typo" kind of a bug. Instead of going through a method the field was accessed directly.