### PR TITLE
With the new JDOM 1.1.3 in maven-osgi-bundles the XInclude feature in…

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/FileUtil.java
@@ -54,12 +54,14 @@ public class FileUtil {
      */
     public static Element loadXMLFile(final String filePath, final AbstractBaseEditPart widget) throws Exception{
         final IPath path = buildAbsolutePath(filePath, widget);
-        SAXBuilder saxBuilder = new SAXBuilder();
+        final SAXBuilder saxBuilder = new SAXBuilder();
         saxBuilder.setEntityResolver(new CssEntityResolver());
-        File file = ResourceUtil.getFile(path);
+        saxBuilder.setFeature("http://apache.org/xml/features/xinclude", true);
+
+        final File file = ResourceUtil.getFile(path);
         final Document doc;
         if (file == null) {
-            InputStream inputStream = ResourceUtil.pathToInputStream(path);
+            final InputStream inputStream = ResourceUtil.pathToInputStream(path);
             doc = saxBuilder.build(inputStream);
             inputStream.close();
         } else {


### PR DESCRIPTION
… OPI Builder FileUtils.java needs to be enabled explicitly.

see ControlSystemStudio/cs-studio#2351.