### PR TITLE
Updated repository to compile with Eclipse Neon (4.6) plugins.

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -21,7 +21,7 @@
     <cs-studio.version>4.5</cs-studio.version>
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
     <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>
-    <orbit-site>${eclipse.mirror.url}/tools/orbit/downloads/drops/R20160221192158/repository/</orbit-site>
+    <orbit-site>${eclipse.mirror.url}/tools/orbit/R-builds/R20170307180635/repository</orbit-site>
     <rap-e4-site>${eclipse.central.url}/rt/rap/incubator/3.0/e4/target/site</rap-e4-site>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
@@ -35,9 +35,7 @@
     <sonar.language>java</sonar.language>
     <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-    <sonar.junit.reportsPath>
-      ../${project.artifactId}.test/target/surefire-reports/
-    </sonar.junit.reportsPath>
+    <sonar.junit.reportsPath>../${project.artifactId}.test/target/surefire-reports/</sonar.junit.reportsPath>
     <!--sonar.host.url>INSERT YOUR SONARQUBE URL</sonar.host.url -->
     <!--sonar.jdbc.url>INSERT YOUR JDBC CONNECTION</sonar.jdbc.url -->
     <!--sonar.jdbc.driver>INSERT YOUR JDBC DRIVER</sonar.jdbc.driver -->
@@ -67,12 +65,13 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/mars</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.5</eclipse-update-site>
-        <rap-site>${eclipse.mirror.url}/rt/rap/3.0</rap-site>
-        <rap-gef-site>http://archive.eclipse.org/rt/rap/incubator/nightly/gef/20150327-1849/</rap-gef-site>
-        <platform-version>[4.4,4.5)</platform-version>
-        <swtbot-site>${eclipse.central.url}/technology/swtbot/mars/dev-build/update-site</swtbot-site>
+        <eclipse-site>${eclipse.mirror.url}/releases/neon</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.6</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/3.1</rap-site>
+        <rap-gef-site>http://archive.eclipse.org/rt/rap/incubator/nightly/gef/20150327-1849</rap-gef-site>
+        <platform-version>[4.4,4.6)</platform-version>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/releases/latest/</swtbot-site>
+        <efx-site>${eclipse.mirror.url}/efxclipse/runtime-released/2.4.0/site</efx-site>
       </properties>
     </profile>
     <profile>
@@ -204,7 +203,7 @@
     </repository>
     <repository>
       <id>efx</id>
-      <url>${eclipse.mirror.url}/efxclipse/runtime-released/2.1.0/site</url>
+      <url>${efx-site}</url>
       <layout>p2</layout>
     </repository>
   </repositories>
@@ -297,7 +296,7 @@
             </configuration>
         </plugin>
       </plugins>
-    </pluginManagement>
+    </pluginManagement> 
     <!-- PLUGIN CONFIGURATION -->
     <plugins>
       <plugin>
@@ -435,7 +434,7 @@
         </configuration>
       </plugin>
       <!-- Used for collecting tests results before sending them to Sonar. -->
-      <plugin>
+   <!--   <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.5.3.201107060350</version>
@@ -450,7 +449,7 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
+      </plugin> -->
     </plugins>
   </build>
 </project>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -296,7 +296,7 @@
             </configuration>
         </plugin>
       </plugins>
-    </pluginManagement> 
+    </pluginManagement>
     <!-- PLUGIN CONFIGURATION -->
     <plugins>
       <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <cs-studio.version>4.5</cs-studio.version>
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
     <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>
-    <orbit-site>${eclipse.mirror.url}/tools/orbit/downloads/drops/R20160221192158/repository/</orbit-site>
+    <orbit-site>${eclipse.mirror.url}/tools/orbit/R-builds/R20170307180635/repository</orbit-site>
     <rap-e4-site>${eclipse.mirror.url}/rt/rap/incubator/3.0/e4/target/site</rap-e4-site>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
@@ -35,9 +35,7 @@
     <sonar.language>java</sonar.language>
     <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-    <sonar.junit.reportsPath>
-      ../${project.artifactId}.test/target/surefire-reports/
-    </sonar.junit.reportsPath>
+    <sonar.junit.reportsPath>../${project.artifactId}.test/target/surefire-reports/</sonar.junit.reportsPath>
     <!--sonar.host.url>INSERT YOUR SONARQUBE URL</sonar.host.url -->
     <!--sonar.jdbc.url>INSERT YOUR JDBC CONNECTION</sonar.jdbc.url -->
     <!--sonar.jdbc.driver>INSERT YOUR JDBC DRIVER</sonar.jdbc.driver -->
