### PR TITLE
Update to use Tycho 1.0.0 to build.

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -16,7 +16,7 @@
   <!-- PROPERTIES -->
   <properties>
     <!-- VERSIONS -->
-    <tycho.version>0.23.1</tycho.version>
+    <tycho.version>1.0.0</tycho.version>
     <tycho-extras.version>${tycho.version}</tycho-extras.version>
     <cs-studio.version>4.5</cs-studio.version>
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
@@ -365,6 +365,10 @@
         <artifactId>tycho-compiler-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
+          <!-- We don't commit the project settings files
+          (.settings/org.eclipse.jdt.core.prefs), so we
+          don't want the Eclipse defaults affecting the build. -->
+          <useProjectSettings>false</useProjectSettings>
           <!-- This is to avoid errors when using restricted API from org.ecpics.vtype, and sun.* -->
           <compilerArgument>-err:-forbidden</compilerArgument>
         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,7 @@
   <!-- PROPERTIES -->
   <properties>
     <!-- VERSIONS -->
-    <tycho.version>0.23.1</tycho.version>
+    <tycho.version>1.0.0</tycho.version>
     <tycho-extras.version>${tycho.version}</tycho-extras.version>
     <cs-studio.version>4.5</cs-studio.version>
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
@@ -356,6 +356,10 @@
         <artifactId>tycho-compiler-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
+          <!-- We don't commit the project settings files
+          (.settings/org.eclipse.jdt.core.prefs), so we
+          don't want the Eclipse defaults affecting the build. -->
+          <useProjectSettings>false</useProjectSettings>
           <!-- This is to avoid errors when using restricted API from sun.*:
             org.csstudio.rap.core, org.csstudio.security -->
           <compilerArgument>-err:-forbidden</compilerArgument>


### PR DESCRIPTION
Revert the change in default behaviour, which is to use Eclipse
settings files as part of the build.  Since we don't commit these, the
ones that are autogenerated by Eclipse are only going to make the build
inconsistent.

See #2080.