### PR TITLE
Issue 2413 boy combo windows

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ComboEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ComboEditPart.java
@@ -11,8 +11,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.csstudio.opibuilder.editparts.AbstractPVWidgetEditPart;
 import org.csstudio.opibuilder.editparts.ExecutionMode;
@@ -40,6 +38,8 @@ import org.eclipse.swt.widgets.Combo;
  *
  */
 public final class ComboEditPart extends AbstractPVWidgetEditPart {
+    /** Running on Windows ("win32" or similar) */
+    private static final boolean is_windows = SWT.getPlatform().toLowerCase().contains("win");
 
     private IPVListener loadItemsFromPVListener;
 
@@ -83,12 +83,11 @@ public final class ComboEditPart extends AbstractPVWidgetEditPart {
                 comboSelectionListener = new SelectionAdapter(){
                         @Override
                         public void widgetSelected(SelectionEvent e) {
-                            Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Combo click " + e);
-                            Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Button 1 " + (e.stateMask & SWT.BUTTON1));
-                            Logger.getLogger(getClass().getName()).log(Level.SEVERE, SWT.getPlatform());
                             // Only react if the selection was accomplished
                             // by clicking on an item.
-                            if (e.stateMask == SWT.BUTTON1)
+                            // Skip this test on windows, where the stateMask
+                            // is always empty, so cannot guard against scroll wheel changes.
+                            if (is_windows  ||  e.stateMask == SWT.BUTTON1)
                                 setPVValue(AbstractPVWidgetModel.PROP_PVNAME, combo.getText());
                             else
                             {   // Ignore selections from mouse wheel (stateMask == 0).

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ComboEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/ComboEditPart.java
@@ -11,6 +11,8 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.csstudio.opibuilder.editparts.AbstractPVWidgetEditPart;
 import org.csstudio.opibuilder.editparts.ExecutionMode;
@@ -81,6 +83,9 @@ public final class ComboEditPart extends AbstractPVWidgetEditPart {
                 comboSelectionListener = new SelectionAdapter(){
                         @Override
                         public void widgetSelected(SelectionEvent e) {
+                            Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Combo click " + e);
+                            Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Button 1 " + (e.stateMask & SWT.BUTTON1));
+                            Logger.getLogger(getClass().getName()).log(Level.SEVERE, SWT.getPlatform());
                             // Only react if the selection was accomplished
                             // by clicking on an item.
                             if (e.stateMask == SWT.BUTTON1)


### PR DESCRIPTION
 #2276 tried to prevent combo box value changes via the mouse-wheel-guard.

Turns out that doesn't work on Windows, where the combo box event doesn't include mouse button information, so there's no straight forward way to distinguish an honest 'click' by the user to select a combo item from a mouse wheel induced flurry of value changes.

Fixes #2350 (and duplicate #2413)