### PR TITLE
Fix for XInclude -- resolving entities with workspace relative path

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/CssEntityResolver.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/scriptUtil/CssEntityResolver.java
@@ -14,23 +14,24 @@ import org.xml.sax.SAXException;
 public class CssEntityResolver implements EntityResolver {
 
     @Override
-    public InputSource resolveEntity(String publicId, String systemId)
-            throws SAXException, IOException {
+    public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
         try {
-           URI uri = new URI(systemId);
-           File file = new File(uri);
-           if(!file.exists()) {
-               IPath path = ResourceUtil.getPathFromString(file.getPath());
-               InputStream inputStream = ResourceUtil.pathToInputStream(path);
-               if(inputStream != null) {
-                   return new InputSource(inputStream);
-               }
-           }
-       } catch (Exception e) {
-        // Entity may not be found and this may throw exception. This is normal and FileUtil will revert to xi:fallback
-       }
+            URI uri = new URI(systemId);
+            File file = new File(uri);
+            if (!file.exists()) {
+                IPath path = ResourceUtil.getPathFromString(file.getPath());
+                InputStream inputStream = ResourceUtil.pathToInputStream(path);
 
-       return null;
+                if (inputStream != null) {
+                    InputSource source = new InputSource(systemId);
+                    source.setByteStream(inputStream);
+                    return source;
+                }
+            }
+        } catch (Exception e) {
+            // Entity may not be found and this may throw exception. This is normal and FileUtil will revert to xi:fallback
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
This fixes Xinclude, so that xi:include href paths form within workspace are resolved. Bug was due to update of JDOM to 1.1.3.

In reference with: #2351 

