### PR TITLE
When reading font.def, use font_default_pixels_or_points

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server.test/src/org/csstudio/alarm/beast/server/AlarmLogicUnitTest.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server.test/src/org/csstudio/alarm/beast/server/AlarmLogicUnitTest.java
@@ -943,7 +943,7 @@ public class AlarmLogicUnitTest
         System.out.println("Initial alarm      : " + initial_alarm_time);
         System.out.println("Global notification: " + now);
         // Should use global_delay from the initial alarm...
-        assertEquals(global_delay, TimeDuration.toSecondsDouble(Duration.between(initial_alarm_time, now)), 0.2);
+        assertEquals(global_delay, TimeDuration.toSecondsDouble(Duration.between(initial_alarm_time, now)), global_delay/3);
 
         // .. but reflect the most severe alarm in the notification.
         // Not really checking what was in the notification,

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/MediaService.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/MediaService.java
@@ -281,7 +281,7 @@ public final class MediaService {
                     continue;
                 int i;
                 if ((i = line.indexOf('=')) != -1) {
-                    boolean isPixels = false;
+                    boolean isPixels = PreferencesHelper.isDefaultFontSizeInPixels();
                     String name = line.substring(0, i).trim();
                     String trimmedName = name;
                     if (name.contains("(")) //$NON-NLS-1$

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/MediaService.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/MediaService.java
@@ -293,6 +293,7 @@ public final class MediaService {
                             isPixels = true;
                             trimmedLine = trimmedLine.substring(0, trimmedLine.length()-2);
                         } else if (line.endsWith("pt")) { //$NON-NLS-1$
+                            isPixels = false;
                             trimmedLine = trimmedLine.substring(0, trimmedLine.length()-2);
                         }
 


### PR DESCRIPTION
Newer format font.def can then use "px" or "pt" on each font, but
default comes from the same preference that's used for all fonts.

Fixes #2389