### PR TITLE
BOY: For SWT widgets, don't overwrite the context menu ..

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/AbstractSWTWidgetFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/AbstractSWTWidgetFigure.java
@@ -196,9 +196,10 @@ public abstract class AbstractSWTWidgetFigure<T extends Control> extends Figure 
 
                 hookGEFToSWTWidget(swtWidget, menuDetectListener);
 
-                // hook the context menu to combo
-                swtWidget.setMenu(editPart.getViewer().getContextMenu()
-                        .createContextMenu(composite));
+                // hook the context menu, unless SWT widget already created its own context menu
+                if (swtWidget.getMenu() == null)
+                    swtWidget.setMenu(editPart.getViewer().getContextMenu()
+                            .createContextMenu(composite));
             }
 
             /**Add menu detect listener recursively to all children widgets inside the SWT Widget.


### PR DESCRIPTION
.. if widget itself already creates one.

Necessary to fix #2363, to allow the Data Browser 3 BOY widget to have a context menu simiular to the Data Browser 2 BOY widget. 