### PR TITLE
2002: Also change OPI Shell

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -244,7 +244,7 @@ public final class OPIShell implements IOPIRuntime {
 
     private DisplayModel createDisplayModel() throws Exception {
         displayModel = new DisplayModel(path);
-        XMLUtil.fillDisplayModelFromInputStream(ResourceUtil.pathToInputStream(path), displayModel);
+        XMLUtil.fillDisplayModelFromInputStream(ResourceUtil.pathToInputStream(path), displayModel, null, macrosInput);
         if (macrosInput != null) {
             macrosInput = macrosInput.getCopy();
             macrosInput.getMacrosMap().putAll(displayModel.getMacrosInput().getMacrosMap());


### PR DESCRIPTION
This changes OPI Shell so that it benefits from the changes made for https://github.com/ControlSystemStudio/cs-studio/issues/2002.

Specifically the Shell will now fill the DisplayModel from the XML using the parent displays macro map, as the OPIRuntimeDelegate is already doing.