### PR TITLE
core base feature: org.csstudio.vtype.pv.ui was removed in #2065

### DIFF
--- a/core/base/base-features/org.csstudio.core.base.feature/feature.xml
+++ b/core/base/base-features/org.csstudio.core.base.feature/feature.xml
@@ -35,11 +35,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.csstudio.vtype.pv.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
.. so vtype.pv.ui must also be removed from the core base feature, otherwise the build breaks looking for a missing plugin