### PR TITLE
Throttle the rate of updates when using the scaled slider widget

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.csstudio.swt.widgets.datadefinition.IManualValueChangeListener;
 import org.csstudio.swt.widgets.figureparts.AlphaLabel;
 import org.csstudio.swt.widgets.util.GraphicsUtil;
+import org.csstudio.swt.widgets.util.OPITimer;
 import org.csstudio.swt.widgets.util.RepeatFiringBehavior;
 import org.csstudio.swt.xygraph.linearscale.AbstractScale.LabelSide;
 import org.csstudio.swt.xygraph.linearscale.LinearScale;
@@ -430,6 +431,8 @@ public class ScaledSliderFigure extends AbstractLinearMarkedFigure {
 
                 protected boolean armed;
 
+                private OPITimer timer;
+
                 public void mouseDoubleClicked(MouseEvent me) {
 
                 }
@@ -449,8 +452,19 @@ public class ScaledSliderFigure extends AbstractLinearMarkedFigure {
                         double valuePosition =
                                 ((LinearScale)scale).getValuePosition(getCoercedValue(), false);
 
-                        if(value != oldValue){
-                            fireManualValueChange(value);
+                        if(value != oldValue) {
+                            if(timer == null) {
+                                timer = new OPITimer();
+                            }
+                            if(timer.isDue()) {
+                                timer.start(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        fireManualValueChange(value);
+                                        System.out.println("Timer called");
+                                    }
+                                }, 100);
+                            }
                         }
                         start = new Point(
                                     horizontal? valuePosition: 0,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
@@ -461,7 +461,6 @@ public class ScaledSliderFigure extends AbstractLinearMarkedFigure {
                                     @Override
                                     public void run() {
                                         fireManualValueChange(value);
-                                        System.out.println("Timer called");
                                     }
                                 }, 100);
                             }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
@@ -460,6 +460,7 @@ public class ScaledSliderFigure extends AbstractLinearMarkedFigure {
                                 timer.start(new Runnable() {
                                     @Override
                                     public void run() {
+                                        // Update the change listeners with the current value after some delay
                                         fireManualValueChange(value);
                                     }
                                 }, 100);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/figures/ScaledSliderFigure.java
@@ -452,6 +452,9 @@ public class ScaledSliderFigure extends AbstractLinearMarkedFigure {
                         double valuePosition =
                                 ((LinearScale)scale).getValuePosition(getCoercedValue(), false);
 
+                        // Throttle updates to a maximum of 10 Hz. This avoids a large number of
+                        // updates being queued and continuing to update the PV value (and hence
+                        // the slider position) after the drag has finished.
                         if(value != oldValue) {
                             if(timer == null) {
                                 timer = new OPITimer();
@@ -460,7 +463,8 @@ public class ScaledSliderFigure extends AbstractLinearMarkedFigure {
                                 timer.start(new Runnable() {
                                     @Override
                                     public void run() {
-                                        // Update the change listeners with the current value after some delay
+                                        // This call is what finally sets the PV value to the
+                                        // latest cached value.
                                         fireManualValueChange(value);
                                     }
                                 }, 100);


### PR DESCRIPTION
This adds a timer that limits the rate of control updates to once per 100ms to address https://github.com/ControlSystemStudio/cs-studio/issues/2320.