### PR TITLE
Enable the arrow by default in converted EDM menubuttons

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeMenuButtonClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activeMenuButtonClass.java
@@ -34,6 +34,7 @@ public class Opi_activeMenuButtonClass extends OpiWidget {
         {
             new OpiString(widgetContext, "pv_name", convertPVName(r.getControlPv()));
             new OpiBoolean(widgetContext, "actions_from_pv", true);
+            new OpiBoolean(widgetContext, "show_down_arrow", true);
         }
 
         log.config("Edm_activeMenuButtonClass written.");


### PR DESCRIPTION
Respect the change in #1073 in the EDM converter.