### PR TITLE
While updating filter, enable alarmtable opiwidget if filte ritem is valid.

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetEditPart.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui.alarmtable.opiwidget/src/org/csstudio/alarm/beast/ui/alarmtable/opiwidget/AlarmTableWidgetEditPart.java
@@ -182,8 +182,10 @@ public class AlarmTableWidgetEditPart extends AbstractWidgetEditPart implements 
                 executeWithDisplay(() -> figure.setBorder(AlarmRepresentationScheme.getDisonnectedBorder()));
                 getAlarmTable().getActiveAlarmTable().getTable().setEnabled(false);
             }
-            else
+            else {
+                getAlarmTable().getActiveAlarmTable().getTable().setEnabled(true);
                 getAlarmTable().setFilterItem(item, model);
+            }
         }
     }
 


### PR DESCRIPTION
Further fix for #1995 

When alarm is disabled first and then finds a server connectivity, updateFilter will disable but needs to enable it back.