### PR TITLE
Don't use WorkbenchAdvisor.eventLoopIdle() to do background work.

### DIFF
--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchAdvisor.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchAdvisor.java
@@ -1,6 +1,5 @@
 package org.csstudio.trayicon;
 
-import org.csstudio.startup.application.OpenDocumentEventProcessor;
 import org.csstudio.utility.product.ApplicationWorkbenchAdvisor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
@@ -14,8 +13,8 @@ public class TrayApplicationWorkbenchAdvisor extends ApplicationWorkbenchAdvisor
 
     private TrayIcon trayIcon;
 
-    public TrayApplicationWorkbenchAdvisor(OpenDocumentEventProcessor openDocProcessor) {
-        super(openDocProcessor);
+    public TrayApplicationWorkbenchAdvisor() {
+        super();
         trayIcon = new TrayIcon();
     }
 

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayWorkbench.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayWorkbench.java
@@ -2,7 +2,6 @@ package org.csstudio.trayicon;
 
 import java.util.Map;
 
-import org.csstudio.startup.application.OpenDocumentEventProcessor;
 import org.csstudio.startup.module.WorkbenchExtPoint;
 import org.csstudio.utility.product.Workbench;
 import org.eclipse.ui.application.WorkbenchAdvisor;
@@ -18,10 +17,7 @@ public class TrayWorkbench extends Workbench implements WorkbenchExtPoint {
      */
     @Override
     protected WorkbenchAdvisor createWorkbenchAdvisor(final Map<String, Object> parameters) {
-        final OpenDocumentEventProcessor openDocProcessor =
-                  (OpenDocumentEventProcessor) parameters.get(
-                          OpenDocumentEventProcessor.OPEN_DOC_PROCESSOR);
-        return new TrayApplicationWorkbenchAdvisor(openDocProcessor);
+        return new TrayApplicationWorkbenchAdvisor();
     }
 
 }

--- a/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/ApplicationWorkbenchAdvisor.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/ApplicationWorkbenchAdvisor.java
@@ -9,7 +9,6 @@ package org.csstudio.utility.product;
 
 import java.net.URL;
 
-import org.csstudio.startup.application.OpenDocumentEventProcessor;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
@@ -17,7 +16,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.application.IWorkbenchConfigurer;
 import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
 import org.eclipse.ui.application.WorkbenchAdvisor;
@@ -43,10 +41,7 @@ import org.osgi.framework.Bundle;
 @SuppressWarnings("restriction")
 public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
 
-    protected OpenDocumentEventProcessor openDocProcessor;
-
-    public ApplicationWorkbenchAdvisor(OpenDocumentEventProcessor openDocProcessor) {
-        this.openDocProcessor = openDocProcessor;
+    public ApplicationWorkbenchAdvisor() {
     }
 
     @Override
@@ -72,13 +67,6 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
     @Override
     public String getInitialWindowPerspectiveId() {
         return CSStudioPerspective.ID;
-    }
-
-    @Override
-    public void eventLoopIdle(final Display display) {
-        if (openDocProcessor != null)
-            openDocProcessor.catchUp(display);
-        super.eventLoopIdle(display);
     }
 
     @Override

--- a/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/Workbench.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.product/src/org/csstudio/utility/product/Workbench.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 import org.csstudio.logging.LogConfigurator;
 import org.csstudio.platform.workspace.RelaunchConstants;
 import org.csstudio.security.authentication.LoginJob;
-import org.csstudio.startup.application.OpenDocumentEventProcessor;
 import org.csstudio.startup.module.WorkbenchExtPoint;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.equinox.app.IApplication;
@@ -73,10 +72,7 @@ public class Workbench implements WorkbenchExtPoint
      * @return a new advisor instance
      */
     protected WorkbenchAdvisor createWorkbenchAdvisor(final Map<String, Object> parameters) {
-        final OpenDocumentEventProcessor openDocProcessor =
-                  (OpenDocumentEventProcessor) parameters.get(
-                          OpenDocumentEventProcessor.OPEN_DOC_PROCESSOR);
-        return new ApplicationWorkbenchAdvisor(openDocProcessor);
+        return new ApplicationWorkbenchAdvisor();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
The openDisplay jobs are being handled on background threads using asyncExec,
and the eventLoopIdle() method is not reliably called.

Not for merge just yet, needs review @kasemir @berryma4 @shroffk .

See #2329 