@@ -67,12 +65,13 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/mars</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.5</eclipse-update-site>
-        <rap-site>${eclipse.mirror.url}/rt/rap/3.0</rap-site>
-        <rap-gef-site>http://archive.eclipse.org/rt/rap/incubator/nightly/gef/20150327-1849/</rap-gef-site>
-        <platform-version>[4.4,4.5)</platform-version>
-        <swtbot-site>${eclipse.central.url}/technology/swtbot/mars/dev-build/update-site</swtbot-site>
+        <eclipse-site>${eclipse.mirror.url}/releases/neon</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.6</eclipse-update-site>
+        <rap-site>${eclipse.mirror.url}/rt/rap/3.1</rap-site>
+        <rap-gef-site>http://archive.eclipse.org/rt/rap/incubator/nightly/gef/20150327-1849</rap-gef-site>
+        <platform-version>[4.4,4.6)</platform-version>
+        <swtbot-site>${eclipse.central.url}/technology/swtbot/releases/latest/</swtbot-site>
+        <efx-site>${eclipse.mirror.url}/efxclipse/runtime-released/2.4.0/site</efx-site>
       </properties>
     </profile>
     <profile>
@@ -172,7 +171,7 @@
         </repository>
         <repository>
           <id>efx</id>
-          <url>${eclipse.mirror.url}/efxclipse/runtime-released/2.1.0/site</url>
+          <url>${efx-site}</url>
           <layout>p2</layout>
         </repository>
       </repositories>

--- a/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/ApplicationWorkbenchAdvisor.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/ApplicationWorkbenchAdvisor.java
@@ -27,58 +27,54 @@ import org.eclipse.ui.internal.ide.IDEInternalWorkbenchImages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import org.osgi.framework.Bundle;
 
-/** Tell the workbench how to behave.
- *  @author Kay Kasemir
- *  @author Xihui Chen - IDE-specific workbench images
+/**
+ * Tell the workbench how to behave.
+ * 
+ * @author Kay Kasemir
+ * @author Xihui Chen - IDE-specific workbench images
+ * 
+ * Updated {@link ApplicationWorkbenchAdvisor#declareWorkbenchImages()} with new IDE specific images to
+ * be in line with Eclipse 4.6 Neon. CSS uses same IDE specific images as Eclipse.
+ * 
+ * @author <a href="mailto:borut.terpinc@cosylab.com">Borut Terpinc</a>
  */
+
+
 @SuppressWarnings("restriction")
