### PR TITLE
Add .classpath file for opibuilder.rcp.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/.classpath
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+        <accessrules>
+            <accessrule kind="accessible" pattern="javafx/**"/>
+        </accessrules>
+    </classpathentry>
+    <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+    <classpathentry kind="src" path="src"/>
+    <classpathentry kind="output" path="target/classes"/>
+</classpath>


### PR DESCRIPTION
This allows explicitly adding access rules to allow access to JavaFX
and so removing Eclipse warnings.

Since .settings files are in .gitignore this is an exception and needs -f to add to the repo.  So this is just a suggestion, but I think it may be a good idea.

See #2024.