### PR TITLE
opibuilder.jseditor default = false

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/plugin.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/plugin.xml
@@ -13,7 +13,7 @@
       </editor>
       <editor
             class="org.eclipse.ui.editors.text.TextEditor"
-            default="true"
+            default="false"
             extensions="js"
             icon="icons/js.gif"
             id="org.csstudio.opibuilder.jseditor"


### PR DESCRIPTION
Simple javascript editor is not default anymore, so other editors can be
set as default.

#2371 