### PR TITLE
First attempt at labelling waveforms with annotations.

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/AnnotationInfo.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/AnnotationInfo.java
@@ -84,6 +84,23 @@ public class AnnotationInfo
         return "Annotation for item " + item_index + ": '" + text + "' @ " + TimeHelper.format(time) + ", " + value;
     }
 
+    @Override
+    public boolean equals(Object other)
+    {
+        boolean value = false;
+        if (!(other instanceof AnnotationInfo))
+            value = false;
+        if (other == this)
+            value = true;
+        AnnotationInfo otherAnn = (AnnotationInfo) other;
+        value = this.item_index == otherAnn.getItemIndex() &&
+                this.time.equals(otherAnn.getTime()) &&
+                this.value == otherAnn.getValue() &&
+                this.offset.equals(otherAnn.getOffset()) &&
+                this.text.equals(otherAnn.getText());
+        return value;
+    }
+
     /** Write XML formatted annotation configuration
      *  @param writer PrintWriter
      */

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
@@ -523,6 +523,11 @@ public class Controller
             {
                 getArchivedData(item, model.getStartTime(), model.getEndTime());
             }
+
+            public void changedAnnotations()
+            {
+                plot.setAnnotations(model.getAnnotations());
+            }
         };
         model.addListener(model_listener);
     }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -10,6 +10,7 @@ package org.csstudio.trends.databrowser2.ui;
 import java.io.File;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -407,4 +408,55 @@ public class ModelBasedPlot
     {
         plot.requestUpdate();
     }
+
+    public Collection<AnnotationInfo> getAnnotations()
+    {
+        ArrayList<AnnotationInfo> annotations = new ArrayList<>();
+        for (Annotation<Instant> annotation : plot.getAnnotations()) {
+            System.out.println("Getting annotation " + annotation);
+        }
+        return annotations;
+    }
+
+    /**
+     * Ensure that the two sets of annotations are the same.
+     * @param annotations
+     */
+    void setAnnotations(Collection<AnnotationInfo> newAnnotations)
+    {
+        ArrayList<AnnotationInfo> plotAnnotationInfos = new ArrayList<>();
+        final List<Trace<Instant>> traces = new ArrayList<>();
+        for (Trace<Instant> trace : plot.getTraces())
+            traces.add(trace);
+        for (Annotation<Instant> annotation: plot.getAnnotations())
+        {
+            AnnotationInfo plotAnnotationInfo = new AnnotationInfo(
+                    traces.indexOf(annotation.getTrace()),
+                    annotation.getPosition(),
+                    annotation.getValue(),
+                    annotation.getOffset(),
+                    annotation.getText()
+                    );
+            if (!newAnnotations.contains(plotAnnotationInfo))
+                plot.removeAnnotation(annotation);
+            else
+                plotAnnotationInfos.add(plotAnnotationInfo);
+        }
+        // now we have a copy
+
+        for (AnnotationInfo annotation : newAnnotations)
+        {
+            if (!plotAnnotationInfos.contains(annotation))
+            {
+                Annotation<Instant> newAnnotation = new Annotation<Instant>(
+                        traces.get(annotation.getItemIndex()),
+                        annotation.getTime(),
+                        annotation.getValue(),
+                        annotation.getOffset(),
+                        annotation.getText());
+                plot.addAnnotation(newAnnotation);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
This isn't for merging - I need some help from @kasemir.  See #1980 and #1970.

There are a number of reasons why this is tricky:

* At present, annotation changes are passed only from the plot back to the model, not from the model through to the plot
* The annotation is very happy to draw itself outside of the plot window
* The annotation is saved into the `.plt` file, but it shouldn't really be because it's only associated with the optional waveform view
* There are two lists of annotations - `AnnotationInfos` on the model side and `Annotations` on the plot side.  These need to be kept in sync and since they are both immutable it's a bit of work

This commit solves some of these problems, but not necessarily in a good way:

* The waveform plot annotation is identified simply by having the name "Waveform view"
* The best behaviour would be for the annotation to be draggable and the plot to be updated.  This works but is so slow that you can drag the annotation at most one point

Perhaps Kay can see some simpler ways to do things.