### PR TITLE
Opibuilder: optionally use pixels to specify font height.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LabelEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/LabelEditPart.java
@@ -43,6 +43,7 @@ public class LabelEditPart extends AbstractWidgetEditPart {
         labelFigure.setVerticalAlignment(getWidgetModel().getVerticalAlignment());
         labelFigure.setSelectable(determinSelectable());
         labelFigure.setText(getWidgetModel().getText());
+        labelFigure.setFontPixels(getWidgetModel().getFontPixels());
         if(labelFigure instanceof WrappableTextFigure)
             ((WrappableTextFigure) labelFigure).setShowScrollbar(getWidgetModel().isShowScrollbar());
         updatePropertyVisibility();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/SpinnerEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/SpinnerEditpart.java
@@ -56,6 +56,7 @@ public class SpinnerEditpart extends AbstractPVWidgetEditPart {
         labelFigure.setOpaque(!getWidgetModel().isTransparent());
         labelFigure.setHorizontalAlignment(getWidgetModel().getHorizontalAlignment());
         labelFigure.setVerticalAlignment(getWidgetModel().getVerticalAlignment());
+        labelFigure.setFontPixels(getWidgetModel().getFontPixels());
         spinner.setMax(getWidgetModel().getMaximum());
         spinner.setMin(getWidgetModel().getMinimum());
         spinner.setStepIncrement(getWidgetModel().getStepIncrement());

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/TextUpdateEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/TextUpdateEditPart.java
@@ -85,6 +85,7 @@ public class TextUpdateEditPart extends AbstractPVWidgetEditPart {
         labelFigure.setHorizontalAlignment(widgetModel.getHorizontalAlignment());
         labelFigure.setVerticalAlignment(widgetModel.getVerticalAlignment());
         labelFigure.setRotate(widgetModel.getRotationAngle());
+        labelFigure.setFontPixels(widgetModel.getFontPixels());
     }
 
     /**

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/TabModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/TabModel.java
@@ -100,6 +100,7 @@ public class TabModel extends AbstractContainerModel {
         addProperty(new IntegerProperty(PROP_MINIMUM_TAB_HEIGHT, "Minimum Tab Height",
                 WidgetPropertyCategory.Display, 10, 10, 1000));
         setPropertyVisible(PROP_FONT, false);
+        setPropertyVisible(PROP_FONT_PIXELS, false);
         addTabsProperties();
     }
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/WebBrowserModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/WebBrowserModel.java
@@ -38,6 +38,7 @@ public class WebBrowserModel extends AbstractWidgetModel {
         addProperty(new BooleanProperty(PROP_SHOW_TOOLBAR, "Show Toolbar",
                 WidgetPropertyCategory.Display, true));
         setPropertyVisible(PROP_FONT, false);
+        setPropertyVisible(PROP_FONT_PIXELS, false);
     }
 
     public String getURL(){

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/XYGraphModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/model/XYGraphModel.java
@@ -221,6 +221,7 @@ public class XYGraphModel extends AbstractPVWidgetModel {
         addAxisProperties();
         addTraceProperties();
         setPropertyVisible(PROP_FONT, false);
+        setPropertyVisible(PROP_FONT_PIXELS, false);
     }
 
     @Override

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
@@ -49,7 +49,6 @@ import org.csstudio.opibuilder.util.BOYPVFactory;
 import org.csstudio.opibuilder.util.ConsoleService;
 import org.csstudio.opibuilder.util.OPIBuilderMacroUtil;
 import org.csstudio.opibuilder.util.OPIColor;
-import org.csstudio.opibuilder.util.OPIFont;
 import org.csstudio.opibuilder.util.SingleSourceHelper;
 import org.csstudio.opibuilder.visualparts.BorderFactory;
 import org.csstudio.opibuilder.visualparts.TooltipLabel;
@@ -80,6 +79,9 @@ import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.gef.requests.DropRequest;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionFilter;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.progress.UIJob;
@@ -281,6 +283,20 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
                 getWidgetModel().getBorderWidth(), getWidgetModel().getBorderColor(),
                 getWidgetModel().getName());
     }
+
+    public Font calculateFont() {
+        Font font = getWidgetModel().getFont().getSWTFont();
+        boolean pixels = getWidgetModel().getFontPixels();
+        if (pixels) {
+            FontData fontData = font.getFontData()[0];
+            int configuredSize = fontData.getHeight();
+            int heightInPoints = (configuredSize * 72) / Display.getDefault().getDPI().y;
+            fontData.setHeight(heightInPoints);
+            font = new Font(font.getDevice(), fontData);
+        }
+        return font;
+    }
+
 
     protected ConnectionHandler createConnectionHandler() {
         return new ConnectionHandler(this);
@@ -536,7 +552,7 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
                     .getColor(getWidgetModel().getForegroundColor()));
 
         if (allPropIds.contains(AbstractWidgetModel.PROP_FONT))
-            figure.setFont(getWidgetModel().getFont().getSWTFont());
+            figure.setFont(calculateFont());
 
         if (allPropIds.contains(AbstractWidgetModel.PROP_VISIBLE))
             figure.setVisible(getExecutionMode() == ExecutionMode.RUN_MODE ? getWidgetModel()
@@ -642,11 +658,12 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
             @Override
             public boolean handleChange(Object oldValue, Object newValue,
                     IFigure figure) {
-                figure.setFont(((OPIFont) newValue).getSWTFont());
+                figure.setFont(calculateFont());
                 return false;
             }
         };
         setPropertyChangeHandler(AbstractWidgetModel.PROP_FONT, fontHandler);
+        setPropertyChangeHandler(AbstractWidgetModel.PROP_FONT_PIXELS, fontHandler);
 
         IWidgetPropertyChangeHandler borderHandler = new IWidgetPropertyChangeHandler() {
             @Override

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractWidgetModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/AbstractWidgetModel.java
@@ -136,9 +136,14 @@ public abstract class AbstractWidgetModel implements IAdaptable,
     public static final String PROP_COLOR_FOREGROUND = "foreground_color";//$NON-NLS-1$
 
     /**
-     * Foreground color.
+     * Font.
      */
     public static final String PROP_FONT = "font";//$NON-NLS-1$
+
+    /**
+     * Whether to interpret font height in pixels rather than points.
+     */
+    public static final String PROP_FONT_PIXELS = "font_pixels";//$NON-NLS-1$
 
     /**
      * Visibility of the widget.
@@ -339,6 +344,8 @@ public abstract class AbstractWidgetModel implements IAdaptable,
                 WidgetPropertyCategory.Display, new RGB(192, 192, 192)));
         addProperty(new FontProperty(PROP_FONT, "Font",
                 WidgetPropertyCategory.Display, MediaService.DEFAULT_FONT));
+        addProperty(new BooleanProperty(PROP_FONT_PIXELS, "Font Pixels",
+                WidgetPropertyCategory.Display, false));
         addProperty(new ColorProperty(PROP_BORDER_COLOR, "Border Color",
                 WidgetPropertyCategory.Border, new RGB(0, 128, 255)));
         addProperty(new ComboProperty(PROP_BORDER_STYLE,"Border Style",
@@ -472,6 +479,10 @@ public abstract class AbstractWidgetModel implements IAdaptable,
 
     public OPIFont getFont(){
         return (OPIFont)getPropertyValue(PROP_FONT);
+    }
+
+    public boolean getFontPixels(){
+        return (boolean)getPropertyValue(PROP_FONT_PIXELS);
     }
 
     public RGB getForegroundColor(){

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/model/DisplayModel.java
@@ -157,6 +157,7 @@ public class DisplayModel extends AbstractContainerModel {
         setPropertyVisible(PROP_TOOLTIP, false);
         setPropertyVisible(PROP_ACTIONS, false);
         setPropertyVisible(PROP_FONT, false);
+        setPropertyVisible(PROP_FONT_PIXELS, false);
         setPropertyVisibleAndSavable(PROP_FRAME_RATE, false, false);
         setPropertyVisibleAndSavable(PROP_BOY_VERSION, false, true);
         addProperty(new ActionsProperty(PROP_ACTIONS, "Actions",

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/TextFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/TextFigure.java
@@ -35,6 +35,8 @@ public class TextFigure extends Figure implements Introspectable, ITextFigure{
     protected V_ALIGN verticalAlignment = V_ALIGN.TOP;
     protected H_ALIGN horizontalAlignment = H_ALIGN.LEFT;
 
+    protected boolean fontPixels = false;
+
     protected boolean runMode;
 
     protected boolean selectable = true;
@@ -323,12 +325,15 @@ public class TextFigure extends Figure implements Introspectable, ITextFigure{
         Font font = realFont;
 
         int i=0;
-        //shrink font size to fit the figure.
-        while(h > (clientArea.height+2) && h > 10 && i++<20){
-            FontData fd = font.getFontData()[0];
-            fd.setHeight(fd.getHeight()-1);
-            font = CustomMediaFactory.getInstance().getFont(fd);
-            h = getTextSize(font).height;
+        // Shrink font size to fit the figure, if fonts are not
+        // explicitly sized by pixel.
+        if (! fontPixels) {
+            while(h > (clientArea.height+2) && h > 10 && i++<20){
+                FontData fd = font.getFontData()[0];
+                fd.setHeight(fd.getHeight()-1);
+                font = CustomMediaFactory.getInstance().getFont(fd);
+                h = getTextSize(font).height;
+            }
         }
         realFont = font;
         graphics.setFont(font);
@@ -351,8 +356,6 @@ public class TextFigure extends Figure implements Introspectable, ITextFigure{
                 }
             }
         }
-
-
         graphics.translate(-textArea.x, -textArea.y);
     }
 
@@ -360,6 +363,14 @@ public class TextFigure extends Figure implements Introspectable, ITextFigure{
     public void setFont(Font f) {
         realFont = f;
         super.setFont(f);
+    }
+
+    public void setFontPixels(boolean fontPixels) {
+        if(this.fontPixels == fontPixels)
+            return;
+        this.fontPixels = fontPixels;
+        revalidate();
+        repaint();
     }
 
     @Override


### PR DESCRIPTION
For discussion - I haven't tried to make this perfect since it may be necessary to alter the strategy.

In particular, some widgets have additional configurable fonts that would need the additional property.

See #1990.