### PR TITLE
Sim pvs

### DIFF
--- a/applications/diag/diag-plugins/org.csstudio.diag.epics.pvtree/pv_tree.product
+++ b/applications/diag/diag-plugins/org.csstudio.diag.epics.pvtree/pv_tree.product
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="EPICS PV Tree" id="org.csstudio.diag.epics.pvtree.product" application="org.csstudio.diag.epics.pvtree.application" useFeatures="false" includeLaunchers="true">
+<product name="EPICS PV Tree" uid="pvtree" id="org.csstudio.diag.epics.pvtree.product" application="org.csstudio.diag.epics.pvtree.application" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
 
    <launcherArgs>
+      <vmArgs>-Dosgi.requiredJavaVersion=1.8 -Xms256m -Xmx1024m -Dorg.osgi.framework.bundle.parent=ext -Dosgi.framework.extensions=org.eclipse.fx.osgi -Dorg.osgi.framework.system.packages.extra=sun.misc
+      </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
    </launcherArgs>
 
+   <launcher name="pv_tree">
+      <solaris/>
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+
+   <vm>
+   </vm>
+
    <plugins>
-      <plugin id="com.diffplug.osgi.extension.sun.misc" fragment="true"/>
       <plugin id="com.ibm.icu"/>
       <plugin id="javax.annotation"/>
       <plugin id="javax.inject"/>
@@ -20,13 +31,16 @@
       <plugin id="org.apache.batik.css"/>
       <plugin id="org.apache.batik.util"/>
       <plugin id="org.apache.batik.util.gui"/>
+      <plugin id="org.apache.commons.io"/>
       <plugin id="org.apache.commons.jxpath"/>
+      <plugin id="org.apache.commons.lang3"/>
       <plugin id="org.csstudio.apputil"/>
       <plugin id="org.csstudio.apputil.ui"/>
       <plugin id="org.csstudio.autocomplete"/>
       <plugin id="org.csstudio.autocomplete.ui"/>
       <plugin id="org.csstudio.csdata"/>
       <plugin id="org.csstudio.diag.epics.pvtree"/>
+      <plugin id="org.csstudio.diirt.util.core.preferences"/>
       <plugin id="org.csstudio.java"/>
       <plugin id="org.csstudio.logbook"/>
       <plugin id="org.csstudio.ui.util"/>
@@ -101,5 +115,11 @@
       <plugin id="org.w3c.dom.svg"/>
    </plugins>
 
+   <configurations>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.osgi" autoStart="true" startLevel="1" />
+   </configurations>
 
 </product>

--- a/applications/diag/diag-plugins/org.csstudio.diag.epics.pvtree/src/org/csstudio/diag/epics/pvtree/model/TreeModelItem.java
+++ b/applications/diag/diag-plugins/org.csstudio.diag.epics.pvtree/src/org/csstudio/diag/epics/pvtree/model/TreeModelItem.java
@@ -273,6 +273,12 @@ public class TreeModelItem
             logger.fine("Known item " + record_name + "." + info + ", not traversing inputs (again)");
             return;
         }
+        final List<String> type_links = field_info.get(type);
+        if (type_links == null)
+        {
+            logger.fine("Type " + type + " has no known links");
+            return;
+        }
         // Could fetch all links in parallel,
         // but to keep the model clean we drop empty links.
         // Reading them one by one, then adding only
@@ -282,7 +288,7 @@ public class TreeModelItem
         // to a tree that initially shows all yet-to-be-resolved links,
         // then removes the empty ones while
         // expanding the non-empty subtrees
-        links_to_read.addAll(field_info.get(type));
+        links_to_read.addAll(type_links);
         model.incrementLinks(links_to_read.size());
         resolveNextLink();
     }

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/FlipFlopPV.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/FlipFlopPV.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.sim;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.csstudio.vtype.pv.PV;
+import org.diirt.vtype.ValueFactory;
+
+/** Simulated PV for flipflop
+ *  @author Kay Kasemir, based on similar code in org.csstudio.utility.pv and diirt
+ */
+@SuppressWarnings("nls")
+public class FlipFlopPV extends SimulatedPV
+{
+    private static final List<String> labels = Arrays.asList(Boolean.FALSE.toString(), Boolean.TRUE.toString());
+    private int value = 0;
+
+    public static PV forParameters(final String name, final List<Double> parameters) throws Exception
+    {
+        if (parameters.size() <= 0)
+            return new FlipFlopPV(name, 1);
+        else if (parameters.size() == 1)
+            return new FlipFlopPV(name, parameters.get(0));
+        throw new Exception("sim://flipflop needs no parameters or (update_seconds)");
+    }
+
+    public FlipFlopPV(final String name, final double update_seconds)
+    {
+        super(name);
+        start(update_seconds);
+    }
+
+    @Override
+    protected void update()
+    {
+        value = 1 - value;
+        notifyListenersOfValue(ValueFactory.newVEnum(value, labels, ValueFactory.alarmNone(), ValueFactory.timeNow()));
+    }
+}

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/GaussianNoisePV.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/GaussianNoisePV.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.sim;
+
+import java.util.List;
+import java.util.Random;
+
+import org.csstudio.vtype.pv.PV;
+
+/** Simulated PV for sine
+ *  @author Kay Kasemir, based on similar PV in org.csstudio.utility.pv and diirt
+ */
+@SuppressWarnings("nls")
+public class GaussianNoisePV extends SimulatedDoublePV
+{
+    private static final Random rand = new Random();
+    private final double center, std_dev;
+
+    public static PV forParameters(final String name, List<Double> parameters) throws Exception
+    {
+        if (parameters.isEmpty())
+            return new GaussianNoisePV(name, 0.0, 1.0, 0.1);
+        if (parameters.size() == 3)
+            return new GaussianNoisePV(name, parameters.get(0), parameters.get(1), parameters.get(2));
+        throw new Exception("sim://gaussianNoise needs no parameters or (center, std_dev, update_seconds)");
+    }
+
+    public GaussianNoisePV(final String name, final double center, final double std_dev, final double update_seconds)
+    {
+        super(name);
+        this.center = center;
+        this.std_dev = std_dev;
+        start(center-2*std_dev, center+2*std_dev, update_seconds);
+    }
+
+    @Override
+    public double compute()
+    {
+        return center + rand.nextGaussian() * std_dev;
+    }
+}

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/GaussianNoisePV.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/GaussianNoisePV.java
@@ -12,8 +12,8 @@ import java.util.Random;
 
 import org.csstudio.vtype.pv.PV;
 
