### PR TITLE
Databrowser: avoid deadlocks taking snapshots (4.3)

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -427,11 +427,27 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
     /** @return {@link Image} of current plot. Caller must dispose */
     public Image getImage()
     {
-        Image image = plot_image.orElse(null);
-        if (image != null)
-            synchronized (image)
+        // Using locking to protect plot_image can cause deadlocks due to a
+        // bug in SWT: https://bugs.eclipse.org/bugs/show_bug.cgi?id=265265
+        // Instead, just try again if the image was disposed.
+        // Is there still a canvas that will generate an image?
+        if (! isDisposed())
+            while (true)
             {
-                return new Image(display, image, SWT.IMAGE_COPY);
+                Image image = plot_image.orElse(null);
+                if (image == null)
+                    break;
+                try
+                {
+                    return new Image(display, image, SWT.IMAGE_COPY);
+                }
+                catch (Throwable ex)
+                {
+                    // If image was disposed, try again
+                    // Otherwise give up
+                    if (! image.isDisposed())
+                        break;
+                }
             }
         return new Image(display, 10, 10);
     }


### PR DESCRIPTION
Creating SWT Images on background threads can cause deadlocks:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=265265
Here just try again if the cause of exception was image being
disposed, since it will be refreshed.

See #1988; porting fix to 4.3 branch.