### PR TITLE
Tool-tip override fix

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/AbstractSWTWidgetFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/AbstractSWTWidgetFigure.java
@@ -68,10 +68,20 @@ public abstract class AbstractSWTWidgetFigure<T extends Control> extends Figure 
 
         @Override
         public void mouseEnter(MouseEvent e) {
-            control.setToolTipText(editPart.getWidgetModel()
+            control.setToolTipText(getConnectionText() + editPart.getWidgetModel()
                     .getTooltip());
         };
+        private String getConnectionText(){
+            if (editPart == null || editPart.getConnectionHandler() == null || editPart.getConnectionHandler().getToolTipText() == null){
+            return "";
+            }
+            return editPart.getConnectionHandler().getToolTipText();
+        }
+
+
     }
+
+
     protected boolean runmode;
     protected AbstractBaseEditPart editPart;
 
@@ -499,6 +509,7 @@ public abstract class AbstractSWTWidgetFigure<T extends Control> extends Figure 
         Runnable task;
         if (wrapComposite != null) {
             task = new Runnable() {
+                @Override
                 public void run() {
                     if (!wrapComposite.isDisposed()) {
                         getSWTWidget().setMenu(null);
@@ -509,6 +520,7 @@ public abstract class AbstractSWTWidgetFigure<T extends Control> extends Figure 
             };
         } else {
             task = new Runnable() {
+                @Override
                 public void run() {
                     if (!getSWTWidget().isDisposed()) {
                         getSWTWidget().setMenu(null);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/AbstractBaseEditPart.java
@@ -136,10 +136,10 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
 
     private boolean hasStartedPVs = false;
 
-    public AbstractBaseEditPart() {
+   public AbstractBaseEditPart() {
         propertyListenerMap = new HashMap<String, WidgetPropertyChangeListener>();
+     }
 
-    }
 
     @Override
     public void activate() {
@@ -409,7 +409,7 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
         return null;
     }
 
-    protected ConnectionHandler getConnectionHandler() {
+    public ConnectionHandler getConnectionHandler() {
         return connectionHandler;
     }
 
@@ -559,7 +559,7 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
 
         if (allPropIds.contains(AbstractWidgetModel.PROP_TOOLTIP)) {
             if (!getWidgetModel().getTooltip().equals("")) { //$NON-NLS-1$
-                tooltipLabel = new TooltipLabel(getWidgetModel());
+                tooltipLabel = new TooltipLabel(this);
                 figure.setToolTip(tooltipLabel);
             }
         }
@@ -701,7 +701,7 @@ public abstract class AbstractBaseEditPart extends AbstractGraphicalEditPart imp
                     figure.setToolTip(null);
                 else {
                     if (tooltipLabel == null)
-                        tooltipLabel = new TooltipLabel(getWidgetModel());
+                        tooltipLabel = new TooltipLabel(AbstractBaseEditPart.this);
                     figure.setToolTip(tooltipLabel);
                 }
                 return false;

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/ConnectionHandler.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/ConnectionHandler.java
@@ -61,15 +61,7 @@ public class ConnectionHandler {
      */
     private boolean connected;
 
-    /**
-     * The origin tooltip property value.
-     */
-    private String originTooltip;
-
-    /**
-     * The previous tool tip when is was connected.
-     */
-    private String preTooltip;
+    private String toolTipText;
 
     private IFigure figure;
 
@@ -89,8 +81,6 @@ public class ConnectionHandler {
         widgetModel = editpart.getWidgetModel();
         this.display = editpart.getViewer().getControl().getDisplay();
         pvMap = new ConcurrentHashMap<String, IPV>();
-        preTooltip = widgetModel.getRawTooltip();
-        originTooltip = preTooltip;
         connected = true;
     }
 
@@ -122,19 +112,15 @@ public class ConnectionHandler {
         }
         if(sb.length()>0){
             sb.append("------------------------------\n");
-            widgetModel.setTooltip(sb.toString() + preTooltip);
+            toolTipText = sb.toString();
         }else
-            widgetModel.setTooltip(originTooltip);
-
+            toolTipText = "";
     }
 
     /**Mark a widget as disconnected.
      * @param pvName the name of the PV that is disconnected.
      */
     protected void markWidgetAsDisconnected(IPV pv){
-        if(connected){
-            preTooltip = widgetModel.getRawTooltip();
-        }
         refreshModelTooltip();
         if(!connected)
             return;
@@ -200,6 +186,10 @@ public class ConnectionHandler {
      */
     public Map<String, IPV> getAllPVs() {
         return pvMap;
+    }
+
+    public String getToolTipText() {
+        return toolTipText;
     }
 
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/visualparts/TooltipLabel.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/visualparts/TooltipLabel.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.visualparts;
 
+import org.csstudio.opibuilder.editparts.AbstractBaseEditPart;
 import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FigureUtilities;
@@ -14,28 +15,54 @@ import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.swt.widgets.Display;
 
-/**Tooltip label which will show the latest tooltip value from its widget model.
+/**
+ * Tooltip label which will show the latest tooltip value from its widget model.
+ *
  * @author Xihui Chen
  *
  */
 public class TooltipLabel extends Figure {
 
     private AbstractWidgetModel widgetModel;
+    private AbstractBaseEditPart editPart;
+    private String tooltipText;
 
     public TooltipLabel(AbstractWidgetModel widgetModel) {
         this.widgetModel = widgetModel;
     }
 
+    public TooltipLabel(AbstractBaseEditPart editPart) {
+        this.widgetModel = editPart.getWidgetModel();
+        this.editPart = editPart;
+    }
+
     @Override
     protected void paintClientArea(Graphics graphics) {
         super.paintClientArea(graphics);
-        graphics.drawText(widgetModel.getTooltip(),1, 1);
+        if (widgetModel == null) {
+            return;
+        }
+        if (tooltipText == null) {
+            tooltipText = getConnectionText() + widgetModel.getTooltip();
+        }
+        graphics.drawText(tooltipText, 1, 1);
     }
 
     @Override
     public Dimension getPreferredSize(int wHint, int hHint) {
-        return FigureUtilities.getTextExtents(
-                widgetModel.getTooltip(), Display.getDefault().getSystemFont()).expand(2,2);
+
+        if (widgetModel == null) {
+            return new Dimension(wHint, hHint);
+        }
+        tooltipText = getConnectionText() + widgetModel.getTooltip();
+        return FigureUtilities.getTextExtents(tooltipText, Display.getDefault().getSystemFont()).expand(2, 2);
+    }
+
+    private String getConnectionText(){
+        if (editPart == null || editPart.getConnectionHandler() == null || editPart.getConnectionHandler().getToolTipText() == null){
+        return "";
+        }
+        return editPart.getConnectionHandler().getToolTipText();
     }
 
 }


### PR DESCRIPTION
#2275 
ConnectionHandler was overriding tool-tip values. This caused inconsistent values when tooltip was changed with javascript.  Architecture was changed, so whenever tool-tip is displayed, it queries connectionHandler for extra connection text to be added to tool-tip. No overriding of
tool-tip property is made, only text is added to figure.

