### PR TITLE
Ensure BOY widgets can't ever get keyboard focus.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
@@ -565,6 +565,7 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
         }
         // Disable tab traversal
         figure.setFocusTraversable(false);
+        figure.setRequestFocusEnabled(false);
     }
 
     @Override

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/AbstractChoiceFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/AbstractChoiceFigure.java
@@ -237,4 +237,12 @@ public abstract class AbstractChoiceFigure extends Figure implements Introspecta
         }
     }
 
+    @Override
+    public void setRequestFocusEnabled(boolean requestFocusEnabled) {
+        super.setRequestFocusEnabled(requestFocusEnabled);
+        for (Toggle toggle : toggles) {
+            toggle.setRequestFocusEnabled(requestFocusEnabled);
+        }
+    }
+
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScrollbarFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScrollbarFigure.java
@@ -797,4 +797,13 @@ public class ScrollbarFigure extends Figure implements Orientable, Introspectabl
         pageUp.setFocusTraversable(focusTraversable);
         pageDown.setFocusTraversable(focusTraversable);
     }
+
+    @Override
+    public void setRequestFocusEnabled(boolean requestFocusEnabled) {
+        super.setRequestFocusEnabled(requestFocusEnabled);
+        buttonUp.setRequestFocusEnabled(requestFocusEnabled);
+        buttonDown.setRequestFocusEnabled(requestFocusEnabled);
+        pageUp.setRequestFocusEnabled(requestFocusEnabled);
+        pageDown.setRequestFocusEnabled(requestFocusEnabled);
+    }
 }


### PR DESCRIPTION
This commit ensures they can't be selected for keyboard operation even
if they are clicked.

See #2038 and #2141.