### PR TITLE
Fix problems with hide toolbar option.

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
@@ -200,7 +200,7 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
     /** @return <code>true</code> if toolbar is visible */
     public boolean isToolbarVisible()
     {
-        return toolbar.getControl().isVisible();
+        return toolbar.getControl().getVisible();
     }
 
     /** @param show <code>true</code> if toolbar should be displayed */


### PR DESCRIPTION
When a plot file specified the hide toolbar option, it would still be displayed when the plot file was loaded with the data browser OPI widget and that widget was placed inside a container (e.g. a grouping container or a tab).

The reason for this was that the code hiding the toolbar incorrectly checked whether it was visible, so that it would not hide it if it was set to visible but the container containing the data browser was not visible yet.

The fix in this patch is very simple: By using `getVisible` instead of `isVisible`, we only check whether the toolbar itself has already been hidden or not and do not consider the visibility state of all the parent containers.