### PR TITLE
Copy StringSplitter.java to org.csstudio.opibuilder.converter.

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/META-INF/MANIFEST.MF
@@ -15,8 +15,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.4.1",
  org.eclipse.core.resources;bundle-version="3.4.1",
  org.csstudio.opibuilder,
  org.eclipse.help,
- org.apache.commons.lang;bundle-version="2.6.0",
- org.csstudio.java;bundle-version="3.2.0"
+ org.apache.commons.lang;bundle-version="2.6.0"
 Bundle-Activator: org.csstudio.opibuilder.converter.EDM2OPIConverterPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/build.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/build.xml
@@ -3,8 +3,7 @@
      for the EDM converter.
 
      It doesn't build any of the UI components,
-     meaning the only dependencies are org.csstudio.java
-     and org.apache.commons.lang.
+     meaning the only dependency is org.apache.commons.lang.
 
      This will generally be invoked by Maven, meaning
      that Apache Commons Lang jar file will have been
@@ -39,12 +38,6 @@
   </path>
   <!-- Compile Java sources -->
   <target name="compile" depends="prepare">
-    <!-- org.csstudio.java -->
-    <javac srcdir="../../../../core/platform/platform-plugins/org.csstudio.java/src" destdir="${classes}" includeantruntime="true" deprecation="on" debug="on">
-      <classpath>
-        <path refid="build.classpath"/>
-      </classpath>
-    </javac>
     <!-- org.csstudio.opibuilder.converter -->
     <javac srcdir="src" destdir="${classes}" excludes="**/org/csstudio/opibuilder/converter/ui/*.java, **/EDM2OPIConverterPlugin.java" includeantruntime="true" deprecation="on" debug="on">
       <classpath>

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/StringSplitter.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/StringSplitter.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2011 Oak Ridge National Laboratory.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.converter;
+
+import java.util.regex.Pattern;
+
+/**
+ * NOTE: this class has been copied from the org.csstudio.java plug-in in
+ * order to allow compiling this plug-in into a stand-alone jar file.
+ * Please edit that file and copy here if changes need to be made.
+ *
+ * Split string into segments
+ *
+ *  @author Nick Battam
+ *  @author Kay Kasemir
+ *  @author Xihui Chen - Original <code> StringUtil.splitIgnoreInQuotes()</code>
+ *
+ */
+public class StringSplitter
+{
+    private static final String QUOTE = "'\\\"";
+    private static final String NOT_QUOTE = "^" + QUOTE;
+
+    private static final char SPACE = ' ';
+    private static final char TAB = '\t';
+    private static final char PIPE = '|';
+
+    private static final String ESCAPED_QUOTE = "\\\\\\\"";
+    private static final String ESCAPED_SINGLE_QUOTE = "\\\\\'";
+
+    static final String SUBSTITUTE_QUOTE = "\uF8FF";
+    static final String SUBSTITUTE_SINGLE_QUOTE = "\uE000";
+
+    private static final String splitRegex = "(?="
+            + "([" + NOT_QUOTE + "]*"  // any number of non-quotes
+            +  "[" + QUOTE + "]"       // a quote
+            +  "[" + NOT_QUOTE + "]*"  // any number of non-quotes
+            +  "[" + QUOTE + "]"       // a quote, not preceeded by an escape
+            + ")*"                     // any number of times
+            +  "[" + NOT_QUOTE + "]*"  // any number of non quotes
+            + "$)";
+
+    /** Prevent instantiation */
+    private StringSplitter()
+    {
+        // NOP
+    }
+
+
+    /** Split source string into an array of elements separated by the splitting character,
+     *  but ignoring split characters enclosed in quotes.
+     *
+     *  @param trimmedSource String to be split
+     *  @param splitChar Character used to split the source string, e.g. ',' or ' '
+     *  @param deleteHeadTailQuotes Delete quotes in the head and tail of individual elements
+     *                              if <code>true</code>
+     *  @return Array of individual elements
+     *  @throws Exception on parse error (missing end of quoted string)
+     */
+    @SuppressWarnings("nls")
+    public static String[] splitIgnoreInQuotes(final String source,
+                                               final char splitChar,
+                                               final boolean deleteHeadTailQuotes) throws Exception
+    {
+        // Trim, replace tabs with spaces so we only need to handle
+        // space in the following; only if not splitting on TAB
+        final String trimmedSource;
+        if (splitChar != TAB) {
+            trimmedSource = source.replace(TAB, SPACE).trim();
+        }
+        else {
+            trimmedSource = source;
+        }
+
+        final String escapedSource = substituteEscapedQuotes(trimmedSource);
+
+        String fullRegex = splitChar + splitRegex;
+        if (splitChar == PIPE) {
+            fullRegex = "\\" + fullRegex;
+        }
+
+        return Pattern.compile(fullRegex)
+                .splitAsStream(escapedSource)
+                .filter(item -> !item.isEmpty())
+                .map(item -> item.trim())
+                .map(item -> deleteHeadTailQuotes ? removeQuotes(item) : item)
+                .map(item -> revertQuoteSubsitutions(item))
+                .toArray(size -> new String[size]);
+    }
+
+    /**
+     * Remove matching quotes from start/end of input string
+     * If there are no quotes or if the leading or trailing
+     * quotes do not match, this method has no effect.
+     *
+     * @param input String to parse
+     * @return String with any wrapping quotes removed.
+     */
+    static String removeQuotes(String input) {
+
+        if (input.startsWith("\"") && input.endsWith("\"") || input.startsWith("'") && input.endsWith("'")) {
+            return input.substring(1, input.length() - 1);
+        } else {
+            return input;
+        }
+    }
+
+    /**
+     * Remove escaped quotes (single and double) from the input string.
+     * These may be found inside a 'quoted section' and should not be processed.
+     *
+     * Replace the character sequences with an unlikely unicode character.
+     *
+     * @param source String to process
+     * @return
+     */
+    static String substituteEscapedQuotes(String source) {
+
+        return source
+                .replaceAll(ESCAPED_QUOTE, SUBSTITUTE_QUOTE)
+                .replaceAll(ESCAPED_SINGLE_QUOTE, SUBSTITUTE_SINGLE_QUOTE);
+
+    }
+
+    /**
+     * Restore 'escaped quotes' (single and double) removed with
+     * {@link StringSplitter.substitueEscapeQuotes}
+     *
+     * @param source String to process
+     * @return
+     */
+    static String revertQuoteSubsitutions(String input) {
+        return input
+                .replaceAll(SUBSTITUTE_SINGLE_QUOTE, ESCAPED_SINGLE_QUOTE)
+                .replaceAll(SUBSTITUTE_QUOTE, ESCAPED_QUOTE);
+
+    }
+}

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/model/EdmColor.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/model/EdmColor.java
@@ -13,7 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import java.util.logging.Logger;
-import org.csstudio.java.string.StringSplitter;
+import org.csstudio.opibuilder.converter.StringSplitter;
 
 /**
  * Specific class representing EdmColor property.

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/parser/EdmColorsListParser.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/parser/EdmColorsListParser.java
@@ -12,7 +12,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.csstudio.java.string.StringSplitter;
+import org.csstudio.opibuilder.converter.StringSplitter;
 import org.csstudio.opibuilder.converter.model.EdmAttribute;
 import org.csstudio.opibuilder.converter.model.EdmColor;
 import org.csstudio.opibuilder.converter.model.EdmEntity;

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/parser/EdmParser.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/parser/EdmParser.java
@@ -14,7 +14,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 
 import java.util.logging.Logger;
-import org.csstudio.java.string.StringSplitter;
+import org.csstudio.opibuilder.converter.StringSplitter;
 import org.csstudio.opibuilder.converter.model.EdmEntity;
 import org.csstudio.opibuilder.converter.model.EdmException;
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activePipClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_activePipClass.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.csstudio.java.string.StringSplitter;
+import org.csstudio.opibuilder.converter.StringSplitter;
 import org.csstudio.opibuilder.converter.model.EdmString;
 import org.csstudio.opibuilder.converter.model.Edm_activePipClass;
 

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_relatedDisplayClass.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/Opi_relatedDisplayClass.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.csstudio.java.string.StringSplitter;
+import org.csstudio.opibuilder.converter.StringSplitter;
 import org.csstudio.opibuilder.converter.model.EdmBoolean;
 import org.csstudio.opibuilder.converter.model.EdmString;
 import org.csstudio.opibuilder.converter.model.Edm_relatedDisplayClass;

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/PVNameConversion.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.converter/src/main/org/csstudio/opibuilder/converter/writer/PVNameConversion.java
@@ -11,9 +11,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.csstudio.opibuilder.converter.StringSplitter;
 import org.apache.commons.lang.StringUtils;
 import java.util.logging.Logger;
-import org.csstudio.java.string.StringSplitter;
 
 public class PVNameConversion {
 


### PR DESCRIPTION
This breaks the golden rule of avoiding code duplication, but it allows
building the EDM converter into a stand-alone jar file for external use. This
had previously been possible by including the org.csstudio.java plugin, but
since that developed a dependency on an Eclipse plugin that mechanism for
building proved to be tricky as well.

See #2325.