### PR TITLE
XYGraph: Only disable 'scrolling' for zoom/pan in time-based plot

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph/src/org/csstudio/swt/xygraph/figures/PlotArea.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.xygraph/src/org/csstudio/swt/xygraph/figures/PlotArea.java
@@ -298,7 +298,7 @@ public class PlotArea extends Figure {
      */
     private void zoomInOut(final boolean horizontally,
             final boolean vertically, final double factor) {
-        xyGraph.getEventManager().setScrollingDisabled(false);
+        disableTimebasedScrolling();
         if (horizontally)
             for (Axis axis : xyGraph.getXAxisList()) {
                 final double center = axis.getPositionValue(start.x, false);
@@ -309,6 +309,27 @@ public class PlotArea extends Figure {
                 final double center = axis.getPositionValue(start.y, false);
                 axis.zoomInOut(center, factor);
             }
+    }
+
+    /** _If_ this is a time-based plot, disabled scrolling
+     *
+     *  <p>Checks if there's any time-based X axis.
+     *  If so, disable scrolling.
+     *
+     *  <p>For plots that don't have a time axis,
+     *  scrolling doesn't really apply but it is used
+     *  internally to allow display updates, which should
+     *  continue for a non-time-based plot.
+     */
+    private void disableTimebasedScrolling()
+    {
+       for (Axis axis : xyGraph.getXAxisList())
+           if (axis.isDateEnabled())
+           {
+               xyGraph.getEventManager().setScrollingDisabled(false);
+               return;
+           }
+       // No time axis found, leave scrolling untouched
     }
 
     /**
@@ -462,7 +483,7 @@ public class PlotArea extends Figure {
                     axis.setRange(t1, t2, true);
                     axis.setScrollingDisabled(true);
                 }
-                xyGraph.getEventManager().setScrollingDisabled(false);
+                disableTimebasedScrolling();
                 break;
             case HORIZONTAL_ZOOM:
                 for (Axis axis : xyGraph.getXAxisList()) {
@@ -472,7 +493,7 @@ public class PlotArea extends Figure {
                     axis.setRange(t1, t2, true);
                     axis.setScrollingDisabled(true);
                 }
-                xyGraph.getEventManager().setScrollingDisabled(false);
+                disableTimebasedScrolling();
                 break;
             case VERTICAL_ZOOM:
                 for (Axis axis : xyGraph.getYAxisList()) {
@@ -482,7 +503,7 @@ public class PlotArea extends Figure {
                     axis.setRange(t1, t2, true);
                     axis.setScrollingDisabled(true);
                 }
-                xyGraph.getEventManager().setScrollingDisabled(false);
+                disableTimebasedScrolling();
                 break;
             case PANNING:
                 pan();
@@ -511,7 +532,7 @@ public class PlotArea extends Figure {
 
         /** Pan axis according to start/end from mouse listener */
         private void pan() {
-            xyGraph.getEventManager().setScrollingDisabled(false);
+            disableTimebasedScrolling();
             List<Axis> axes = xyGraph.getXAxisList();
             for (int i = 0; i < axes.size(); ++i) {
                 final Axis axis = axes.get(i);


### PR DESCRIPTION
Fixes #2318