### PR TITLE
2204 tray

### DIFF
--- a/core/utility/utility-features/org.csstudio.core.trayicon.feature/build.properties
+++ b/core/utility/utility-features/org.csstudio.core.trayicon.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/core/utility/utility-features/org.csstudio.core.trayicon.feature/feature.xml
+++ b/core/utility/utility-features/org.csstudio.core.trayicon.feature/feature.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.csstudio.core.trayicon.feature"
+      label="Minimize to Tray Feature"
+      version="4.1.0.qualifier">
+
+   <description>
+      Feature containing the 'minimize to tray' functionality.
+   </description>
+
+   <plugin
+         id="org.csstudio.trayicon"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/core/utility/utility-features/org.csstudio.core.trayicon.feature/pom.xml
+++ b/core/utility/utility-features/org.csstudio.core.trayicon.feature/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.csstudio</groupId>
+    <artifactId>utility-features</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.csstudio.core.trayicon.feature</artifactId>
+  <packaging>eclipse-feature</packaging>
+  <version>4.1.0-SNAPSHOT</version>
+</project>

--- a/core/utility/utility-features/org.csstudio.core.utility.feature/feature.xml
+++ b/core/utility/utility-features/org.csstudio.core.utility.feature/feature.xml
@@ -128,13 +128,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.csstudio.trayicon"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-
-
 </feature>

--- a/core/utility/utility-features/org.csstudio.core.utility.feature/feature.xml
+++ b/core/utility/utility-features/org.csstudio.core.utility.feature/feature.xml
@@ -128,4 +128,13 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.csstudio.trayicon"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+
+
 </feature>

--- a/core/utility/utility-features/pom.xml
+++ b/core/utility/utility-features/pom.xml
@@ -13,6 +13,9 @@
       org.csstudio.core.utility.feature
     </module>
     <module>
+      org.csstudio.core.trayicon.feature
+    </module>
+    <module>
       org.csstudio.core.utility.rap.feature
     </module>
   </modules>

--- a/core/utility/utility-plugins/org.csstudio.trayicon/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/META-INF/MANIFEST.MF
@@ -1,0 +1,19 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: CS-Studio Tray Icon
+Bundle-SymbolicName: org.csstudio.trayicon;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.swt,
+ org.csstudio.startup;bundle-version="3.2.1",
+ org.csstudio.utility.product,
+ org.eclipse.ui;bundle-version="3.108.1",
+ org.eclipse.equinox.app;bundle-version="1.3.400",
+ org.eclipse.e4.core.services;bundle-version="2.0.100",
+ javax.inject;bundle-version="1.0.0",
+ org.eclipse.osgi.services;bundle-version="3.5.100",
+ org.eclipse.e4.ui.workbench,
+ org.eclipse.e4.core.contexts,
+ org.eclipse.e4.core.di;bundle-version="1.6.1",
+ org.eclipse.core.runtime;bundle-version="3.12.0"
+Export-Package: org.csstudio.trayicon

--- a/core/utility/utility-plugins/org.csstudio.trayicon/build.properties
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/build.properties
@@ -1,0 +1,7 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               preferences.ini,\
+               plugin.xml
+src.includes = preferences.ini

--- a/core/utility/utility-plugins/org.csstudio.trayicon/plugin.xml
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/plugin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            category="org.csstudio.platform.ui.css.platform"
+            class="org.csstudio.trayicon.TrayIconPreferencePage"
+            id="org.csstudio.trayicon"
+            name="Minimize to Tray">
+      </page>
+   </extension>
+</plugin>

