### PR TITLE
Databrowser waveform view: Second attempt at labelling waveforms with annotations

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/Annotation.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/Annotation.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.graphics.Point;
 @SuppressWarnings("nls")
 public class Annotation<XTYPE extends Comparable<XTYPE>>
 {
+    final protected boolean internal;
     final protected Trace<XTYPE> trace;
 
     /** The position and value, i.e. x/y in value space */
@@ -34,11 +35,24 @@ public class Annotation<XTYPE extends Comparable<XTYPE>>
     /** Constructor */
     public Annotation(final Trace<XTYPE> trace, final XTYPE position, final double value, final Point offset, final String text)
     {
+        this(false, trace, position, value, offset, text);
+    }
+
+    /** Constructor */
+    public Annotation(final boolean internal, final Trace<XTYPE> trace, final XTYPE position, final double value, final Point offset, final String text)
+    {
+        this.internal = internal;
         this.trace = Objects.requireNonNull(trace);
         this.position = Objects.requireNonNull(position);
         this.value = value;
         this.offset = Objects.requireNonNull(offset);
         this.text = Objects.requireNonNull(text);
+    }
+
+    /** @return Internal annotation, not created by user? */
+    public boolean isInternal()
+    {
+        return internal;
     }
 
     /** @return Trace for which this annotation shows values */

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.graphics.Rectangle;
  *  @param <XTYPE> Data type used for the {@link PlotDataItem}
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<XTYPE>
 {
     /** 'X' marks the spot, and this is it's radius. */
@@ -48,9 +49,9 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
     private Optional<Rectangle> screen_box = Optional.empty();
 
     /** Constructor */
-    public AnnotationImpl(final Trace<XTYPE> trace, final XTYPE position, final double value, final Point offset, final String text)
+    public AnnotationImpl(final boolean internal, final Trace<XTYPE> trace, final XTYPE position, final double value, final Point offset, final String text)
     {
-        super(trace, position, value, offset, text);
+        super(internal, trace, position, value, offset, text);
     }
 
     /** Set to new location

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
@@ -47,7 +47,10 @@ public class EditAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialo
     {
         super(shell);
         this.plot = plot;
-        annotations = plot.getAnnotations();
+        annotations = new ArrayList<>();
+        for (Annotation<XTYPE> annotation : plot.getAnnotations())
+            if (! annotation.isInternal())
+                annotations.add(annotation);
     }
 
     @Override

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -485,7 +485,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         if (annotation instanceof AnnotationImpl)
             annotations.add((AnnotationImpl)annotation);
         else
-            annotations.add(new AnnotationImpl<XTYPE>(annotation.getTrace(), annotation.getPosition(),
+            annotations.add(new AnnotationImpl<XTYPE>(annotation.isInternal(), annotation.getTrace(), annotation.getPosition(),
                                                       annotation.getValue(), annotation.getOffset(),
                                                       annotation.getText()));
         requestUpdate();

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -316,7 +316,7 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
             }
             if (location != null)
                 plot.getUndoableActionManager().execute(
-                    new AddAnnotationAction<XTYPE>(plot, new AnnotationImpl<XTYPE>(trace, location, value, new Point(20, -20), text)));
+                    new AddAnnotationAction<XTYPE>(plot, new AnnotationImpl<XTYPE>(false, trace, location, value, new Point(20, -20), text)));
         });
     }
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToolbarHandler.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToolbarHandler.java
@@ -8,9 +8,10 @@
 package org.csstudio.swt.rtplot.internal;
 
 import org.csstudio.swt.rtplot.Activator;
+import org.csstudio.swt.rtplot.Annotation;
 import org.csstudio.swt.rtplot.Messages;
-import org.csstudio.swt.rtplot.RTPlotListener;
 import org.csstudio.swt.rtplot.RTPlot;
+import org.csstudio.swt.rtplot.RTPlotListener;
 import org.csstudio.swt.rtplot.data.PlotDataItem;
 import org.csstudio.swt.rtplot.undo.UndoableActionManager;
 import org.eclipse.jface.action.Action;
@@ -151,7 +152,7 @@ public class ToolbarHandler<XTYPE extends Comparable<XTYPE>>
             public void widgetSelected(final SelectionEvent e)
             {
                 new EditAnnotationDialog<XTYPE>(toolbar.getShell(), plot).open();
-                edit_annotation.setEnabled(! plot.getAnnotations().isEmpty());
+                edit_annotation.setEnabled(haveUserAnnotations());
             }
         });
         // Enable if there are annotations to remove
@@ -161,7 +162,7 @@ public class ToolbarHandler<XTYPE extends Comparable<XTYPE>>
             @Override
             public void changedAnnotations()
             {
-                edit_annotation.getDisplay().asyncExec(() -> edit_annotation.setEnabled(! plot.getAnnotations().isEmpty()));
+                edit_annotation.getDisplay().asyncExec(() -> edit_annotation.setEnabled(haveUserAnnotations()));
             }
         });
 
@@ -174,6 +175,15 @@ public class ToolbarHandler<XTYPE extends Comparable<XTYPE>>
                 plot.showCrosshair(crosshair.getSelection());
             }
         });
+    }
+
+    /** @return Are there any user (non-internal) annotations? */
+    private boolean haveUserAnnotations()
+    {
+        for (Annotation<XTYPE> annotation : plot.getAnnotations())
+            if (!annotation.isInternal())
+                return true;
+        return false;
     }
 
     private void addZoom()

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToolbarHandler.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToolbarHandler.java
@@ -162,7 +162,11 @@ public class ToolbarHandler<XTYPE extends Comparable<XTYPE>>
             @Override
             public void changedAnnotations()
             {
-                edit_annotation.getDisplay().asyncExec(() -> edit_annotation.setEnabled(haveUserAnnotations()));
+                edit_annotation.getDisplay().asyncExec(() ->
+                {
+                    if (! edit_annotation.isDisposed())
+                        edit_annotation.setEnabled(haveUserAnnotations());
+                });
             }
         });
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/util/UpdateThrottle.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/util/UpdateThrottle.java
@@ -114,7 +114,8 @@ public class UpdateThrottle
         timer.shutdown();
         try
         {
-            timer.awaitTermination(1, TimeUnit.SECONDS);
+            if (! timer.awaitTermination(2, TimeUnit.SECONDS))
+                Activator.getLogger().log(Level.WARNING, "Update thread didn't close down within two seconds");
         }
         catch (InterruptedException e)
         {

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/AnnotationInfo.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/AnnotationInfo.java
@@ -32,8 +32,8 @@ import org.w3c.dom.Element;
 @SuppressWarnings("nls")
 public class AnnotationInfo
 {
-    // TODO: "Transient" flag: Not saved. Cannot be edited */
-    final int item_index;
+    final private boolean internal;
+    final private int item_index;
     final private Instant time;
     final private double value;
     final private Point offset;
@@ -41,11 +41,23 @@ public class AnnotationInfo
 
     public AnnotationInfo(final int item_index, final Instant time, final double value, final Point offset, final String text)
     {
+        this(false, item_index, time, value, offset, text);
+    }
+
+    public AnnotationInfo(final boolean internal, final int item_index, final Instant time, final double value, final Point offset, final String text)
+    {
+        this.internal = internal;
         this.item_index = item_index;
         this.time = time;
         this.value = value;
         this.offset = offset;
         this.text = text;
+    }
+
+    /** @return Internal annotation, created by databrowser and not user? */
+    public boolean isInternal()
+    {
+        return internal;
     }
 
     /** @return Index of item */
@@ -82,7 +94,8 @@ public class AnnotationInfo
     public int hashCode()
     {
         final int prime = 31;
-        int result = item_index;
+        int result = internal ? prime : 0;
+        result = prime * result + item_index;
         result = prime * result + offset.hashCode();
         result = prime * result + text.hashCode();
         result = prime * result + time.hashCode();
@@ -100,7 +113,8 @@ public class AnnotationInfo
         if (! (obj instanceof AnnotationInfo))
             return false;
         final AnnotationInfo other = (AnnotationInfo) obj;
-        return item_index == other.item_index  &&
+        return internal == other.internal      &&
+               item_index == other.item_index  &&
                offset.equals(other.offset)     &&
                text.equals(other.text)         &&
                time.equals(other.time)         &&
@@ -110,7 +124,7 @@ public class AnnotationInfo
     @Override
     public String toString()
     {
-        return "Annotation for item " + item_index + ": '" + text + "' @ " + TimeHelper.format(time) + ", " + value;
+        return (internal ? "Internal Annotation for item " : "Annotation for item ") + item_index + ": '" + text + "' @ " + TimeHelper.format(time) + ", " + value;
     }
 
     /** Write XML formatted annotation configuration
@@ -118,6 +132,8 @@ public class AnnotationInfo
      */
     public void write(final PrintWriter writer)
     {
+        if (internal)
+            return;
         XMLWriter.start(writer, 2, XMLPersistence.TAG_ANNOTATION);
         writer.println();
         XMLWriter.XML(writer, 3, XMLPersistence.TAG_PV, item_index);

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/AnnotationInfo.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/AnnotationInfo.java
@@ -29,8 +29,10 @@ import org.w3c.dom.Element;
  *
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class AnnotationInfo
 {
+    // TODO: "Transient" flag: Not saved. Cannot be edited */
     final int item_index;
     final private Instant time;
     final private double value;
@@ -39,7 +41,6 @@ public class AnnotationInfo
 
     public AnnotationInfo(final int item_index, final Instant time, final double value, final Point offset, final String text)
     {
-
         this.item_index = item_index;
         this.time = time;
         this.value = value;
@@ -77,7 +78,35 @@ public class AnnotationInfo
         return text;
     }
 
-    @SuppressWarnings("nls")
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = item_index;
+        result = prime * result + offset.hashCode();
+        result = prime * result + text.hashCode();
+        result = prime * result + time.hashCode();
+        long temp;
+        temp = Double.doubleToLongBits(value);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (! (obj instanceof AnnotationInfo))
+            return false;
+        final AnnotationInfo other = (AnnotationInfo) obj;
+        return item_index == other.item_index  &&
+               offset.equals(other.offset)     &&
+               text.equals(other.text)         &&
+               time.equals(other.time)         &&
+               Double.doubleToLongBits(value) == Double.doubleToLongBits(other.value);
+    }
+
     @Override
     public String toString()
     {

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
@@ -537,8 +537,6 @@ public class Controller
                 if (changing_annotations)
                     return;
                 changing_annotations = true;
-                // TODO Remove
-                System.out.println("Controller: Update annotations in plot because model changed: " + model.getAnnotations());
                 plot.setAnnotations(model.getAnnotations());
                 changing_annotations = false;
             }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -10,6 +10,7 @@ package org.csstudio.trends.databrowser2.ui;
 import java.io.File;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -400,6 +401,29 @@ public class ModelBasedPlot
     public void setTimeRange(final Instant start, final Instant end)
     {
         display.asyncExec(() -> plot.getXAxis().setValueRange(start, end));
+    }
+
+    /** Set annotations in plot to match model's annotations
+     *  @param newAnnotations Annotations to show in plot
+     */
+    void setAnnotations(final Collection<AnnotationInfo> newAnnotations)
+    {
+        final List<Trace<Instant>> traces = new ArrayList<>();
+        for (Trace<Instant> trace : plot.getTraces())
+            traces.add(trace);
+
+        // Remove old annotations from plot
+        final List<Annotation<Instant>> plot_annotations = new ArrayList<>(plot.getAnnotations());
+        for (Annotation<Instant> old : plot_annotations)
+            plot.removeAnnotation(old);
+
+        // Set new annotations in plot
+        for (AnnotationInfo annotation : newAnnotations)
+            plot.addAnnotation(new Annotation<Instant>(traces.get(annotation.getItemIndex()),
+                                                       annotation.getTime(),
+                                                       annotation.getValue(),
+                                                       annotation.getOffset(),
+                                                       annotation.getText()));
     }
 
     /** Refresh the plot because the data has changed */

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -119,7 +119,8 @@ public class ModelBasedPlot
                 for (Annotation<Instant> annotation : plot.getAnnotations())
                 {
                     final int item_index = traces.indexOf(annotation.getTrace());
-                    annotations.add(new AnnotationInfo(item_index,
+                    annotations.add(new AnnotationInfo(annotation.isInternal(),
+                                                       item_index,
                                                        annotation.getPosition(), annotation.getValue(),
                                                        annotation.getOffset(), annotation.getText()));
                 }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -419,7 +419,8 @@ public class ModelBasedPlot
 
         // Set new annotations in plot
         for (AnnotationInfo annotation : newAnnotations)
-            plot.addAnnotation(new Annotation<Instant>(traces.get(annotation.getItemIndex()),
+            plot.addAnnotation(new Annotation<Instant>(annotation.isInternal(),
+                                                       traces.get(annotation.getItemIndex()),
                                                        annotation.getTime(),
                                                        annotation.getValue(),
                                                        annotation.getOffset(),

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
@@ -380,7 +380,6 @@ public class WaveformView extends DataBrowserAwareView
 
     private void removeAnnotation()
     {
-        System.out.println("WaveformView.removeAnnotation()"); // TODO remove
         final List<AnnotationInfo> modelAnnotations = new ArrayList<AnnotationInfo>(model.getAnnotations());
         if (modelAnnotations.remove(waveform_annotation))
         {
@@ -419,11 +418,9 @@ public class WaveformView extends DataBrowserAwareView
             }
             i++;
         }
-        waveform_annotation = new AnnotationInfo(item_index,
-                                                 sample.getPosition(),
-                                                 sample.getValue(),
-                                                 offset,
-                                                 ANNOTATION_TEXT);
+        waveform_annotation = new AnnotationInfo(true, item_index,
+                                                 sample.getPosition(), sample.getValue(),
+                                                 offset, ANNOTATION_TEXT);
         annotations.add(waveform_annotation);
         changing_annotations = true;
         model.setAnnotations(annotations);

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
@@ -261,6 +261,7 @@ public class WaveformView extends DataBrowserAwareView
     @Override
     protected void updateModel(final Model old_model, final Model model)
     {
+        removeAnnotation();
         this.model = model;
         if (old_model != model)
         {
@@ -428,12 +429,15 @@ public class WaveformView extends DataBrowserAwareView
 
     private void removeAnnotation()
     {
-        final List<AnnotationInfo> modelAnnotations = new ArrayList<AnnotationInfo>(model.getAnnotations());
-        if (modelAnnotations.remove(waveform_annotation))
+        if (model != null)
         {
-            changing_annotations = true;
-            model.setAnnotations(modelAnnotations);
-            changing_annotations = false;
+            final List<AnnotationInfo> modelAnnotations = new ArrayList<AnnotationInfo>(model.getAnnotations());
+            if (modelAnnotations.remove(waveform_annotation))
+            {
+                changing_annotations = true;
+                model.setAnnotations(modelAnnotations);
+                changing_annotations = false;
+            }
         }
         waveform_annotation = null;
     }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
@@ -138,10 +138,9 @@ public class WaveformView extends DataBrowserAwareView
         @Override
         public void changedTimerange()
         {
-            // TODO Why?
-            System.out.println("WaveformView: Plot changed timerange...");
-//            if (model_item != null)
-//                showSelectedSample();
+            // Update selected sample to assert that it's one of the visible ones.
+            if (model_item != null)
+                showSelectedSample();
         }
     };
 

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
@@ -441,8 +441,8 @@ public class WaveformView extends DataBrowserAwareView
     private void updateAnnotation(final Instant time, final double value)
     {
         final List<AnnotationInfo> annotations = new ArrayList<AnnotationInfo>(model.getAnnotations());
-        // Start annotation somewhat above the sample
-        Point offset = new Point(-30, -30);
+        // Initial annotation offset
+        Point offset = new Point(20, -20);
         // If already in model, note its offset and remove
         for (AnnotationInfo annotation : annotations)
         {

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
@@ -261,6 +261,8 @@ public class WaveformView extends DataBrowserAwareView
     @Override
     protected void updateModel(final Model old_model, final Model model)
     {
+        if (this.model == model)
+            return;
         removeAnnotation();
         this.model = model;
         if (old_model != model)


### PR DESCRIPTION
@willrogers , this is based on your code from #1993, to fix #1980, part of #1970.
Currently selected waveform sample is again indicated by annotation in plot, plus
 * That annotation cannot be deleted or edited by the user, it's not saved in the *.plt file
 * User can move the annotation, whereupon the selected waveform is updated
 * Added flags to break loops between model and plot updates

Not implemented: Some visual indication for offscreen annotations, as the suggested arrow on left resp. right side of plot. That would be a general update to the annotation rendering, not specific to waveforms, so can be done in different update.