### PR TITLE
Prevent changing DB pv name to an empty string.

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/ModelItem.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/ModelItem.java
@@ -122,6 +122,8 @@ abstract public class ModelItem
     public boolean setName(String new_name) throws Exception
     {
         new_name = new_name.trim();
+        if (new_name.isEmpty())
+            throw new Exception("Empty PV name");
         if (new_name.equals(name))
             return false;
         name = new_name;


### PR DESCRIPTION
This could get the plot into an inconsistent state where you cannot
delete the item.

See #2284.