-public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor
-{
+public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
     private OpenDocumentEventProcessor openDocProcessor;
 
-    public ApplicationWorkbenchAdvisor(
-            OpenDocumentEventProcessor openDocProcessor) {
+    public ApplicationWorkbenchAdvisor(OpenDocumentEventProcessor openDocProcessor) {
         this.openDocProcessor = openDocProcessor;
     }
 
     @Override
-    public WorkbenchWindowAdvisor createWorkbenchWindowAdvisor(
-                    final IWorkbenchWindowConfigurer configurer)
-    {
+    public WorkbenchWindowAdvisor createWorkbenchWindowAdvisor(final IWorkbenchWindowConfigurer configurer) {
         return new ApplicationWorkbenchWindowAdvisor(configurer);
     }
 
     @SuppressWarnings("nls")
     @Override
-    public void initialize(final IWorkbenchConfigurer configurer)
-    {
+    public void initialize(final IWorkbenchConfigurer configurer) {
         // Per default, state is not preserved (RCP book 5.1.1)
         configurer.setSaveAndRestore(true);
 
         // Register adapters needed by Navigator view to display workspace files
         IDE.registerAdapters();
 
-        // Declares all IDE-specific workbench images. This includes both "shared"
-        // images (named in {@link IDE.SharedImages}) and internal images.
-        configurer.declareImage(IDE.SharedImages.IMG_OBJ_PROJECT,
-                Activator.getImageDescriptor("icons/project_open.png"), true);
-        configurer.declareImage(IDE.SharedImages.IMG_OBJ_PROJECT_CLOSED,
-                Activator.getImageDescriptor("icons/project_close.png"), true);
-
+        // declare workbench specific images
         declareWorkbenchImages();
     }
 
     /** @return ID of initial perspective */
     @Override
-    public String getInitialWindowPerspectiveId()
-    {
+    public String getInitialWindowPerspectiveId() {
         return CSStudioPerspective.ID;
     }
 
     @Override
-    public void eventLoopIdle(final Display display)
-    {
-        if(openDocProcessor != null)
+    public void eventLoopIdle(final Display display) {
+        if (openDocProcessor != null)
             openDocProcessor.catchUp(display);
         super.eventLoopIdle(display);
     }
@@ -94,107 +90,105 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor
     }
 
     /**
-     * Workaround for RCP bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=234252
-     *
-     * Declares all IDE-specific workbench images. This includes both "shared"
-     * images (named in {@link IDE.SharedImages}) and internal images (named in
+     * Declares all IDE-specific workbench images. CSS uses the same IDE-specific images as Eclipse product. 
+     * This includes both "shared"
+     * images (named in {@link org.eclipse.ui.ide.IDE.SharedImages}) and
+     * internal images (named in
      * {@link org.eclipse.ui.internal.ide.IDEInternalWorkbenchImages}).
      *
-     * @see org.eclipse.ui.internal.ide.IDEWorkbenchAdvisor#declareImage
+     * @see IWorkbenchConfigurer#declareImage
      */
     private void declareWorkbenchImages() {
+
+        
+        /**
+         * prefix:
+         * e - enabled icons
+         * d - disabled icons
+         * 
+         * lcl - toolbar icons
+         * tool - toolbar icons
+         * obj - model object icons 
+         * wizban - wizdard icons 
+         * eviewview - icons
+         */
+        
         final String ICONS_PATH = "$nl$/icons/full/";//$NON-NLS-1$
-        final String PATH_ELOCALTOOL = ICONS_PATH + "elcl16/"; // Enabled //$NON-NLS-1$
-        final String PATH_DLOCALTOOL = ICONS_PATH + "dlcl16/"; // Disabled //$NON-NLS-1$
-        final String PATH_ETOOL = ICONS_PATH + "etool16/"; // Enabled toolbar //$NON-NLS-1$
-        final String PATH_DTOOL = ICONS_PATH + "dtool16/"; // Disabled toolbar //$NON-NLS-1$
-        final String PATH_OBJECT = ICONS_PATH + "obj16/"; // Model object //$NON-NLS-1$
-        final String PATH_WIZBAN = ICONS_PATH + "wizban/"; // Wizard //$NON-NLS-1$
+        final String PATH_ELOCALTOOL = ICONS_PATH + "elcl16/"; //$NON-NLS-1$
+        final String PATH_DLOCALTOOL = ICONS_PATH + "dlcl16/"; //$NON-NLS-1$
+        final String PATH_ETOOL = ICONS_PATH + "etool16/"; //$NON-NLS-1$
+        final String PATH_DTOOL = ICONS_PATH + "dtool16/"; //$NON-NLS-1$
+        final String PATH_OBJECT = ICONS_PATH + "obj16/"; //$NON-NLS-1$
+        final String PATH_WIZBAN = ICONS_PATH + "wizban/"; //$NON-NLS-1$
         final String PATH_EVIEW = ICONS_PATH + "eview16/"; //$NON-NLS-1$
         Bundle ideBundle = Platform.getBundle(IDEWorkbenchPlugin.IDE_WORKBENCH);
 
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC,
-                PATH_ETOOL + "build_exec.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC_HOVER,
-                PATH_ETOOL + "build_exec.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC_DISABLED,
-                PATH_DTOOL + "build_exec.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle,IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC,
-                PATH_ETOOL + "search_src.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC_HOVER,
-                PATH_ETOOL + "search_src.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC_DISABLED,
-                PATH_DTOOL + "search_src.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_NEXT_NAV,
-                PATH_ETOOL + "next_nav.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PREVIOUS_NAV,
-                PATH_ETOOL + "prev_nav.gif", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_NEWPRJ_WIZ,
-                PATH_WIZBAN + "newprj_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_NEWFOLDER_WIZ,
-                PATH_WIZBAN + "newfolder_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_NEWFILE_WIZ,
-                PATH_WIZBAN + "newfile_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_IMPORTDIR_WIZ,
-                PATH_WIZBAN + "importdir_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_IMPORTZIP_WIZ,
-                PATH_WIZBAN + "importzip_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_EXPORTDIR_WIZ,
-                PATH_WIZBAN + "exportdir_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_EXPORTZIP_WIZ,
-                PATH_WIZBAN + "exportzip_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_RESOURCEWORKINGSET_WIZ,
-                PATH_WIZBAN + "workset_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_DLGBAN_SAVEAS_DLG,
-                PATH_WIZBAN + "saveas_wiz.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_DLGBAN_QUICKFIX_DLG,
-                PATH_WIZBAN + "quick_fix.png", false); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJ_PROJECT,
-                PATH_OBJECT + "prj_obj.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJ_PROJECT_CLOSED,
-                PATH_OBJECT + "cprj_obj.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OPEN_MARKER,
-                PATH_ELOCALTOOL + "gotoobj_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ELCL_QUICK_FIX_ENABLED,
-                PATH_ELOCALTOOL + "smartmode_co.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_DLCL_QUICK_FIX_DISABLED,
-                PATH_DLOCALTOOL + "smartmode_co.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_FIXABLE_WARNING,
-                PATH_OBJECT + "quickfix_warning_obj.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_FIXABLE_ERROR,
-                PATH_OBJECT + "quickfix_error_obj.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJS_TASK_TSK,
-                PATH_OBJECT + "taskmrk_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJS_BKMRK_TSK,
-                PATH_OBJECT + "bkmrk_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_COMPLETE_TSK,
-                PATH_OBJECT + "complete_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_INCOMPLETE_TSK,
-                PATH_OBJECT + "incomplete_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_WELCOME_ITEM,
-                PATH_OBJECT + "welcome_item.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_WELCOME_BANNER,
-                PATH_OBJECT + "welcome_banner.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_ERROR_PATH,
-                PATH_OBJECT + "error_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_WARNING_PATH,
-                PATH_OBJECT + "warn_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_INFO_PATH,
-                PATH_OBJECT + "info_tsk.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_LCL_FLAT_LAYOUT,
-                PATH_ELOCALTOOL + "flatLayout.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_LCL_HIERARCHICAL_LAYOUT,
-                PATH_ELOCALTOOL + "hierarchicalLayout.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEM_CATEGORY,
-                PATH_ETOOL + "problem_category.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEMS_VIEW,
-                PATH_EVIEW + "problems_view.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEMS_VIEW_ERROR,
-                PATH_EVIEW + "problems_view_error.gif", true); //$NON-NLS-1$
-        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEMS_VIEW_WARNING,
-                PATH_EVIEW + "problems_view_warning.gif", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC, PATH_ETOOL + "build_exec.png", false);
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC_HOVER, PATH_ETOOL + "build_exec.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC_DISABLED, PATH_DTOOL + "build_exec.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC, PATH_ETOOL + "search_src.png", //$NON-NLS-1$
+                false);
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC_HOVER, PATH_ETOOL + "search_src.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC_DISABLED, PATH_DTOOL + "search_src.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_NEXT_NAV, PATH_ETOOL + "next_nav.png", //$NON-NLS-1$
+                false);
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PREVIOUS_NAV, PATH_ETOOL + "prev_nav.png", //$NON-NLS-1$
+                false);
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_NEWPRJ_WIZ, PATH_WIZBAN + "newprj_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_NEWFOLDER_WIZ, PATH_WIZBAN + "newfolder_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_NEWFILE_WIZ, PATH_WIZBAN + "newfile_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_IMPORTDIR_WIZ, PATH_WIZBAN + "importdir_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_IMPORTZIP_WIZ, PATH_WIZBAN + "importzip_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_EXPORTDIR_WIZ, PATH_WIZBAN + "exportdir_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_EXPORTZIP_WIZ, PATH_WIZBAN + "exportzip_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_WIZBAN_RESOURCEWORKINGSET_WIZ, PATH_WIZBAN + "workset_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_DLGBAN_SAVEAS_DLG, PATH_WIZBAN + "saveas_wiz.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_DLGBAN_QUICKFIX_DLG, PATH_WIZBAN + "quick_fix.png", false); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJ_PROJECT, PATH_OBJECT + "prj_obj.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJ_PROJECT_CLOSED, PATH_OBJECT + "cprj_obj.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OPEN_MARKER, PATH_ELOCALTOOL + "gotoobj_tsk.png", true); //$NON-NLS-1$
+
+        // Quick fix icons
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ELCL_QUICK_FIX_ENABLED, PATH_ELOCALTOOL + "smartmode_co.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_DLCL_QUICK_FIX_DISABLED, PATH_DLOCALTOOL + "smartmode_co.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_FIXABLE_WARNING, PATH_OBJECT + "quickfix_warning_obj.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_FIXABLE_ERROR, PATH_OBJECT + "quickfix_error_obj.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_FIXABLE_INFO, PATH_OBJECT + "quickfix_info_obj.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJS_TASK_TSK, PATH_OBJECT + "taskmrk_tsk.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDE.SharedImages.IMG_OBJS_BKMRK_TSK, PATH_OBJECT + "bkmrk_tsk.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_COMPLETE_TSK, PATH_OBJECT + "complete_tsk.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_INCOMPLETE_TSK, PATH_OBJECT + "incomplete_tsk.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_WELCOME_ITEM, PATH_OBJECT + "welcome_item.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_WELCOME_BANNER, PATH_OBJECT + "welcome_banner.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_ERROR_PATH, PATH_OBJECT + "error_tsk.png", //$NON-NLS-1$
+                true);
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_WARNING_PATH, PATH_OBJECT + "warn_tsk.png", //$NON-NLS-1$
+                true);
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_OBJS_INFO_PATH, PATH_OBJECT + "info_tsk.png", //$NON-NLS-1$
+                true);
+
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_LCL_FLAT_LAYOUT, PATH_ELOCALTOOL + "flatLayout.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_LCL_HIERARCHICAL_LAYOUT, PATH_ELOCALTOOL + "hierarchicalLayout.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEM_CATEGORY, PATH_ETOOL + "problem_category.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEMS_VIEW, PATH_EVIEW + "problems_view.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEMS_VIEW_ERROR, PATH_EVIEW + "problems_view_error.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEMS_VIEW_WARNING, PATH_EVIEW + "problems_view_warning.png", true); //$NON-NLS-1$
+        declareWorkbenchImage(ideBundle, IDEInternalWorkbenchImages.IMG_ETOOL_PROBLEMS_VIEW_INFO, PATH_EVIEW + "problems_view_info.png", true); //$NON-NLS-1$
     }
 
