### PR TITLE
OPIBuilder: do not allow keyboard traversal of controls.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figureparts/ROIFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figureparts/ROIFigure.java
@@ -335,8 +335,6 @@ public class ROIFigure extends Figure {
             ROIRectDragger roiRectDragger = new ROIRectDragger();
             roiRectFigure.addMouseListener(roiRectDragger);
             roiRectFigure.addMouseMotionListener(roiRectDragger);
-            setFocusTraversable(true);
-            setRequestFocusEnabled(true);
             resizeHandlers = new ResizeHandler[HANDLERS_COUNT];
             add(roiRectFigure);
             for(int i=0; i<HANDLERS_COUNT; i++){

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ActionButtonFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ActionButtonFigure.java
@@ -111,9 +111,6 @@ public class ActionButtonFigure extends Figure implements Introspectable, ITextF
         mousePressed = false;
         listeners = new ArrayList<ButtonActionListener>();
 
-        setRequestFocusEnabled(true);
-        setFocusTraversable(true);
-
         setLayoutManager(new StackLayout());
 
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/IntensityGraphFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/IntensityGraphFigure.java
@@ -756,8 +756,6 @@ public class IntensityGraphFigure extends Figure implements Introspectable {
         add(yAxis);
 
         roiMap = new HashMap<String, ROIFigure>(2);
-        setFocusTraversable(true);
-        setRequestFocusEnabled(true);
     }
 
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
@@ -132,8 +132,6 @@ public class ScaledSliderFigure extends AbstractLinearMarkedFigure {
             }
         });
 
-        setRequestFocusEnabled(true);
-        setFocusTraversable(true);
         addKeyListener(new KeyListener() {
 
                 public void keyPressed(KeyEvent ke) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScrollbarFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScrollbarFigure.java
@@ -264,8 +264,6 @@ public class ScrollbarFigure extends Figure implements Orientable, Introspectabl
         };
         clickable.setOpaque(true);
         clickable.setBackgroundColor(COLOR_TRACK);
-        clickable.setRequestFocusEnabled(false);
-        clickable.setFocusTraversable(false);
         clickable.addChangeListener(new ChangeListener() {
             public void handleStateChanged(ChangeEvent evt) {
                 if (clickable.getModel().isArmed())
@@ -365,8 +363,6 @@ public class ScrollbarFigure extends Figure implements Orientable, Introspectabl
      *
      */
     private void initializeListeners() {
-        setRequestFocusEnabled(true);
-        setFocusTraversable(true);
         addKeyListener(new KeyListener() {
 
                 public void keyPressed(KeyEvent ke) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/SpinnerFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/SpinnerFigure.java
@@ -95,8 +95,6 @@ public class SpinnerFigure extends Figure implements Introspectable {
     public SpinnerFigure() {
         formatType = NumericFormatType.DECIMAL;
         spinnerListeners = new ArrayList<IManualValueChangeListener>();
-        setRequestFocusEnabled(true);
-        setFocusTraversable(true);
         addKeyListener(new KeyListener() {
             @Override
             public void keyPressed(KeyEvent ke) {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ThumbWheelFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ThumbWheelFigure.java
@@ -190,10 +190,8 @@ public class ThumbWheelFigure extends Figure implements Introspectable{
 
             add(down, BorderLayout.BOTTOM);
 
-            // Enable focusing and key operation only in run mode.
+            // Enable key operation only in run mode.
             if (runmode) {
-                setRequestFocusEnabled(true);
-                setFocusTraversable(true);
 
                 // When the user clicks this figure, the focus is requested so that
                 // this widget can get key events.


### PR DESCRIPTION
This leads to unexpected controls being enabled by space or enter.  In
practice, keyboard traversal was not working correctly.

See #2038.