### PR TITLE
Update .classpath files to remove access rule errors in Eclipse.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,12 @@ products/KEK/plugins/org.csstudio.kek.build/*/build.log
 *.prefs
 .project
 .classpath
+# A few plugins need access rules to be defined and so
+# committing the .classpath file is useful
+!core/utility/utility-plugins/org.csstudio.logging.ui/.classpath
+!applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/.classpath
+!applications/saverestore/saverestore-plugins/org.csstudio.saverestore.ui/.classpath
+!applications/saverestore/saverestore-plugins/org.csstudio.ui.fx.util/.classpath
 
 # The rest seems to be a copy/paste of the Mercurial ingnore rules,
 # which don't work with GIT (no "syntax: regexp"...)

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/.classpath
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv.test/.classpath
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="output" path="target/classes"/>
-</classpath>

--- a/applications/saverestore/saverestore-plugins/org.csstudio.saverestore.ui/.classpath
+++ b/applications/saverestore/saverestore-plugins/org.csstudio.saverestore.ui/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+        <accessrules>
+            <accessrule kind="accessible" pattern="javafx/**"/>
+        </accessrules>
+    </classpathentry>
+    <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+    <classpathentry kind="src" path="src"/>
+    <classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/applications/saverestore/saverestore-plugins/org.csstudio.ui.fx.util/.classpath
+++ b/applications/saverestore/saverestore-plugins/org.csstudio.ui.fx.util/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+        <accessrules>
+            <accessrule kind="accessible" pattern="javafx/**"/>
+        </accessrules>
+    </classpathentry>
+    <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+    <classpathentry kind="src" path="src"/>
+    <classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/build/cs-studio-jenkins-checkstyle
+++ b/build/cs-studio-jenkins-checkstyle
@@ -6,7 +6,7 @@
 -->
 <!--
     Checkstyle-Configuration: cs-studio
-    Description: 
+    Description:
 Checkstyle configuration that checks the sun coding conventions.
 -->
 <module name="Checker">
@@ -29,20 +29,20 @@ Checkstyle configuration that checks the sun coding conventions.
   <module name="FileTabCharacter">
     <property name="severity" value="error"/>
     <property name="eachLine" value="true"/>
-    <property name="fileExtensions" value="java,xml,product,html"/>
+    <property name="fileExtensions" value="java,xml,product,html,classpath"/>
   </module>
   <module name="RegexpSingleline">
     <metadata name="net.sf.eclipsecs.core.comment" value="To check line do not have trailing spaces"/>
     <property name="severity" value="error"/>
     <property name="format" value=" +$"/>
     <property name="message" value="Trailing whitespaces"/>
-    <property name="fileExtensions" value="java,xml,product,html"/>
+    <property name="fileExtensions" value="java,xml,product,html,classpath"/>
   </module>
   <module name="RegexpMultiline">
     <metadata name="net.sf.eclipsecs.core.comment" value="To check line endings do not use carriage return"/>
     <property name="severity" value="error"/>
     <property name="format" value="\r"/>
     <property name="message" value="Invalid Eol"/>
-    <property name="fileExtensions" value="java,xml,product,html"/>
+    <property name="fileExtensions" value="java,xml,product,html,classpath"/>
   </module>
 </module>

--- a/core/utility/utility-plugins/org.csstudio.logging.ui/.classpath
+++ b/core/utility/utility-plugins/org.csstudio.logging.ui/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+        <accessrules>
+            <accessrule kind="accessible" pattern="javafx/**"/>
+        </accessrules>
+    </classpathentry>
+    <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+    <classpathentry kind="src" path="src"/>
+    <classpathentry kind="output" path="target/classes"/>
+</classpath>


### PR DESCRIPTION
This completes what I started in #2112.

See #2024.