+    /**
+     * Declares an IDE-specific workbench image.
+     *
+     * @param symbolicName
+     *            the symbolic name of the image
+     * @param path
+     *            the path of the image file; this path is relative to the base
+     *            of the IDE plug-in
+     * @param shared
+     *            <code>true</code> if this is a shared image, and
+     *            <code>false</code> if this is not a shared image
+     * @see IWorkbenchConfigurer#declareImage
+     */
     private void declareWorkbenchImage(Bundle ideBundle, String symbolicName, String path, boolean shared) {
         URL url = FileLocator.find(ideBundle, new Path(path), null);
         ImageDescriptor desc = ImageDescriptor.createFromURL(url);

--- a/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/ApplicationWorkbenchAdvisor.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/ApplicationWorkbenchAdvisor.java
@@ -29,13 +29,13 @@ import org.osgi.framework.Bundle;
 
 /**
  * Tell the workbench how to behave.
- * 
+ *
  * @author Kay Kasemir
  * @author Xihui Chen - IDE-specific workbench images
- * 
+ *
  * Updated {@link ApplicationWorkbenchAdvisor#declareWorkbenchImages()} with new IDE specific images to
- * be in line with Eclipse 4.6 Neon. CSS uses same IDE specific images as Eclipse.
- * 
+ * be in line with Eclipse 4.6 Neon. CSS uses same IDE specific images as Eclipse. Ref: bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=234252
+ *
  * @author <a href="mailto:borut.terpinc@cosylab.com">Borut Terpinc</a>
  */
 
@@ -63,6 +63,7 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
         IDE.registerAdapters();
 
         // declare workbench specific images
+        // According to bug -- bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=234252
         declareWorkbenchImages();
     }
 
