### PR TITLE
Databrowser: handle misconfiguration and log error.

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/preferences/Preferences.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/preferences/Preferences.java
@@ -208,7 +208,7 @@ public class Preferences
             }
             catch (Throwable ex)
             {
-                throw new Error("Error in archive preference '" + spec + "'");
+                Activator.getLogger().log(Level.WARNING, "Misconfigured archive data source: " + spec, ex);
             }
         }
         return archives.toArray(new ArchiveDataSource[archives.size()]);


### PR DESCRIPTION
See #1999.

If there is a problem with configuration of the default data sources, the Archive Search View won't render properly.  However, in other cases the same exception is unhandled as well.  So better to log a warning at the time and continue than to throw an unhandled exception.