-/** Simulated PV for sine
- *  @author Kay Kasemir, based on similar PV in org.csstudio.utility.pv and diirt
+/** Simulated PV for gaussian noise
+ *  @author Kay Kasemir, based on similar PV in diirt
  */
 @SuppressWarnings("nls")
 public class GaussianNoisePV extends SimulatedDoublePV

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/GaussianWavePV.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/GaussianWavePV.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.vtype.pv.sim;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.csstudio.vtype.pv.PV;
+
+/** Simulated PV for gaussian wave
+ *  @author Kay Kasemir, based on similar PV in diirt
+ */
+@SuppressWarnings("nls")
+public class GaussianWavePV extends SimulatedDoubleArrayPV
+{
+    private final double period;
+    private final double[] shape;
+    private final Instant start = Instant.now();
+
+    public static PV forParameters(final String name, List<Double> parameters) throws Exception
+    {
+        if (parameters.isEmpty())
+            return new GaussianWavePV(name, 1.0, 100.0, 100, 0.1);
+        if (parameters.size() == 4)
+            return new GaussianWavePV(name, parameters.get(0), parameters.get(1), parameters.get(2).intValue(), parameters.get(3));
+        throw new Exception("sim://gaussianwave needs no parameters or" +
+                            "(period_seconds, std_dev, size, update_seconds)");
+    }
+
+    public GaussianWavePV(final String name, final double period_seconds, final double std_dev,
+                          int size, final double update_seconds)
+    {
+        super(name);
+        period = period_seconds;
+
+        if (size < 1)
+            size = 1;
+
+        shape = new double[size];
+        final double center = size / 2.0;
+        for (int i=0; i<size; ++i)
+        {
+            final double dx = i - center;
+            shape[i] = Math.exp(- dx*dx / std_dev);
+        }
+        start(0.0, 1.0, update_seconds);
+    }
+
+    @Override
+    public double[] compute()
+    {
+        final double[] value = new double[shape.length];
+
+        final Duration dist = Duration.between(start, Instant.now());
+        final double t = dist.getSeconds() + dist.getNano()*1e-9;
+        final double periods = period > 0 ? t / period : 0.0;
+        final int i0 = (int) ((periods - (int)periods) * value.length);
+
+        // value[..] = shape[i0 to end] concatenated with shape[0 to i0-1]
+        final int rest = value.length - i0;
+        System.arraycopy(shape, i0, value, 0, rest);
+        System.arraycopy(shape, 0, value, rest, i0);
+        return value;
+    }
+}

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/SimPVFactory.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/SimPVFactory.java
@@ -54,6 +54,8 @@ public class SimPVFactory implements PVFactory
             return RampPV.forParameters(name, parseDoubles(parameters));
         else if (func.equals("noise"))
             return NoisePV.forParameters(name, parseDoubles(parameters));
+        else if (func.equalsIgnoreCase("gaussiannoise"))
+            return GaussianNoisePV.forParameters(name, parseDoubles(parameters));
         else if (func.equals("strings"))
             return StringsPV.forParameters(name, parseDoubles(parameters));
         else if (func.startsWith("intermittent"))           // diirt used "intermittentChannel"

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/SimPVFactory.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/SimPVFactory.java
@@ -62,6 +62,8 @@ public class SimPVFactory implements PVFactory
             return SawtoothWavePV.forParameters(name, parseDoubles(parameters));
         else if (func.toLowerCase().startsWith("sinewave")) // diirt used "sineWaveform"
             return SineWavePV.forParameters(name, parseDoubles(parameters));
+        else if (func.toLowerCase().startsWith("gaussianwave")) // diirt used "gaussianWaveform"
+            return GaussianWavePV.forParameters(name, parseDoubles(parameters));
         else if (func.toLowerCase().startsWith("noisewave")) // diirt used "noiseWaveform"
             return NoiseWavePV.forParameters(name, parseDoubles(parameters));
         else if (func.equals("flipflop"))

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/SimPVFactory.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/sim/SimPVFactory.java
@@ -64,6 +64,8 @@ public class SimPVFactory implements PVFactory
             return SineWavePV.forParameters(name, parseDoubles(parameters));
         else if (func.toLowerCase().startsWith("noisewave")) // diirt used "noiseWaveform"
             return NoiseWavePV.forParameters(name, parseDoubles(parameters));
+        else if (func.equals("flipflop"))
+            return FlipFlopPV.forParameters(name, parseDoubles(parameters));
         else
             throw new Exception("Unknown simulated PV " + name);
     }


### PR DESCRIPTION
Support sim://flipflop, sim://gaussianwave, sim://gaussiannoise in vtype.pv for #1429

While opening them in pvtree, noticed an error in there for non-record PVs like these sim:// PVs, so removed that.