### PR TITLE
Don't select rectangle widget if transparent.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/RectangleEditpart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/RectangleEditpart.java
@@ -22,6 +22,7 @@
 
 package org.csstudio.opibuilder.widgets.editparts;
 
+import org.csstudio.opibuilder.editparts.ExecutionMode;
 import org.csstudio.opibuilder.properties.IWidgetPropertyChangeHandler;
 import org.csstudio.opibuilder.util.OPIColor;
 import org.csstudio.opibuilder.widgets.model.AbstractShapeModel;
@@ -37,15 +38,14 @@ import org.eclipse.draw2d.IFigure;
  */
 public class RectangleEditpart extends AbstractShapeEditPart {
 
-
-
     @Override
     protected IFigure doCreateFigure() {
-        OPIRectangleFigure figure = new OPIRectangleFigure();
+        OPIRectangleFigure figure = new OPIRectangleFigure(getExecutionMode() == ExecutionMode.RUN_MODE);
         RectangleModel model = getWidgetModel();
         figure.setFill(model.getFillLevel());
         figure.setHorizontalFill(model.isHorizontalFill());
         figure.setTransparent(model.isTransparent());
+        figure.setSelectable(determineSelectable());
         figure.setLineColor(model.getLineColor());
         figure.setGradient(model.isGradient());
         figure.setBackGradientStartColor(model.getBackgroundGradientStartColor());
@@ -161,6 +161,16 @@ public class RectangleEditpart extends AbstractShapeEditPart {
         return ((OPIRectangleFigure)getFigure()).getFill();
     }
 
-
+    /**
+     * The rectangle is selectable if it has any actions, has a tooltip defined
+     * or is opaque.  A transparent rectangle should pass clicks or tooltips through.
+     * @return whether the rectangle is selectable
+     */
+    private boolean determineSelectable(){
+        boolean hasActions = !getWidgetModel().getActionsInput().getActionsList().isEmpty();
+        boolean hasTooltip = getWidgetModel().getTooltip().trim().length() > 0;
+        boolean opaque = !getWidgetModel().isTransparent();
+        return hasActions || hasTooltip || opaque;
+    }
 
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/OPIRectangleFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/OPIRectangleFigure.java
@@ -47,16 +47,17 @@ public final class OPIRectangleFigure extends RectangleFigure implements Introsp
      * The fill grade (0 - 100%).
      */
     private double fill = 100;
+    private boolean runMode;
 
     /**
      * The orientation (horizontal==true | vertical==false).
      */
     private boolean horizontalFill = true;
 
-    /**
-     * The transparent state of the background.
-     */
+    /** The transparent state of the background. */
     private boolean transparent = false;
+    /** Whether the rectangle should be selectable at runtime. */
+    private boolean selectable;
 
     private Color lineColor = CustomMediaFactory.getInstance().getColor(
             CustomMediaFactory.COLOR_PURPLE);
@@ -65,6 +66,10 @@ public final class OPIRectangleFigure extends RectangleFigure implements Introsp
     private Color foreGradientStartColor =ColorConstants.white;
     private boolean gradient=false;
     private boolean useAdvancedGraphics=GraphicsUtil.useAdvancedGraphics();
+
+    public OPIRectangleFigure(boolean runMode) {
+        this.runMode = runMode;
+    }
 
     /**
      * {@inheritDoc}
@@ -250,6 +255,16 @@ public final class OPIRectangleFigure extends RectangleFigure implements Introsp
         repaint();
     }
 
+    public void setSelectable(boolean selectable) {
+        this.selectable = selectable;
+    }
 
+    @Override
+    public boolean containsPoint(int x, int y) {
+        if(runMode && !selectable)
+            return false;
+        else
+            return super.containsPoint(x, y);
+    }
 
 }


### PR DESCRIPTION
As long as it is transparent, has no actions and no tooltip, widgets
underneath should accept clicks and show their tooltips.

See #2149.