--- a/core/utility/utility-plugins/org.csstudio.trayicon/pom.xml
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.csstudio</groupId>
+    <artifactId>utility-plugins</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.csstudio.trayicon</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/core/utility/utility-plugins/org.csstudio.trayicon/preferences.ini
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/preferences.ini
@@ -1,0 +1,5 @@
+# Default settings for tray icon.
+# Final product can override in its plugin_preferences.ini
+
+minimize_to_tray = prompt
+start_minimized = false

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/Messages.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/Messages.java
@@ -1,0 +1,34 @@
+package org.csstudio.trayicon;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.csstudio.trayicon.messages"; //$NON-NLS-1$
+
+    public static String TrayDialog_rememberDecision;
+    public static String TrayDialog_title;
+    public static String TrayDialog_question;
+    public static String TrayDialog_minimize;
+    public static String TrayDialog_exit;
+    public static String TrayDialog_cancel;
+
+    public static String TrayPreferences_saveFailed;
+    public static String TrayPreferences_minimize;
+    public static String TrayPreferences_startMinimized;
+    public static String TrayPreferences_always;
+    public static String TrayPreferences_never;
+    public static String TrayPreferences_prompt;
+
+    public static String TrayIcon_open;
+    public static String TrayIcon_exit;
+
+    public static String TrayIcon_tooltip;
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() { /* prevent instantiation */ }
+
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/Plugin.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/Plugin.java
@@ -1,0 +1,17 @@
+package org.csstudio.trayicon;
+
+import java.util.logging.Logger;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+
+public class Plugin extends AbstractUIPlugin {
+
+    public static final String ID = "org.csstudio.trayicon";
+
+    private static final Logger logger = Logger.getLogger(ID);
+
+    public static Logger getLogger() {
+        return logger;
+    }
+
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchAdvisor.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchAdvisor.java
@@ -1,0 +1,39 @@
+package org.csstudio.trayicon;
+
+import org.csstudio.startup.application.OpenDocumentEventProcessor;
+import org.csstudio.utility.product.ApplicationWorkbenchAdvisor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
+import org.eclipse.ui.application.WorkbenchWindowAdvisor;
+
+public class TrayApplicationWorkbenchAdvisor extends ApplicationWorkbenchAdvisor {
+
+    private TrayIcon trayIcon;
+
+    public TrayApplicationWorkbenchAdvisor(OpenDocumentEventProcessor openDocProcessor) {
+        super(openDocProcessor);
+        trayIcon = new TrayIcon();
+    }
+
+    @Override
+    public WorkbenchWindowAdvisor createWorkbenchWindowAdvisor(final IWorkbenchWindowConfigurer configurer) {
+        return new TrayApplicationWorkbenchWindowAdvisor(configurer, trayIcon);
+    }
+
+    @Override
+    public void postStartup() {
+        IEclipseContext context = PlatformUI.getWorkbench().getService(IEclipseContext.class);
+        // Initialise a perspective saver.
+        TrayListener trayListener = ContextInjectionFactory.make(TrayListener.class, context);
+        trayListener.setTrayIcon(trayIcon);
+        IPreferencesService prefsService = Platform.getPreferencesService();
+        if (prefsService.getBoolean(Plugin.ID, TrayIconPreferencePage.START_MINIMIZED, false, null)) {
+            trayIcon.minimize();
+        }
+    }
+
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchWindowAdvisor.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchWindowAdvisor.java
@@ -1,0 +1,123 @@
+package org.csstudio.trayicon;
+
+import java.io.IOException;
+
+import org.csstudio.utility.product.ApplicationWorkbenchWindowAdvisor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+public class TrayApplicationWorkbenchWindowAdvisor extends ApplicationWorkbenchWindowAdvisor {
+
+    // This requires internal understanding. Since we have changed the labels on
+    // the dialog, MessageButtonWithDialog does not assign standard return codes.
+    // This is fixed in Oxygen but for now we need to know what is going to be returned.
+    public static final String[] BUTTON_LABELS = {
+            Messages.TrayDialog_minimize,
+            Messages.TrayDialog_exit,
+            Messages.TrayDialog_cancel};
+    private static final int MINIMIZE_BUTTON_ID = 256;
+    private static final int EXIT_BUTTON_ID = 257;
+    private static final int CANCEL_BUTTON_ID = IDialogConstants.CANCEL_ID;
+    private static final int DIALOG_CLOSED = -1;
+
+    private TrayIcon trayIcon;
+
+    public TrayApplicationWorkbenchWindowAdvisor(IWorkbenchWindowConfigurer configurer, TrayIcon trayIcon) {
+        super(configurer);
+        this.trayIcon = trayIcon;
+    }
+
+    /**
+     * Prompt the user for selection of minimise on exit behaviour.
+     *
+     * @return xx_BUTTON_ID of clicked button or DIALOG_CLOSED
+     */
+    private int promptForAction() {
+        Shell parent = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+        ScopedPreferenceStore store = new ScopedPreferenceStore(InstanceScope.INSTANCE, Plugin.ID);
+        MessageDialogWithToggle dialog = new MessageDialogWithToggle(parent, Messages.TrayDialog_title, null,
+                Messages.TrayDialog_question, MessageDialog.QUESTION, BUTTON_LABELS, 2,
+                Messages.TrayDialog_rememberDecision, false);
+        dialog.open();
+
+        int response = dialog.getReturnCode();
+
+        // Store the decision if checkbox selected on the form
+        if (dialog.getToggleState()) {
+            if (response == MINIMIZE_BUTTON_ID) {
+                store.setValue(TrayIconPreferencePage.MINIMIZE_TO_TRAY, MessageDialogWithToggle.ALWAYS);
+            } else if (response == EXIT_BUTTON_ID) {
+                store.setValue(TrayIconPreferencePage.MINIMIZE_TO_TRAY, MessageDialogWithToggle.NEVER);
+            }
+            try {
+                store.save();
+            } catch (IOException e) {
+                Plugin.getLogger().warning(Messages.TrayPreferences_saveFailed + e.getMessage());
+            }
+        }
+        return response;
+    }
+
+    /**
+     * Manage a close event based on the user preferences, user action
+     *
+     *  Three possible outcomes:
+     *  i) abort the exit (return False)
+     *      * user:CANCEL
+     *      * user:DIALOG_CLOSED
+     *  ii) continue to close this window and possibly the application (return preWindowShellClose())
+     *      * preference:NEVER
+     *      * user:EXIT
+     *      * multiple open windows
+     *      * application already minimised
+     *  iii) create trayIcon, minimise window but do not exit (return False)
+     *      * preference:ALWAYS
+     *      * user:MINIMIZE
+     *
+     * @see org.eclipse.ui.application.WorkbenchWindowAdvisor#preWindowShellClose
+     */
+    @Override
+    public boolean preWindowShellClose() {
+
+        boolean closeWindow;
+        int userAction = DIALOG_CLOSED;
+        int numWindows = PlatformUI.getWorkbench().getWorkbenchWindowCount();
+
+        IPreferencesService prefs = Platform.getPreferencesService();
+        String minPref = prefs.getString(
+                Plugin.ID, TrayIconPreferencePage.MINIMIZE_TO_TRAY, null, null);
+
+        if (minPref.equals(MessageDialogWithToggle.PROMPT) &&
+                numWindows == 1) {  // no prompt if multiple windows
+            userAction = promptForAction();
+        }
+
+        if (numWindows > 1 ||
+                trayIcon.isMinimized() ||
+                minPref.equals(MessageDialogWithToggle.NEVER) ||
+                userAction == EXIT_BUTTON_ID) {  // user action: exit
+            // allow to continue
+            closeWindow = super.preWindowShellClose();
+        }
+        else if (minPref.equals(MessageDialogWithToggle.ALWAYS) ||
+                userAction == MINIMIZE_BUTTON_ID) {
+            // minimise the window and block application exit
+            trayIcon.minimize();
+            closeWindow = false;
+        }
+        else {  // user_action is CANCEL_BUTTON_ID or DIALOG_CLOSED
+            // block application exit
+            closeWindow = false;
+        }
+
+        return closeWindow;
+    }
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayIcon.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayIcon.java
@@ -1,0 +1,134 @@
+package org.csstudio.trayicon;
+
+import org.csstudio.utility.product.Activator;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.TrayItem;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+public class TrayIcon {
+
+    private static final String IMAGE_FILE = "icons/css.ico";
+    private static final Image IMAGE = Activator.getImageDescriptor(IMAGE_FILE).createImage();
+    private TrayItem trayItem;
+    private IWorkbenchWindow[] windows;
+
+    private boolean minimized;
+    public boolean isMinimized() {
+        return minimized;
+    }
+
+    /**
+     * Minimize the application to a tray icon.
+     *  - left-click will reopen the window(s)
+     *  - right-click popup menu to open or exit.
+     *
+     */
+    public void minimize() {
+        windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+        for (IWorkbenchWindow window : PlatformUI.getWorkbench().getWorkbenchWindows()) {
+            window.getShell().setVisible(false);
+        }
+
+        trayItem = createTrayItem();
+        minimized = true;
+    }
+
+    /**
+     * Restore application window(s) from the toolbar.
+     */
+    public void unminimize() {
+        for (IWorkbenchWindow window : windows) {
+            raiseWindow(window.getShell());
+        }
+        removeFromTray();
+        minimized = false;
+    }
+
+    /**
+     * Cleanup the trayItem
+     */
+    private void removeFromTray() {
+        trayItem.dispose();
+    }
+
+    private void raiseWindow(Shell shell) {
+        shell.setVisible(true);
+        shell.setActive();
+        shell.setFocus();
+        shell.setMinimized(false);
+        shell.layout();
+    }
+
+    /**
+     * Create a Tray widget for CS-Studio with wrapped popup menu
+     */
+    private TrayItem createTrayItem() {
+
+        Menu menu = createPopupMenu();
+
+        TrayItem item = new TrayItem(Display.getCurrent().getSystemTray(), SWT.NONE);
+        item.setImage(IMAGE);
+        item.setToolTipText(Messages.TrayIcon_tooltip);
+        item.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                unminimize();
+            }
+        });
+        item.addListener(SWT.MenuDetect, new Listener() {
+            @Override
+            public void handleEvent(Event event) {
+                menu.setVisible(true);
+            }
+        });
+        // Clean-up the popup menu when the trayItem is disposed. The child
+        // menuItems are disposed when their menu is disposed.
+        item.addListener(SWT.Dispose, new Listener() {
+            @Override
+            public void handleEvent(Event event) {
+                menu.dispose();
+            }
+        });
+
+        return item;
+    }
+
+    private Menu createPopupMenu() {
+        // Create a Menu
+        Menu popupMenu = new Menu(windows[0].getShell(), SWT.POP_UP);
+
+        // Create the open menu item.
+        MenuItem openMenuItem = new MenuItem(popupMenu, SWT.PUSH);
+        openMenuItem.setText(Messages.TrayIcon_open);
+        openMenuItem.addListener(SWT.Selection, new Listener() {
+            @Override
+            public void handleEvent(Event event) {
+                unminimize();
+            }
+        });
+
+        // Create the exit menu item.
+        MenuItem exitMenuItem = new MenuItem(popupMenu, SWT.PUSH);
+        exitMenuItem.setText(Messages.TrayIcon_exit);
+        exitMenuItem.addListener(SWT.Selection, new Listener() {
+            @Override
+            public void handleEvent(Event event) {
+                removeFromTray();
+                PlatformUI.getWorkbench().close();
+            }
+        });
+
+        return popupMenu;
+    }
+
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayIconPreferencePage.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayIconPreferencePage.java
@@ -1,0 +1,42 @@
+package org.csstudio.trayicon;
+
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.RadioGroupFieldEditor;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+public class TrayIconPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+    public static final String MINIMIZE_TO_TRAY = "minimize_to_tray";
+    public static final String START_MINIMIZED = "start_minimized";
+    private ScopedPreferenceStore store;
+
+    @Override
+    protected void createFieldEditors() {
+        final Composite parent = getFieldEditorParent();
+
+        RadioGroupFieldEditor minimizeOnCloseEditor = new RadioGroupFieldEditor(
+                MINIMIZE_TO_TRAY,
+                Messages.TrayPreferences_minimize, 3,
+                new String[][] {{Messages.TrayPreferences_always, MessageDialogWithToggle.ALWAYS},
+                                {Messages.TrayPreferences_never, MessageDialogWithToggle.NEVER},
+                                {Messages.TrayPreferences_prompt, MessageDialogWithToggle.PROMPT}},
+                parent, true);
+        addField(minimizeOnCloseEditor);
+        BooleanFieldEditor startMinimizedEditor = new BooleanFieldEditor(START_MINIMIZED,
+                Messages.TrayPreferences_startMinimized, BooleanFieldEditor.DEFAULT, parent);
+        addField(startMinimizedEditor);
+    }
+
+    @Override
+    public void init(IWorkbench workbench) {
+        store = new ScopedPreferenceStore(InstanceScope.INSTANCE, Plugin.ID);
+        setPreferenceStore(store);
+    }
+
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayListener.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayListener.java
@@ -1,0 +1,37 @@
+package org.csstudio.trayicon;
+
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.eclipse.e4.core.services.events.IEventBroker;
+import org.eclipse.e4.ui.workbench.UIEvents;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+
+public class TrayListener implements EventHandler {
+
+    private TrayIcon trayIcon;
+
+    @Inject
+    private IEventBroker broker;
+
+    @PostConstruct
+    public void lazyLoadInContributorPerspective() {
+        // Subscribe to any part (Editor or View) being activated.
+        broker.subscribe(UIEvents.UILifeCycle.ACTIVATE, this);
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        // When an event is received, maximise the window.
+        if (trayIcon != null && trayIcon.isMinimized()) {
+            trayIcon.unminimize();
+        }
+    }
+
+    public void setTrayIcon(TrayIcon trayIcon) {
+        this.trayIcon = trayIcon;
+    }
+
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayWorkbench.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayWorkbench.java
@@ -1,0 +1,27 @@
+package org.csstudio.trayicon;
+
+import java.util.Map;
+
+import org.csstudio.startup.application.OpenDocumentEventProcessor;
+import org.csstudio.startup.module.WorkbenchExtPoint;
+import org.csstudio.utility.product.Workbench;
+import org.eclipse.ui.application.WorkbenchAdvisor;
+
+public class TrayWorkbench extends Workbench implements WorkbenchExtPoint {
+
+    /**
+     * Creates a workbench advisor that allows minimising the application
+     * to the system tray when closing the last workbench window.
+     *
+     * @param parameters the parameters that may give hints on how to create the advisor
+     * @return a new advisor instance
+     */
+    @Override
+    protected WorkbenchAdvisor createWorkbenchAdvisor(final Map<String, Object> parameters) {
+        final OpenDocumentEventProcessor openDocProcessor =
+                  (OpenDocumentEventProcessor) parameters.get(
+                          OpenDocumentEventProcessor.OPEN_DOC_PROCESSOR);
+        return new TrayApplicationWorkbenchAdvisor(openDocProcessor);
+    }
+
+}

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/messages.properties
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/messages.properties
@@ -1,0 +1,18 @@
+TrayDialog_rememberDecision=Remember my decision
+TrayDialog_title=Minimize to System Tray?
+TrayDialog_question=This is the last CS-Studio window.  Should CS-Studio minimize to the System Tray or exit?
+
+TrayDialog_minimize=Minimize
+TrayDialog_exit=Exit Now
+TrayDialog_cancel=Cancel
+
+TrayPreferences_saveFailed=Failed to save preference:
+TrayPreferences_minimize=Minimize to system tray when closing last window?
+TrayPreferences_startMinimized=Start CS-Studio minimized?
+TrayPreferences_always=Always
+TrayPreferences_never=Never
+TrayPreferences_prompt=Prompt
+
+TrayIcon_open=Open Window
+TrayIcon_exit=Exit CS-Studio
+TrayIcon_tooltip=CS-Studio

--- a/core/utility/utility-plugins/pom.xml
+++ b/core/utility/utility-plugins/pom.xml
@@ -23,6 +23,7 @@
     <module>org.csstudio.security.ui.test</module>
     <module>org.csstudio.startup</module>
     <module>org.csstudio.startup.helper</module>
+    <module>org.csstudio.trayicon</module>
     <module>org.csstudio.utility.batik</module>
     <module>org.csstudio.utility.product</module>
     <module>org.csstudio.utility.product.test</module>

--- a/core/utility/utility-repository/category.xml
+++ b/core/utility/utility-repository/category.xml
@@ -6,6 +6,12 @@
    <feature id="org.csstudio.core.utility.feature.source">
       <category name="org.csstudio.category.core"/>
    </feature>
+   <feature id="org.csstudio.core.trayicon.feature">
+      <category name="org.csstudio.category.core"/>
+   </feature>
+   <feature id="org.csstudio.core.trayicon.feature.source">
+      <category name="org.csstudio.category.core"/>
+   </feature>
    <feature id="org.csstudio.core.utility.rap.feature">
       <category name="org.csstudio.category.core"/>
    </feature>


### PR DESCRIPTION
@berryma4 @lcavalli this is a pull request that should meet the requirements in #2204.  

The behaviour is as follows:

* When the last window is closed, prompt whether to exit cs-studio or to minimise to system tray
* There is a preference option to remember this choice
* From system tray, you can click and either restore or exit
* There is a preference option to start minimised

Because of our use of standalone windows, we find that people are accidentally closing the main window and losing their standalone windows as well.

In order not to disrupt sites that do not want this behaviour, it is not enabled by default.  In order to enable this behaviour, you need to:

* include in `org.csstudio.core.trayicon.feature` in your product
* extend `org.csstudio.startup.module` and use `org.csstudio.trayicon.TrayWorkbench` as your workbench

```
   <extension
         point="org.csstudio.startup.module">
      <startupParameters
            class="org.csstudio.utility.product.StartupParameters">
      </startupParameters>
      <workspace
            class="org.csstudio.utility.product.WorkspacePrompt">
      </workspace>
      <workbench
            class="org.csstudio.trayicon.TrayWorkbench">
      </workbench>
      <project
            class="org.csstudio.startup.module.defaults.DefaultProject">
      </project>
</extension>
```