### PR TITLE
Zoom linking container connections bug fix

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractOpiBuilderAnchor.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractOpiBuilderAnchor.java
@@ -9,14 +9,12 @@ package org.csstudio.opibuilder.editparts;
 
 import org.eclipse.draw2d.AbstractConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
 
 /**
- * We have multiple implementations of the Anchor, and the
- * {@link FixedPointsConnectionRouter} needs to know orientation in
- * which the connector connects to the widget in order to correctly
- * calculate the route.
- * This becomes especially important once the widgets change positions
- * (are animated) through some action.
+ * We have multiple implementations of the Anchor, and the {@link FixedPointsConnectionRouter} needs to know orientation in which the connector
+ * connects to the widget in order to correctly calculate the route. This becomes especially important once the widgets change positions (are
+ * animated) through some action.
  *
  * @author mvitorovic
  */
@@ -27,10 +25,38 @@ abstract public class AbstractOpiBuilderAnchor extends AbstractConnectionAnchor 
      *
      * @author mvitorovic
      */
-    public static enum ConnectorOrientation { HORIZONTAL, VERTICAL }
+    public static enum ConnectorOrientation {
+        HORIZONTAL, VERTICAL
+    }
 
     public AbstractOpiBuilderAnchor(IFigure owner) {
         super(owner);
+    }
+
+    /**
+     * <p>
+     * In case of linking container zoom edge cases appear when linked OPI contains elements staring on point(0,0).
+     * When zooming some anchor points get out of linked container box. This causes broken connection, as
+     * anchor is no longer found.
+     *<p>
+     * This is fixed by moving the anchor back into the bounds of linking container.
+     *
+     * @author Borut Terpinc
+     *
+     * @param point - reference to anchor point
+     * @param owner - reference to the figure
+     *
+     */
+
+    public static void fixZoomEdgeRounding(Point point, IFigure owner) {
+        final Point checkPoint = point.getCopy();
+        owner.getParent().translateToRelative(checkPoint);
+        if (checkPoint.x < 0) {
+            point = point.translate(Math.abs(checkPoint.x), 0);
+        }
+        if (checkPoint.y < 0) {
+            point = point.translate(0, Math.abs(checkPoint.y));
+        }
     }
 
     /**

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/FixedPositionAnchor.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/FixedPositionAnchor.java
@@ -11,23 +11,16 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 
-/**The anchor is on a fixed position of the figure.
- * For example, left, right, top left, ...
+/**
+ * The anchor is on a fixed position of the figure. For example, left, right, top left, ...
+ *
  * @author Xihui Chen
  *
  */
 public class FixedPositionAnchor extends AbstractOpiBuilderAnchor {
 
     public enum AnchorPosition {
-        TOP,
-        LEFT,
-//        CENTER,
-        RIGHT,
-        BOTTOM,
-        TOP_LEFT,
-        TOP_RIGHT,
-        BOTTOM_LEFT,
-        BOTTOM_RIGHT;
+        TOP, LEFT, RIGHT, BOTTOM, TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT;
     }
 
     private AnchorPosition anchorPosition;
@@ -51,17 +44,14 @@ public class FixedPositionAnchor extends AbstractOpiBuilderAnchor {
 
     }
 
-
     public FixedPositionAnchor(IFigure owner, AnchorPosition anchorPosition) {
         super(owner);
         this.anchorPosition = anchorPosition;
     }
 
     /**
-     * Returns the bounds of this ChopboxAnchor's owner. Subclasses can override
-     * this method to adjust the box the anchor can be placed on. For instance,
-     * the owner figure may have a drop shadow that should not be included in
-     * the box.
+     * Returns the bounds of this ChopboxAnchor's owner. Subclasses can override this method to adjust the box the anchor can be placed on. For
+     * instance, the owner figure may have a drop shadow that should not be included in the box.
      *
      * @return The bounds of this ChopboxAnchor's owner
      * @since 2.0
@@ -75,26 +65,25 @@ public class FixedPositionAnchor extends AbstractOpiBuilderAnchor {
         return getLocation(null);
     }
 
-
     @Override
     public Point getLocation(Point reference) {
         Rectangle box = getBox();
-        int x=box.x, y=box.y;
+        int x = box.x, y = box.y;
         switch (anchorPosition) {
         case BOTTOM:
         case BOTTOM_LEFT:
         case BOTTOM_RIGHT:
-            y=box.y + box.height;
+            y = box.y + box.height;
             break;
-//        case CENTER:
+        // case CENTER:
         case LEFT:
         case RIGHT:
-            y=box.y + box.height/2;
+            y = box.y + box.height / 2;
             break;
         case TOP:
         case TOP_LEFT:
         case TOP_RIGHT:
-            y=box.y;
+            y = box.y;
             break;
         default:
             break;
@@ -104,23 +93,24 @@ public class FixedPositionAnchor extends AbstractOpiBuilderAnchor {
         case LEFT:
         case BOTTOM_LEFT:
         case TOP_LEFT:
-            x=box.x;
+            x = box.x;
             break;
-//        case CENTER:
+        // case CENTER:
         case TOP:
         case BOTTOM:
-            x=box.x + box.width/2;
+            x = box.x + box.width / 2;
             break;
         case BOTTOM_RIGHT:
         case RIGHT:
         case TOP_RIGHT:
-            x=box.x + box.width;
+            x = box.x + box.width;
             break;
         default:
             break;
         }
-        Point p= new Point(x, y);
+        Point p = new Point(x, y);
         getOwner().translateToAbsolute(p);
+        fixZoomEdgeRounding(p, getOwner());
         return p;
     }
 
@@ -135,23 +125,20 @@ public class FixedPositionAnchor extends AbstractOpiBuilderAnchor {
     public boolean equals(Object obj) {
         if (obj instanceof FixedPositionAnchor) {
             FixedPositionAnchor other = (FixedPositionAnchor) obj;
-            return other.getOwner() == getOwner()
-                    && other.getBox().equals(getBox()) &&
-                            other.anchorPosition == anchorPosition;
+            return other.getOwner() == getOwner() && other.getBox().equals(getBox()) && other.anchorPosition == anchorPosition;
         }
         return false;
     }
 
     /**
-     * The owning figure's hashcode is used since equality is approximately
-     * based on the owner.
+     * The owning figure's hashcode is used since equality is approximately based on the owner.
      *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
         if (getOwner() != null)
-            return getOwner().hashCode()^(anchorPosition.ordinal()+31);
+            return getOwner().hashCode() ^ (anchorPosition.ordinal() + 31);
         else
             return super.hashCode();
     }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PolyGraphAnchor.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PolyGraphAnchor.java
@@ -42,6 +42,7 @@ public class PolyGraphAnchor extends AbstractOpiBuilderAnchor {
     public Point getLocation(Point reference) {
         Point p = polyline.getPoints().getPoint(pointIndex);
         polyline.translateToAbsolute(p);
+        fixZoomEdgeRounding(p, getOwner());
         return p;
     }
 


### PR DESCRIPTION
When zooming, some connection anchors were moved out of bounds. This
caused connections from linking containers to disappear.