### PR TITLE
openfile: Allow multiple tools to register for a file extension

### DIFF
--- a/core/utility/utility-plugins/org.csstudio.openfile/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.openfile/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Open file action
 Bundle-SymbolicName: org.csstudio.openfile;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0"
-Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen <chenx1@ornl.gov> - SNS
+Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen - SNS
 Bundle-Description: Open file action used by startup
 Export-Package: org.csstudio.openfile

--- a/core/utility/utility-plugins/org.csstudio.openfile/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.openfile/pom.xml
@@ -8,6 +8,6 @@
     <version>4.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.openfile</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>4.5.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/utility/utility-plugins/org.csstudio.openfile/schema/openDisplay.exsd
+++ b/core/utility/utility-plugins/org.csstudio.openfile/schema/openDisplay.exsd
@@ -9,6 +9,8 @@
          Extension point that allows generic operator interface tools to register so that programs like an alarm interface can open operator interface panels.
 
 Extensions register the file extension that they handle, and will then receive that file name and a generic string parameter for additional parameters like macros that are specific to the implementation of an operator interface tool.
+
+Multiple tools can register for the same file extension, but only one should then set &quot;default: true&quot; or leave it undefined, while all others need to set &quot;default: false&quot;. If more than one tool registers without &quot;default: false&quot;, the last one found in the registry will be invoked.
       </documentation>
    </annotation>
 
@@ -68,6 +70,16 @@ Extensions register the file extension that they handle, and will then receive t
                </appinfo>
             </annotation>
          </attribute>
+         <attribute name="default" type="boolean">
+            <annotation>
+               <documentation>
+                  Is this the default display tool for the file extension?
+When multiple handler classes register for the same file extension, the one defined as &apos;default&apos; will be chosen.
+A secondary handler class registered with &quot;default: false&quot; will only be invoked if there is no handler available with &quot;default: true&quot;.
+The &quot;default&quot; setting defaults to true.
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -111,7 +123,7 @@ Extensions register the file extension that they handle, and will then receive t
          <meta.section type="implementation"/>
       </appinfo>
       <documentation>
-         org.csstudio.opibuilder implements this for 'opi' files
+         org.csstudio.opibuilder implements this for &apos;opi&apos; files
       </documentation>
    </annotation>
 


### PR DESCRIPTION
For the transition from BOY to the display builder, this allows the display builder to register as a secondary, non-default 'openfile' handler for *.opi files.
As long as the BOY plugins are in the product, they will open *.opi files from the alarm UI or the command line.
When BOY plugins are removed from the product, the display builder will open *.opi files from the alarm UI or the command line.

The 'issue' that it fixes is related to the display builder, https://github.com/kasemir/org.csstudio.display.builder/issues/212