### PR TITLE
Remove duplicated Maven parent IDs.

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/pom.xml
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>alarm-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 

--- a/applications/alarm/alarm-plugins/pom.xml
+++ b/applications/alarm/alarm-plugins/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>alarm</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>alarm-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/appunorganized/appunorganized-features/org.csstudio.email.feature/pom.xml
+++ b/applications/appunorganized/appunorganized-features/org.csstudio.email.feature/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.email.feature</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/applications/appunorganized/appunorganized-features/org.csstudio.graphene.feature/pom.xml
+++ b/applications/appunorganized/appunorganized-features/org.csstudio.graphene.feature/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.graphene.feature</artifactId>
   <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/applications/appunorganized/appunorganized-features/org.csstudio.utilities.debugging.feature/pom.xml
+++ b/applications/appunorganized/appunorganized-features/org.csstudio.utilities.debugging.feature/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utilities.debugging.feature</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/applications/appunorganized/appunorganized-features/org.csstudio.utilities.feature/pom.xml
+++ b/applications/appunorganized/appunorganized-features/org.csstudio.utilities.feature/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utilities.feature</artifactId>
   <version>3.2.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/applications/appunorganized/appunorganized-features/org.csstudio.utilities.rap.feature/pom.xml
+++ b/applications/appunorganized/appunorganized-features/org.csstudio.utilities.rap.feature/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utilities.rap.feature</artifactId>
   <version>3.2.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/applications/appunorganized/appunorganized-features/org.eclipse.nebula.widgets.grid.feature/pom.xml
+++ b/applications/appunorganized/appunorganized-features/org.eclipse.nebula.widgets.grid.feature/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.eclipse.nebula.widgets.grid.feature</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.debugging.rdbshell/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.debugging.rdbshell/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.debugging.rdbshell</artifactId>
   <version>3.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.email.test/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.email.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.email.test</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.email.ui/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.email.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.email.ui</artifactId>
   <version>1.0.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.email/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.email/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.email</artifactId>
   <version>1.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.examples/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.examples/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.examples</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.graphene.opiwidgets/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.graphene.opiwidgets/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.graphene.opiwidgets</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.graphene/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.graphene/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.graphene</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.rap.rtplot/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.rap.rtplot/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.rap.rtplot</artifactId>
   <version>1.2.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.service.channelfinder/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.service.channelfinder/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.service.channelfinder</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.service.math/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.service.math/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.service.math</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.snl.intro/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.snl.intro/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.snl.intro</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.chart/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.chart/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.chart</artifactId>
   <version>3.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot.test/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.rtplot.test</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.rtplot</artifactId>
   <version>1.6.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph.rap/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph.rap/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.xygraph.rap</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph.rcp/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph.rcp/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.xygraph.rcp</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph.test/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.xygraph.test</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.swt.xygraph</artifactId>
   <version>2.0.5-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.utility.pv.ui/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.utility.pv.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>appunorganized-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.pv.ui</artifactId>
   <version>1.0.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/appunorganized/appunorganized-plugins/pom.xml
+++ b/applications/appunorganized/appunorganized-plugins/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>appunorganized</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>appunorganized-plugins</artifactId>
   <packaging>pom</packaging>
   <modules>

--- a/applications/archive/archive-plugins/pom.xml
+++ b/applications/archive/archive-plugins/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>archive</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>archive-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/channel/channel-features/pom.xml
+++ b/applications/channel/channel-features/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>channel</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>channel-features</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/channel/channel-plugins/org.csstudio.pvmanager.formula.channelfinder/pom.xml
+++ b/applications/channel/channel-plugins/org.csstudio.pvmanager.formula.channelfinder/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>channel-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.pvmanager.formula.channelfinder</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/channel/channel-plugins/pom.xml
+++ b/applications/channel/channel-plugins/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>channel</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>channel-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/databrowser/databrowser-plugins/pom.xml
+++ b/applications/databrowser/databrowser-plugins/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>databrowser</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>databrowser-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/display/display-plugins/pom.xml
+++ b/applications/display/display-plugins/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>display</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>display-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/logbook/logbook-plugins/org.csstudio.autocomplete.logbook/pom.xml
+++ b/applications/logbook/logbook-plugins/org.csstudio.autocomplete.logbook/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>logbook-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.autocomplete.logbook</artifactId>
   <version>1.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/opibuilder/opibuilder-plugins/pom.xml
+++ b/applications/opibuilder/opibuilder-plugins/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>opibuilder</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>opibuilder-plugins</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/saverestore/saverestore-plugins/pom.xml
+++ b/applications/saverestore/saverestore-plugins/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>save-set-restore</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>save-set-restore-plugins</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/scan/scan-plugins/pom.xml
+++ b/applications/scan/scan-plugins/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>scan</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>scan-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/applications/shift/shift-plugins/org.csstudio.utility.shift.ui/pom.xml
+++ b/applications/shift/shift-plugins/org.csstudio.utility.shift.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>shift-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.shift.ui</artifactId>
   <version>1.0.4-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/shift/shift-plugins/org.csstudio.utility.shift/pom.xml
+++ b/applications/shift/shift-plugins/org.csstudio.utility.shift/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>shift-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.shift</artifactId>
   <version>1.0.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/applications/snl/snl-plugins/pom.xml
+++ b/applications/snl/snl-plugins/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>snl</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>snl-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/core/base/base-features/org.csstudio.core.base.feature/pom.xml
+++ b/core/base/base-features/org.csstudio.core.base.feature/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>base-features</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.core.base.feature</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/core/base/base-plugins/org.csstudio.vtype.pv.test/pom.xml
+++ b/core/base/base-plugins/org.csstudio.vtype.pv.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>base-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <version>4.0.4-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 