@@ -90,7 +91,7 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
     }
 
     /**
-     * Declares all IDE-specific workbench images. CSS uses the same IDE-specific images as Eclipse product. 
+     * Declares all IDE-specific workbench images. CSS uses the same IDE-specific images as Eclipse product.
      * This includes both "shared"
      * images (named in {@link org.eclipse.ui.ide.IDE.SharedImages}) and
      * internal images (named in
@@ -100,19 +101,18 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
      */
     private void declareWorkbenchImages() {
 
-        
         /**
          * prefix:
          * e - enabled icons
          * d - disabled icons
-         * 
+         *
          * lcl - toolbar icons
          * tool - toolbar icons
-         * obj - model object icons 
-         * wizban - wizdard icons 
+         * obj - model object icons
+         * wizban - wizdard icons
          * eviewview - icons
          */
-        
+
         final String ICONS_PATH = "$nl$/icons/full/";//$NON-NLS-1$
         final String PATH_ELOCALTOOL = ICONS_PATH + "elcl16/"; //$NON-NLS-1$
         final String PATH_DLOCALTOOL = ICONS_PATH + "dlcl16/"; //$NON-NLS-1$


### PR DESCRIPTION
Updates to latest versions also made for Orbit, Swtboot, and Efxclipse.
ApplicationWorkbenchAdvisor.java was changed to resolve the issue with small icons.
Jacoco plugin was commented out for faster build. 