### PR TITLE
Symbol widget incorrect flip

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/src/org/csstudio/opibuilder/widgets/symbol/bool/CommonBoolSymbolEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/src/org/csstudio/opibuilder/widgets/symbol/bool/CommonBoolSymbolEditpart.java
@@ -297,6 +297,8 @@ public abstract class CommonBoolSymbolEditpart extends AbstractBoolEditPart {
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 CommonBoolSymbolFigure imageFigure = (CommonBoolSymbolFigure) figure;
                 int newDegree = (Integer) newValue;
                 int oldDegree = (Integer) oldValue;
@@ -320,6 +322,8 @@ public abstract class CommonBoolSymbolEditpart extends AbstractBoolEditPart {
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 CommonBoolSymbolFigure imageFigure = (CommonBoolSymbolFigure) figure;
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipHMatrix();
                 PermutationMatrix oldMatrix = imageFigure.getPermutationMatrix();
@@ -339,6 +343,8 @@ public abstract class CommonBoolSymbolEditpart extends AbstractBoolEditPart {
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 CommonBoolSymbolFigure imageFigure = (CommonBoolSymbolFigure) figure;
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipVMatrix();
                 PermutationMatrix oldMatrix = imageFigure.getPermutationMatrix();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/src/org/csstudio/opibuilder/widgets/symbol/bool/ControlBoolSymbolEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/src/org/csstudio/opibuilder/widgets/symbol/bool/ControlBoolSymbolEditpart.java
@@ -314,6 +314,8 @@ public class ControlBoolSymbolEditpart extends AbstractBoolControlEditPart {
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 ControlBoolSymbolFigure imageFigure = (ControlBoolSymbolFigure) figure;
                 int newDegree = (Integer) newValue;
                 int oldDegree = (Integer) oldValue;
@@ -338,6 +340,8 @@ public class ControlBoolSymbolEditpart extends AbstractBoolControlEditPart {
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 ControlBoolSymbolFigure imageFigure = (ControlBoolSymbolFigure) figure;
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipHMatrix();
                 PermutationMatrix oldMatrix = imageFigure.getPermutationMatrix();
@@ -357,6 +361,8 @@ public class ControlBoolSymbolEditpart extends AbstractBoolControlEditPart {
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 ControlBoolSymbolFigure imageFigure = (ControlBoolSymbolFigure) figure;
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipVMatrix();
                 PermutationMatrix oldMatrix = imageFigure.getPermutationMatrix();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/src/org/csstudio/opibuilder/widgets/symbol/multistate/CommonMultiSymbolEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets.symbol/src/org/csstudio/opibuilder/widgets/symbol/multistate/CommonMultiSymbolEditPart.java
@@ -446,6 +446,8 @@ public abstract class CommonMultiSymbolEditPart extends AbstractPVWidgetEditPart
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 CommonMultiSymbolFigure imageFigure = (CommonMultiSymbolFigure) figure;
                 int newDegree = (Integer) newValue;
                 int oldDegree = (Integer) oldValue;
@@ -470,6 +472,8 @@ public abstract class CommonMultiSymbolEditPart extends AbstractPVWidgetEditPart
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 CommonMultiSymbolFigure imageFigure = (CommonMultiSymbolFigure) figure;
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipHMatrix();
                 PermutationMatrix oldMatrix = imageFigure.getPermutationMatrix();
@@ -489,6 +493,8 @@ public abstract class CommonMultiSymbolEditPart extends AbstractPVWidgetEditPart
             @Override
             public boolean handleChange(final Object oldValue,
                     final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 CommonMultiSymbolFigure imageFigure = (CommonMultiSymbolFigure) figure;
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipVMatrix();
                 PermutationMatrix oldMatrix = imageFigure.getPermutationMatrix();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ImageEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ImageEditPart.java
@@ -285,6 +285,8 @@ public final class ImageEditPart extends AbstractWidgetEditPart {
         IWidgetPropertyChangeHandler handler = new IWidgetPropertyChangeHandler() {
             @Override
             public boolean handleChange(final Object oldValue, final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 ImageFigure imageFigure = (ImageFigure) figure;
                 int newDegree = getWidgetModel().getDegree((Integer) newValue);
                 int oldDegree = getWidgetModel().getDegree((Integer) oldValue);
@@ -312,6 +314,8 @@ public final class ImageEditPart extends AbstractWidgetEditPart {
         handler = new IWidgetPropertyChangeHandler() {
             @Override
             public boolean handleChange(final Object oldValue, final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 ImageFigure imageFigure = (ImageFigure) figure;
                 // imageFigure.setFlipH((Boolean) newValue);
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipHMatrix();
@@ -335,6 +339,8 @@ public final class ImageEditPart extends AbstractWidgetEditPart {
         handler = new IWidgetPropertyChangeHandler() {
             @Override
             public boolean handleChange(final Object oldValue, final Object newValue, final IFigure figure) {
+                if (oldValue == null || newValue == null)
+                    return false;
                 ImageFigure imageFigure = (ImageFigure) figure;
                 // imageFigure.setFlipV((Boolean) newValue);
                 PermutationMatrix newMatrix = PermutationMatrix.generateFlipVMatrix();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/properties/RulesProperty.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/properties/RulesProperty.java
@@ -172,9 +172,9 @@ public class RulesProperty extends AbstractWidgetProperty {
                         valueElement.setText(exp.getValue().toString());
                     else{
                         Object savedValue = ruleData.getProperty().getPropertyValue();
-                        ruleData.getProperty().setPropertyValue(exp.getValue());
+                        ruleData.getProperty().setPropertyValue_IgnoreOldValue(exp.getValue());
                         ruleData.getProperty().writeToXML(valueElement);
-                        ruleData.getProperty().setPropertyValue(savedValue);
+                        ruleData.getProperty().setPropertyValue_IgnoreOldValue(savedValue);
                     }
                     expElement.addContent(valueElement);
                     ruleElement.addContent(expElement);


### PR DESCRIPTION
Ignore old value while setting the properties in RuleProperty.
And handling null in all the handleChange implementations of the listeners.

Fix for #2009 