### PR TITLE
Disable keyboard traversal for most remaining widgets.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/AbstractSWTWidgetFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/AbstractSWTWidgetFigure.java
@@ -111,6 +111,8 @@ public abstract class AbstractSWTWidgetFigure<T extends Control> extends Figure 
         super();
         this.editPart = editpart;
         this.composite = (Composite) editpart.getViewer().getControl();
+        // Disable tab traversal
+        this.composite.setTabList(new Control[]{});
         //In RAP, FigureCanvas has an inner canvas wrapped, so everything should be on the inner canvas.
         if(OPIBuilderPlugin.isRAP()){
             Control[] children = composite.getChildren();

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
@@ -563,6 +563,8 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
                 figure.setToolTip(tooltipLabel);
             }
         }
+        // Disable tab traversal
+        figure.setFocusTraversable(false);
     }
 
     @Override

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/AbstractChoiceFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/AbstractChoiceFigure.java
@@ -229,4 +229,12 @@ public abstract class AbstractChoiceFigure extends Figure implements Introspecta
         return new DefaultWidgetIntrospector().getBeanInfo(this.getClass());
     }
 
+    @Override
+    public void setFocusTraversable(boolean focusTraversable) {
+        super.setFocusTraversable(focusTraversable);
+        for (Toggle toggle : toggles) {
+            toggle.setFocusTraversable(focusTraversable);
+        }
+    }
+
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScrollbarFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScrollbarFigure.java
@@ -788,4 +788,13 @@ public class ScrollbarFigure extends Figure implements Orientable, Introspectabl
                 tempPattern = DEFAULT_DECIMAL_FORMAT;
         decimalFormat = new DecimalFormat(tempPattern);
     }
+
+    @Override
+    public void setFocusTraversable(boolean focusTraversable) {
+        super.setFocusTraversable(focusTraversable);
+        buttonUp.setFocusTraversable(focusTraversable);
+        buttonDown.setFocusTraversable(focusTraversable);
+        pageUp.setFocusTraversable(focusTraversable);
+        pageDown.setFocusTraversable(focusTraversable);
+    }
 }


### PR DESCRIPTION
@nickbattam this seems to work for everything except for the XYGraph, which I can't figure out right now.