### PR TITLE
JCA PV: Fix metadata with array elements as used for subscription

### DIFF
--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/jca/JCA_PV.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/jca/JCA_PV.java
@@ -190,7 +190,13 @@ public class JCA_PV extends PV implements ConnectionListener, MonitorListener, A
     {
         try
         {
-            channel.get(DBRHelper.getCtrlType(plain_dbr, channel.getFieldType()), 1, meta_get_listener);
+            // With very old IOCs, could only get one element for Ctrl type.
+            // With R3.15.5, fetching just one element for a record.INP$
+            // (i.e. fetching the string as a BYTE[])
+            // crashes the IOC.
+            // --> Using the same request count as for the subscription
+            final int request_count = JCAContext.getInstance().getRequestCount(channel);
+            channel.get(DBRHelper.getCtrlType(plain_dbr, channel.getFieldType()), request_count, meta_get_listener);
             channel.getContext().flushIO();
         }
         catch (Exception ex)
@@ -233,7 +239,7 @@ public class JCA_PV extends PV implements ConnectionListener, MonitorListener, A
             }
 
             // Subscribe to metadata changes (DBE_PROPERTY)
-            final DBRType meta_request = getRequestForMetadata((DBR)metadata);
+            final DBRType meta_request = getRequestForMetadata(metadata);
             if (JCA_Preferences.getInstance().isDbePropertySupported()  &&  meta_request != null)
             {
                 Monitor old_metadata_monitor = null;


### PR DESCRIPTION
Avoids #2175: EPICS R3.15.5 IOCs crash when fetching metadata for record.INP$, a
BYTE[], as DBR_CTRL_BYTE with only 1 element.