### PR TITLE
Fix for no connections after restart

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editpolicies/WidgetNodeEditPolicy.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editpolicies/WidgetNodeEditPolicy.java
@@ -47,7 +47,7 @@ public class WidgetNodeEditPolicy extends GraphicalNodeEditPolicy {
         // To avoid this situation, we make sure that the schema service is already loaded
         // when we add the first connector. The schema service is a singleton and will
         // just be returned whenever requested from now on.
-        SchemaService.getInstance();
+        SchemaService.getInstance(false);
     }
 
     /**
@@ -148,7 +148,7 @@ public class WidgetNodeEditPolicy extends GraphicalNodeEditPolicy {
         IFigure layer = getLayer(LayerConstants.HANDLE_LAYER);
         handles = createAnchorHandles();
         for (int i = 0; i < handles.size(); i++)
-            layer.add((IFigure) handles.get(i));
+            layer.add(handles.get(i));
     }
 
     /**
@@ -173,7 +173,7 @@ public class WidgetNodeEditPolicy extends GraphicalNodeEditPolicy {
             return;
         IFigure layer = getLayer(LayerConstants.HANDLE_LAYER);
         for (int i = 0; i < handles.size(); i++)
-            layer.remove((IFigure) handles.get(i));
+            layer.remove(handles.get(i));
         handles = null;
     }
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/SchemaService.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/SchemaService.java
@@ -1,5 +1,6 @@
 package org.csstudio.opibuilder.util;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
@@ -22,19 +23,53 @@ import org.eclipse.swt.widgets.Display;
 public final class SchemaService {
 
     private static SchemaService instance;
-
     private Map<String, AbstractWidgetModel> schemaWidgetsMap;
 
 
-    private SchemaService() {
-        schemaWidgetsMap = new HashMap<String, AbstractWidgetModel>();
-        reLoad();
+    /*
+     * Instantiating the schema service with the modal process dialog uses the UI thread.
+     * When process dialog is open in UI thread it interferes with connection which is drawn from/to linking containers.
+     *
+     * This causes bug with the connections not being displayed.
+     *
+     * Instance of SchemaService without dialog is created from first instance of WidgetNodeEditPolicy
+    */
+
+
+    private SchemaService(boolean dialog) {
+        schemaWidgetsMap = new HashMap<>();
+        if (dialog){
+          reLoad();
+        }
+        else {
+          reLoadNoProgressMonitor();
+        }
     }
 
-    public synchronized static final SchemaService getInstance() {
+    public static final synchronized SchemaService getInstance() {
         if (instance == null)
-            instance = new SchemaService();
+            instance = new SchemaService(true);
         return instance;
+    }
+
+    public static final synchronized SchemaService getInstance(boolean dialog) {
+        if (instance == null)
+            instance = new SchemaService(dialog);
+        return instance;
+    }
+
+    /**
+     * Reloading schema OPI without the progress monitor
+     */
+
+    public void reLoadNoProgressMonitor() {
+        schemaWidgetsMap.clear();
+        final IPath schemaOPI = PreferencesHelper.getSchemaOPIPath();
+        if (schemaOPI == null || schemaOPI.isEmpty()) {
+            return;
+        }
+        OPIBuilderPlugin.getLogger().log(Level.INFO, () -> "Schema service: connecting to " + schemaOPI);
+        loadSchema(schemaOPI);
     }
 
     /**
@@ -52,8 +87,7 @@ public final class SchemaService {
                 @Override
                 public void run(IProgressMonitor monitor) throws InvocationTargetException,
                         InterruptedException {
-                    monitor.beginTask("Connecting to " + schemaOPI,
-                            IProgressMonitor.UNKNOWN);
+                    monitor.beginTask("Connecting to " + schemaOPI,IProgressMonitor.UNKNOWN);
                     loadSchema(schemaOPI);
                     monitor.done();
                 }
@@ -67,16 +101,15 @@ public final class SchemaService {
         }
         else
             loadSchema(schemaOPI);
-
     }
 
     /**
      * @param schemaOPI
      */
     public void loadSchema(final IPath schemaOPI) {
+        InputStream inputStream = null;
         try {
-            InputStream inputStream = ResourceUtil.pathToInputStream(
-                    schemaOPI, false);
+            inputStream = ResourceUtil.pathToInputStream(schemaOPI, false);
             DisplayModel displayModel = new DisplayModel(schemaOPI);
             XMLUtil.fillDisplayModelFromInputStream(inputStream,
                     displayModel, Display.getDefault());
@@ -91,6 +124,14 @@ public final class SchemaService {
             OPIBuilderPlugin.getLogger().log(Level.WARNING,
                     message, e);
             ConsoleService.getInstance().writeError(message + "\n" + e);//$NON-NLS-1$
+        }
+        finally {
+           if (inputStream != null)
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                ErrorHandlerUtil.handleError("Failed to close stream", e);
+            }
         }
     }
 


### PR DESCRIPTION
Instance of SchemaService without dialog is created from first instance
of WidgetNodeEditPolicy. The dialog was interfering with the
connections, so no connections were displayed after restart. 
#2326 