### PR TITLE
Databrowser: Fix autoscale

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -67,25 +67,30 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                 final PlotDataSearch<XTYPE> search = new PlotDataSearch<>();
                 data.getLock().lock();
                 try
-                {   // Consider first sample at-or-before start
-                    int start = search.findSampleLessOrEqual(data, x_range.getLow());
-                    if (start < 0)
-                        start = 0;
-                    // Last sample is the one just inside end of range.
-                    int stop = search.findSampleLessOrEqual(data, x_range.getHigh());
-                    if (stop < 0)
-                        stop = 0;
-                    // Check [start .. stop], including stop
-                    for (int i=start; i<=stop; ++i)
-                    {
-                        final PlotDataItem<XTYPE> item = data.get(i);
-                        final double value = item.getValue();
-                        if (! Double.isFinite(value))
-                            continue;
-                        if (value < low)
-                            low = value;
-                        if (value > high)
-                            high = value;
+                {
+                    if (data.size() > 0)
+                    {   // Consider first sample at-or-before start
+                        int start = search.findSampleLessOrEqual(data, x_range.getLow());
+                        if (start < 0)
+                            start = 0;
+                        // Last sample is the one just inside end of range.
+                        int stop = search.findSampleLessOrEqual(data, x_range.getHigh());
+                        if (stop < 0)
+                            stop = 0;
+                        // If data is completely outside the x_range,
+                        // we end up using just data[0]
+                        // Check [start .. stop], including stop
+                        for (int i=start; i<=stop; ++i)
+                        {
+                            final PlotDataItem<XTYPE> item = data.get(i);
+                            final double value = item.getValue();
+                            if (! Double.isFinite(value))
+                                continue;
+                            if (value < low)
+                                low = value;
+                            if (value > high)
+                                high = value;
+                        }
                     }
                 }
                 finally

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -64,23 +64,28 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
             {
                 double low = Double.MAX_VALUE;
                 double high = -Double.MAX_VALUE;
+                final PlotDataSearch<XTYPE> search = new PlotDataSearch<>();
                 data.getLock().lock();
                 try
-                {
-                    final int N = data.size();
-                    for (int i=0; i<N; ++i)
+                {   // Consider first sample at-or-before start
+                    int start = search.findSampleLessOrEqual(data, x_range.getLow());
+                    if (start < 0)
+                        start = 0;
+                    // Last sample is the one just inside end of range.
+                    int stop = search.findSampleLessOrEqual(data, x_range.getHigh());
+                    if (stop < 0)
+                        stop = 0;
+                    // Check [start .. stop], including stop
+                    for (int i=start; i<=stop; ++i)
                     {
                         final PlotDataItem<XTYPE> item = data.get(i);
-                        if (x_range.contains(item.getPosition()))
-                        {
-                            final double value = item.getValue();
-                            if (! Double.isFinite(value))
-                                continue;
-                            if (value < low)
-                                low = value;
-                            if (value > high)
-                                high = value;
-                        }
+                        final double value = item.getValue();
+                        if (! Double.isFinite(value))
+                            continue;
+                        if (value < low)
+                            low = value;
+                        if (value > high)
+                            high = value;
                     }
                 }
                 finally


### PR DESCRIPTION
#2026 changed autoscale to only consider the 'visible' range, but
omitted the first sample at-or-before the start time.

Example: Setpoint that last changed a week ago.
That old value would not be included in the autoscale, so you don't see the flat line from that value on until 'now'.

This update performs a binary search for the actual start & end sample
to consider, then autoscale using that range.

Port of similar fix for databrowser3