### PR TITLE
Databrowser: autoscale only to data visible in the plot.

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -49,11 +49,13 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
         this.plot = plot;
     }
 
-    /** Submit background job to determine value range
+    /** Submit background job to determine value range for y axis for values within the
+     * specified x axis.
      *  @param data {@link PlotDataProvider} with values
+     *  @param x_range {@link AxisRange} covering visible part of plot
      *  @return {@link Future} to {@link ValueRange}
      */
-    public Future<ValueRange> determineValueRange(final PlotDataProvider<XTYPE> data)
+    public Future<ValueRange> determineValueRange(final PlotDataProvider<XTYPE> data, final AxisRange<XTYPE> x_range)
     {
         return thread_pool.submit(new Callable<ValueRange>()
         {
@@ -69,13 +71,17 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                     for (int i=0; i<N; ++i)
                     {
                         final PlotDataItem<XTYPE> item = data.get(i);
-                        final double value = item.getValue();
-                        if (! Double.isFinite(value))
-                            continue;
-                        if (value < low)
-                            low = value;
-                        if (value > high)
-                            high = value;
+                        if (item.getPosition().compareTo(x_range.getLow()) > 0 &&
+                                item.getPosition().compareTo(x_range.getHigh()) < 0)
+                        {
+                            final double value = item.getValue();
+                            if (! Double.isFinite(value))
+                                continue;
+                            if (value < low)
+                                low = value;
+                            if (value > high)
+                                high = value;
+                        }
                     }
                 }
                 finally
@@ -89,9 +95,10 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
 
     /** Submit background job to determine value range
      *  @param axis {@link YAxisImpl} for which to determine range
+     *  @param x_axis {@link AxisRange} over which range is to be determined
      *  @return {@link Future} to {@link ValueRange}
      */
-    public Future<ValueRange> determineValueRange(final YAxisImpl<XTYPE> axis)
+    public Future<ValueRange> determineValueRange(final YAxisImpl<XTYPE> axis, final AxisPart<XTYPE> x_axis)
     {
         return thread_pool.submit(new Callable<ValueRange>()
         {
@@ -101,7 +108,7 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                 // In parallel, determine range of all traces in this axis
                 final List<Future<ValueRange>> ranges = new ArrayList<Future<ValueRange>>();
                 for (Trace<XTYPE> trace : axis.getTraces())
-                    ranges.add(determineValueRange(trace.getData()));
+                    ranges.add(determineValueRange(trace.getData(), x_axis.getValueRange()));
 
                 // Merge the trace ranges into overall axis range
                 double low = Double.MAX_VALUE;
@@ -147,7 +154,6 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
         thread_pool.execute(() ->
         {
             final double GAP = 0.1;
-
             // Arrange all axes so they don't overlap by assigning 1/Nth of
             // the vertical range to each one
             // Determine range of each axes' traces in parallel
@@ -161,7 +167,7 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                 // As fallback, assume that new range matches old range
                 new_ranges.add(axis.getValueRange());
                 original_ranges.add(axis.getValueRange());
-                ranges.add(determineValueRange(axis));
+                ranges.add(determineValueRange(axis, plot.getXAxis()));
             }
             final int N = y_axes.size();
             for (int i=0; i<N; ++i)
@@ -346,7 +352,10 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
         });
     }
 
-    /** Perform autoscale for all axes that are marked as such */
+    /**
+     * Perform autoscale for all axes that are marked as such.
+     * Autoscale only for the data that is visible on the plot.
+     */
     public void autoscale()
     {
         // Determine range of each axes' traces in parallel
@@ -356,7 +365,7 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
             if (axis.isAutoscale())
             {
                 y_axes.add(axis);
-                ranges.add(determineValueRange(axis));
+                ranges.add(determineValueRange(axis, plot.getXAxis()));
             }
         final int N = y_axes.size();
         for (int i=0; i<N; ++i)

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -71,8 +71,7 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                     for (int i=0; i<N; ++i)
                     {
                         final PlotDataItem<XTYPE> item = data.get(i);
-                        if (item.getPosition().compareTo(x_range.getLow()) > 0 &&
-                                item.getPosition().compareTo(x_range.getHigh()) < 0)
+                        if (x_range.contains(item.getPosition()))
                         {
                             final double value = item.getValue();
                             if (! Double.isFinite(value))


### PR DESCRIPTION
The previous behaviour was to autoscale according to all the data in a
trace, even if that had scrolled off the left-hand side of the plot.

@kasemir see #2017.