--- a/core/base/base-plugins/org.csstudio.vtype.pv.ui/pom.xml
+++ b/core/base/base-plugins/org.csstudio.vtype.pv.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>base-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.vtype.pv.ui</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/base/base-plugins/org.csstudio.vtype.pv/pom.xml
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>base-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.vtype.pv</artifactId>
   <version>4.0.4-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/base/base-plugins/pom.xml
+++ b/core/base/base-plugins/pom.xml
@@ -18,6 +18,5 @@
     <module>org.csstudio.vtype.pv.ui</module>
     <module>org.csstudio.workspace</module>
   </modules>
-  <groupId>org.csstudio</groupId>
   <version>0.0.1-SNAPSHOT</version>
 </project>

--- a/core/base/pom.xml
+++ b/core/base/pom.xml
@@ -13,5 +13,4 @@
   <module>base-features</module>
   <module>base-repository</module>
   </modules>
-  <groupId>org.csstudio</groupId>
 </project>

--- a/core/diirt/diirt-features/org.csstudio.core.diirt.feature/pom.xml
+++ b/core/diirt/diirt-features/org.csstudio.core.diirt.feature/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>diirt-features</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.core.diirt.feature</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/pom.xml
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.preferences/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>diirt-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.diirt.util.preferences</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util/pom.xml
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>diirt-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.diirt.util</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/platform/platform-features/org.csstudio.core.platform.feature/pom.xml
+++ b/core/platform/platform-features/org.csstudio.core.platform.feature/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>platform-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.core.platform.feature</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/core/platform/platform-features/org.csstudio.core.platform.rap.feature/pom.xml
+++ b/core/platform/platform-features/org.csstudio.core.platform.rap.feature/pom.xml
@@ -5,7 +5,6 @@
     <artifactId>platform-features</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.core.platform.rap.feature</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>

--- a/core/platform/platform-plugins/org.csstudio.platform.libs.epics.ui/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.platform.libs.epics.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>platform-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.platform.libs.epics.ui</artifactId>
   <version>1.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/platform/platform-plugins/org.csstudio.platform.libs.hibernate.ui/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.platform.libs.hibernate.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>platform-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.platform.libs.hibernate.ui</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/platform/platform-plugins/org.csstudio.platform.utility.jms.test/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.platform.utility.jms.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>platform-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 

--- a/core/platform/platform-plugins/org.csstudio.platform.utility.jms.ui/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.platform.utility.jms.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>platform-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.platform.utility.jms.ui</artifactId>
   <version>1.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/platform/platform-plugins/org.csstudio.platform.utility.jms/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.platform.utility.jms/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>platform-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.platform.utility.jms</artifactId>
   <version>1.1.3-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/platform/platform-plugins/org.csstudio.platform.utility.rdb.test/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.platform.utility.rdb.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>platform-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 

--- a/core/platform/platform-plugins/org.csstudio.platform.utility.rdb/pom.xml
+++ b/core/platform/platform-plugins/org.csstudio.platform.utility.rdb/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>platform-plugins</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.platform.utility.rdb</artifactId>
   <version>1.6.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/ui/ui-plugins/org.csstudio.ui.help/pom.xml
+++ b/core/ui/ui-plugins/org.csstudio.ui.help/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>ui-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.ui.help</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/ui/ui-plugins/org.csstudio.ui.menu/pom.xml
+++ b/core/ui/ui-plugins/org.csstudio.ui.menu/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>ui-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.ui.menu</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/ui/ui-plugins/org.csstudio.ui.preferences/pom.xml
+++ b/core/ui/ui-plugins/org.csstudio.ui.preferences/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>ui-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.ui.preferences</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/ui/ui-plugins/org.csstudio.ui.resources/pom.xml
+++ b/core/ui/ui-plugins/org.csstudio.ui.resources/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>ui-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.ui.resources</artifactId>
   <version>1.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/ui/ui-plugins/org.csstudio.ui.util/pom.xml
+++ b/core/ui/ui-plugins/org.csstudio.ui.util/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>ui-plugins</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.ui.util</artifactId>
   <version>4.0.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/ui/ui-plugins/pom.xml
+++ b/core/ui/ui-plugins/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>ui</artifactId>
     <version>4.2.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>ui-plugins</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/core/utility/pom.xml
+++ b/core/utility/pom.xml
@@ -14,5 +14,4 @@
     <module>utility-features</module>
     <module>utility-repository</module>
   </modules>
-  <groupId>org.csstudio</groupId>
 </project>

--- a/core/utility/utility-plugins/org.csstudio.utility.batik/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.batik/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.batik</artifactId>
   <version>1.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/utility/utility-plugins/org.csstudio.utility.pvmanager.ui.toolbox/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.pvmanager.ui.toolbox/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.pvmanager.ui.toolbox</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/utility/utility-plugins/org.csstudio.utility.pvmanager.ui/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.pvmanager.ui/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.pvmanager.ui</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/utility/utility-plugins/org.csstudio.utility.pvmanager.widgets.test/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.pvmanager.widgets.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.pvmanager.widgets.test</artifactId>
   <version>3.1.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>

--- a/core/utility/utility-plugins/org.csstudio.utility.pvmanager.widgets/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.pvmanager.widgets/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.pvmanager.widgets</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource.rap/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource.rap/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.singlesource.rap</artifactId>
   <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource.test/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource.test/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 

--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>utility-plugins</artifactId>
     <version>4.1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.csstudio</groupId>
   <artifactId>org.csstudio.utility.singlesource</artifactId>
   <version>4.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>


### PR DESCRIPTION
See #2024.  This catches most of the duplicate group id warnings, but since I did this with a grep I have missed a few.