### PR TITLE
Alarm Server sevrpv: support

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.configtool/demo/heartbeat.db
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.configtool/demo/heartbeat.db
@@ -1,0 +1,18 @@
+# Example for "Heartbeat PV"
+#
+# Alarm Server sets it to 1 every ~10 seconds,
+# see heartbeat_pv and heartbeat_secs preferences.
+#
+# softIoc -s -m S=Demo -d heartbeat.db
+
+record(bo, "$(S):AlarmServerHeartbeat")
+{
+    # If Alarm Server doesn't write '1' every 10 seconds,
+    # drop to 0 after 30 secs.
+    field(HIGH, "30")
+    field(ZNAM, "Timeout")
+    field(ZSV,  "MAJOR")
+    field(ONAM, "OK")
+    field(DOL,  "1")
+    field(PINI, "YES")
+}

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.configtool/demo/sevrpv.db
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.configtool/demo/sevrpv.db
@@ -1,0 +1,36 @@
+# Example for "Severity PV"
+# used with automated action set to "sevrpv:NameOfPV"
+#
+# softIoc -s -m N=NameOfPV -d sevrpv.db
+
+record(mbbi, "$(N)")
+{
+    field(ZRVL, 0)
+    field(ZRST, "OK")
+    field(ONVL, 1)
+    field(ONST, "MINOR_ACK")
+    field(ONSV, "MINOR")
+    field(TWVL, 2)
+    field(TWST, "MAJOR_ACK")
+    field(TWSV, "MAJOR")
+    field(THVL, 3)
+    field(THST, "INVALID_ACK")
+    field(THSV, "INVALID")
+    field(FRVL, 4)
+    field(FRST, "UNDEFINED_ACK")
+    field(FRSV, "INVALID")
+    field(FVVL, 5)
+    field(FVST, "MINOR")
+    field(FVSV, "MINOR")
+    field(SXVL, 6)
+    field(SXST, "MAJOR")
+    field(SXSV, "MAJOR")
+    field(SVVL, 7)
+    field(SVST, "INVALID")
+    field(SVSV, "INVALID")
+    field(EIVL, 8)
+    field(EIST, "UNDEFINED")
+    field(EISV, "INVALID")
+    field(INP,  "0")
+    field(PINI, "YES")
+}

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server.test/src/org/csstudio/alarm/beast/server/AlarmRDBUnitTest.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server.test/src/org/csstudio/alarm/beast/server/AlarmRDBUnitTest.java
@@ -1,13 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.csstudio.alarm.beast.server;
 
-import org.csstudio.alarm.beast.TreeItem;
 import org.csstudio.apputil.test.TestProperties;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class AlarmRDBUnitTest
                 settings.getString("alarm_rdb_password"),
                 "ALARM",
                 alarm_root);
-        final TreeItem root = rdb.readConfiguration();
+        final ServerTreeItem root = rdb.readConfiguration();
         root.dump(System.out);
     }
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmLogic.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmLogic.java
@@ -474,9 +474,8 @@ public class AlarmLogic implements DelayedAlarmListener, GlobalAlarmListener
 
     /** Acknowledge current alarm severity
      *  @param acknowledge Acknowledge or un-acknowledge?
-     *  @return Resulting {@link SeverityLevel}
      */
-    public SeverityLevel acknowledge(boolean acknowledge)
+    public void acknowledge(boolean acknowledge)
     {
         final AlarmState current, alarm;
         // Cancel any scheduled 'global' update
@@ -503,7 +502,6 @@ public class AlarmLogic implements DelayedAlarmListener, GlobalAlarmListener
         if (clear_global_alarm)
             clearGlobalAlarm();
         listener.alarmStateChanged(current, alarm);
-        return alarm.getSeverity();
     }
 
     /** @return String representation for debugging */

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmLogic.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmLogic.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.csstudio.alarm.beast.server;
 
@@ -474,8 +474,9 @@ public class AlarmLogic implements DelayedAlarmListener, GlobalAlarmListener
 
     /** Acknowledge current alarm severity
      *  @param acknowledge Acknowledge or un-acknowledge?
+     *  @return Resulting {@link SeverityLevel}
      */
-    public void acknowledge(boolean acknowledge)
+    public SeverityLevel acknowledge(boolean acknowledge)
     {
         final AlarmState current, alarm;
         // Cancel any scheduled 'global' update
@@ -502,6 +503,7 @@ public class AlarmLogic implements DelayedAlarmListener, GlobalAlarmListener
         if (clear_global_alarm)
             clearGlobalAlarm();
         listener.alarmStateChanged(current, alarm);
+        return alarm.getSeverity();
     }
 
     /** @return String representation for debugging */

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmPV.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmPV.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 import org.csstudio.alarm.beast.AnnunciationFormatter;
 import org.csstudio.alarm.beast.Preferences;
 import org.csstudio.alarm.beast.SeverityLevel;
+import org.csstudio.alarm.beast.TreeItem;
 import org.csstudio.vtype.pv.PV;
 import org.csstudio.vtype.pv.PVListener;
 import org.csstudio.vtype.pv.PVPool;
@@ -28,7 +29,7 @@ import org.diirt.vtype.VType;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class AlarmPV extends ServerTreeItem implements AlarmLogicListener, FilterListener, PVListener
+public class AlarmPV extends TreeItem implements AlarmLogicListener, FilterListener, PVListener
 {
     private static final long serialVersionUID = -1467537752626320944L;
 
@@ -104,6 +105,12 @@ public class AlarmPV extends ServerTreeItem implements AlarmLogicListener, Filte
         this.server = server;
         setDescription(description);
         setEnablement(enabled, filter);
+    }
+
+    @Override
+    public ServerTreeItem getParent()
+    {
+        return (ServerTreeItem) super.getParent();
     }
 
     /** @return AlarmLogic used by this PV */
@@ -282,8 +289,7 @@ public class AlarmPV extends ServerTreeItem implements AlarmLogicListener, Filte
         logic.computeNewState(received);
         logger.log(Level.FINE, () -> getPathName() + " received " + value + " -> " + logic);
 
-        severity = logic.getAlarmState().getSeverity();
-        if (severity.equals(old_severity))
+        if (logic.getAlarmState().getSeverity().equals(old_severity))
             return;
 
         // Whenever logic computes new state, maximize up parent tree
@@ -330,7 +336,6 @@ public class AlarmPV extends ServerTreeItem implements AlarmLogicListener, Filte
                     alarm.getSeverity(), alarm.getMessage(),
                     alarm.getValue(), alarm.getTime());
     }
-
 
     /** {@inheritDoc} */
     @Override

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmRDB.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmRDB.java
@@ -169,6 +169,19 @@ public class AlarmRDB
                 final int pv_id = result.getInt(3);
                 if (result.wasNull())
                 {
+                    // TODO Check automated action 'sevrpv:' ...
+                    final PreparedStatement sel_actions = connection.prepareStatement(sql.sel_auto_actions_by_id);
+                    sel_actions.setInt(1, id);
+                    final ResultSet act_res = sel_actions.executeQuery();
+                    while (act_res.next())
+                    {
+                        final String action = act_res.getString(2);
+                        if (action.startsWith("sevrpv:"))
+                        {
+                            System.out.println(name + " should update severity PV " + action.substring("sevrpv:".length()));
+                        }
+                    }
+
                     final ServerTreeItem child = new ServerTreeItem(parent, name, id);
                     recurse_items.add(child);
                 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmRDB.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmRDB.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.csstudio.alarm.beast.server;
 
@@ -20,7 +20,6 @@ import java.util.logging.Level;
 import org.csstudio.alarm.beast.SQL;
 import org.csstudio.alarm.beast.SeverityLevel;
 import org.csstudio.alarm.beast.TimestampHelper;
-import org.csstudio.alarm.beast.TreeItem;
 import org.csstudio.alarm.beast.server.AlarmServer.Update;
 import org.csstudio.platform.utility.rdb.RDBUtil;
 
@@ -84,7 +83,7 @@ public class AlarmRDB
      *  @return Root element of the alarm tree hierarchy
      *  @throws Exception on error
      */
-    public TreeItem readConfiguration() throws Exception
+    public ServerTreeItem readConfiguration() throws Exception
     {
         final Connection conn = rdb.getConnection();
         // Disabling the auto-reconnect is about 15% faster, and we don't
@@ -95,7 +94,7 @@ public class AlarmRDB
             conn.prepareStatement(sql.sel_configuration_by_name);
 
         // Get root element
-        final TreeItem root;
+        final ServerTreeItem root;
         try
         {
             statement.setString(1, root_name);
@@ -104,7 +103,7 @@ public class AlarmRDB
                 throw new Exception("Unknown alarm tree root " + root_name);
             final int id = result.getInt(1);
             result.close();
-            root = new TreeItem(null, root_name, id);
+            root = new ServerTreeItem(null, root_name, id);
         }
         finally
         {
@@ -148,9 +147,9 @@ public class AlarmRDB
      *  @param sel_items_by_parent Prepared statement for fetching child elements
      *  @throws Exception on error
      */
-    private void readChildren(final TreeItem parent, final PreparedStatement sel_items_by_parent) throws Exception
+    private void readChildren(final ServerTreeItem parent, final PreparedStatement sel_items_by_parent) throws Exception
     {
-        final List<TreeItem> recurse_items = new ArrayList<TreeItem>();
+        final List<ServerTreeItem> recurse_items = new ArrayList<>();
 
         sel_items_by_parent.setInt(1, parent.getID());
         final ResultSet result = sel_items_by_parent.executeQuery();
@@ -170,7 +169,7 @@ public class AlarmRDB
                 final int pv_id = result.getInt(3);
                 if (result.wasNull())
                 {
-                    final TreeItem child = new TreeItem(parent, name, id);
+                    final ServerTreeItem child = new ServerTreeItem(parent, name, id);
                     recurse_items.add(child);
                 }
                 else
@@ -243,7 +242,7 @@ public class AlarmRDB
         // Recurse to children
         // Cannot do that inside the above while() because that would reuse
         // the statement of the current ResultSet
-        for (TreeItem child : recurse_items)
+        for (ServerTreeItem child : recurse_items)
             readChildren(child, sel_items_by_parent);
     }
 

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
@@ -475,7 +475,6 @@ public class AlarmServer implements Runnable
      */
     void updateConfig(final String path_name) throws Exception
     {
-        // TODO Check for update of node (severity PV)
         resetNagTimer();
         AlarmPV pv = null;
         if (path_name != null)
@@ -488,7 +487,7 @@ public class AlarmServer implements Runnable
             pv = findPV(path[path.length-1]);
         }
         if (pv == null)
-        {   // Unknown PV, so this must be a new PV. Read whole config again
+        {   // Unknown PV, so this must be a new PV, or an area/system/subsys. Read whole config again
             stopPVs();
             readConfiguration();
             startPVs();

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
@@ -399,6 +399,7 @@ public class AlarmServer implements Runnable
         }
         for (AlarmPV pv : pvs)
             pv.stop();
+        SeverityPVHandler.stop();
     }
 
     /** Read the initial alarm configuration
@@ -474,6 +475,7 @@ public class AlarmServer implements Runnable
      */
     void updateConfig(final String path_name) throws Exception
     {
+        // TODO Check for update of node (severity PV)
         resetNagTimer();
         AlarmPV pv = null;
         if (path_name != null)

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.csstudio.alarm.beast.server;
 
@@ -143,7 +143,7 @@ public class AlarmServer implements Runnable
     /** Hierarchical alarm configuration
      *  <p><b>NOTE: Access to tree, PV list and map must synchronize on 'this'</b>
      */
-    private TreeItem alarm_tree;
+    private ServerTreeItem alarm_tree;
 
     /** All the PVs in the alarm_tree, sorted by name
      *  <p><b>NOTE: Access to tree, PV list and map must synchronize on 'this'</b>
@@ -507,7 +507,12 @@ public class AlarmServer implements Runnable
         resetNagTimer();
         final AlarmPV pv = findPV(pv_name);
         if (pv != null)
-            pv.getAlarmLogic().acknowledge(acknowledge);
+        {
+            pv.severity = pv.getAlarmLogic().acknowledge(acknowledge);
+
+            // Likely changed the state, maximize up parent tree
+            pv.getParent().maximizeSeverity();
+        }
     }
 
     /** Locate alarm PV by name

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
@@ -333,6 +333,9 @@ public class AlarmServer implements Runnable
     /** Start PVs */
     private void startPVs()
     {
+        // Write all severity PVs once to assert they have the correct value
+        updateSeverityPVs(alarm_tree);
+
         final long delay = Preferences.getPVStartDelay();
         // Must not sync while calling PV, because Channel Access updates
         // might arrive while we're trying to start/stop channels,
@@ -360,6 +363,20 @@ public class AlarmServer implements Runnable
                 Activator.getLogger().log(Level.SEVERE,
                     "Error starting PV " + pv.getName(), ex);
             }
+        }
+    }
+
+    private void updateSeverityPVs(final TreeItem node)
+    {
+        // AlarmPV leaf has no severity PV nor child nodes
+        if (! (node instanceof ServerTreeItem))
+            return;
+
+        synchronized (node)
+        {
+            ((ServerTreeItem) node).updateSeverityPV();
+            for (int i = node.getChildCount()-1; i>=0; --i)
+                updateSeverityPVs(node.getChild(i));
         }
     }
 

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/AlarmServer.java
@@ -508,7 +508,7 @@ public class AlarmServer implements Runnable
         final AlarmPV pv = findPV(pv_name);
         if (pv != null)
         {
-            pv.severity = pv.getAlarmLogic().acknowledge(acknowledge);
+            pv.getAlarmLogic().acknowledge(acknowledge);
 
             // Likely changed the state, maximize up parent tree
             pv.getParent().maximizeSeverity();

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/Application.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * Copyright (c) 2010-2018 Oak Ridge National Laboratory.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -51,7 +51,7 @@ public class Application implements IApplication
     public Object start(final IApplicationContext context) throws Exception
     {
         // Display configuration info
-        final String version = (String) context.getBrandingBundle().getHeaders().get("Bundle-Version");
+        final String version = context.getBrandingBundle().getHeaders().get("Bundle-Version");
         final String app_info = context.getBrandingName() + " " + version;
 
         // Create parser for arguments and run it.
@@ -126,6 +126,8 @@ public class Application implements IApplication
         final WorkQueue work_queue = new WorkQueue();
         try
         {
+            SeverityPVHandler.initialize();
+
             // Create alarm server
             final AlarmServer alarm_server = new AlarmServer(work_queue, config_name.get());
 

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/ServerTreeItem.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/ServerTreeItem.java
@@ -73,7 +73,14 @@ public class ServerTreeItem extends TreeItem
             ((ServerTreeItem)parent).maximizeSeverity();
 
         // If _this_ node changed its severity, update optional severity PV
-        if (changed  &&  severity_pv_name != null)
-            SeverityPVHandler.update(severity_pv_name, new_severity);
+        if (changed)
+            updateSeverityPV();
+    }
+
+    /** Write to optional severity PV */
+    void updateSeverityPV()
+    {
+        if (severity_pv_name != null)
+            SeverityPVHandler.update(severity_pv_name, severity);
     }
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/ServerTreeItem.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/ServerTreeItem.java
@@ -72,12 +72,8 @@ public class ServerTreeItem extends TreeItem
         if (parent instanceof ServerTreeItem)
             ((ServerTreeItem)parent).maximizeSeverity();
 
-        // TODO If _this_ node changed its severity,
-        //      update optional severity PV
+        // If _this_ node changed its severity, update optional severity PV
         if (changed  &&  severity_pv_name != null)
-        {
-            System.out.println("Node '" + getName() + "' should update PV '" + severity_pv_name + "' to " + new_severity.name());
-            // TODO Write to queue, handle that in other thread
-        }
+            SeverityPVHandler.update(severity_pv_name, new_severity);
     }
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/ServerTreeItem.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/ServerTreeItem.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.alarm.beast.server;
+
+import org.csstudio.alarm.beast.SeverityLevel;
+import org.csstudio.alarm.beast.TreeItem;
+
+/** Node in the alarm tree as used by the server
+ *
+ *  <p>Tracks the alarm severity at this level in the hierarchy
+ *  @author Kay Kasemir
+ */
+public class ServerTreeItem extends TreeItem
+{
+    private static final long serialVersionUID = -2991781205177465014L;
+
+    protected volatile SeverityLevel severity = SeverityLevel.UNDEFINED;
+
+    public ServerTreeItem(ServerTreeItem parent, String name, int id)
+    {
+        super(parent, name, id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ServerTreeItem getParent()
+    {
+        return (ServerTreeItem) super.getParent();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ServerTreeItem getChild(final int index)
+    {
+        return (ServerTreeItem) super.getChild(index);
+    }
+
+    /** Set severity of this item by maximizing over its child severities.
+     *  Recursively updates parent items.
+     */
+    public void maximizeSeverity()
+    {
+        boolean changed = false;
+
+        SeverityLevel new_severity = SeverityLevel.OK;
+
+        synchronized (this)
+        {
+            final int n = getChildCount();
+            for (int i=0; i<n; ++i)
+            {
+                // Maximize severity of all child elements
+                final ServerTreeItem child = getChild(i);
+                if (child instanceof AlarmPV)
+                {
+                    final AlarmPV pv = (AlarmPV) child;
+                    if (! pv.getAlarmLogic().isEnabled())
+                        continue;
+                }
+                if (child.severity.ordinal() > new_severity.ordinal())
+                    new_severity = child.severity;
+            }
+        }
+
+        if (new_severity != severity)
+        {
+            severity = new_severity;
+            changed = true;
+        }
+
+        // Percolate changes towards root
+        final ServerTreeItem parent = getParent();
+        if (parent != null)
+            parent.maximizeSeverity();
+
+        // TODO If _this_ node changed its severity,
+        //      update optional severity PV
+        if (changed)
+        {
+            System.out.println("Update severity PV for " + getName() + " to " + new_severity.name());
+            // TODO Write to queue, handle that in other thread
+        }
+    }
+}

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/SeverityPVHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/SeverityPVHandler.java
@@ -56,13 +56,24 @@ public class SeverityPVHandler
      */
     private static void run()
     {
-        long next_heartbeat = HEARTBEAT_PV.isEmpty() ? -1 : 0;
+        long next_heartbeat;
+
+        if (HEARTBEAT_PV.isEmpty())
+        {
+            logger.info("Not using any heartbeat PV");
+            next_heartbeat = -1;
+        }
+        else
+        {
+            logger.info("Setting heartbeat PV '" + HEARTBEAT_PV + "' every " + HEARTBEAT_MS/1000 + " sec");
+            next_heartbeat = 0;
+        }
 
         while (true)
         {
             try
             {
-                if (next_heartbeat > 0)
+                if (next_heartbeat >= 0)
                 {
                     // Trigger optional 'heartbeat' PV
                     final long now = System.currentTimeMillis();

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/SeverityPVHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/SeverityPVHandler.java
@@ -7,7 +7,18 @@
  ******************************************************************************/
 package org.csstudio.alarm.beast.server;
 
+import static org.csstudio.alarm.beast.server.Activator.logger;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+import org.csstudio.alarm.beast.Preferences;
 import org.csstudio.alarm.beast.SeverityLevel;
+import org.csstudio.vtype.pv.PV;
+import org.csstudio.vtype.pv.PVPool;
 
 /** Handle the update of "severity PVs"
  *
@@ -16,17 +27,121 @@ import org.csstudio.alarm.beast.SeverityLevel;
  *
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class SeverityPVHandler
 {
+    // TODO Add an optional 'heartbeat' PV
 
-    public static void update(final String severity_pv_name, final SeverityLevel severity)
+    private static final int CONNECTION_SECS = (int) Preferences.getConnectionGracePeriod();
+
+
+    /** Pending updates */
+    private static final ConcurrentHashMap<String, SeverityLevel> updates = new ConcurrentHashMap<>();
+
+
+    /** Map of PVs by name */
+    private static final ConcurrentHashMap<String, PV> pvs = new ConcurrentHashMap<>();
+
+
+    /** Initialize, start SeverityPVUpdater thread */
+    public static void initialize()
     {
-        System.out.println("Should update PV '" + severity_pv_name + "' to " + severity.name());
-        // TODO Write to queue, handle that in other thread
+        final Thread thread = new Thread(SeverityPVHandler::run, "SeverityPVUpdater");
+        thread.setDaemon(true);
+        thread.start();
     }
 
+    /** Executed by SeverityPVUpdater:
+     *  Waits for requested updates and performs them.
+     */
+    private static void run()
+    {
+        while (true)
+        {
+            try
+            {
+                if (updates.isEmpty())
+                    Thread.sleep(500);
+                else
+                    performUpdates();
+            }
+            catch (Exception ex)
+            {
+                logger.log(Level.WARNING, "SeverityPVUpdater error", ex);
+            }
+        }
+    }
+
+    /** Perform all requested updates, clearing the 'updates' map */
+    private static void performUpdates()
+    {
+        final Iterator<Entry<String, SeverityLevel>> entries = updates.entrySet().iterator();
+        while (entries.hasNext())
+        {
+            final Entry<String, SeverityLevel> entry = entries.next();
+            final String pv_name = entry.getKey();
+            final SeverityLevel severity = entry.getValue();
+            entries.remove();
+
+            logger.log(Level.FINE, "Should update PV '" + pv_name + "' to " + severity.name());
+
+            // Get or create PV
+            final PV pv = pvs.computeIfAbsent(pv_name, name ->
+            {
+                try
+                {
+                    return PVPool.getPV(name);
+                }
+                catch (Exception ex)
+                {
+                    logger.log(Level.WARNING, "Cannot create severity PV '" + name + "'", ex);
+                    return null;
+                }
+            });
+            if (pv == null)
+                continue;
+
+            try
+            {
+                // Assert connection
+                int timeout = CONNECTION_SECS;
+                while (pv.read() == null)
+                {
+                    TimeUnit.SECONDS.sleep(1);
+                    if (--timeout < 0)
+                        throw new Exception("No connection");
+                }
+                // Write severity
+                pv.write(severity.ordinal());
+            }
+            catch (Exception ex)
+            {
+                logger.log(Level.WARNING, "Cannot set severity PV '" + pv.getName() + "' to " + severity.ordinal(), ex);
+            }
+        }
+    }
+
+    /** Request an update
+     *  @param severity_pv_name Name of severity PV
+     *  @param severity Severity to write
+     */
+    public static void update(final String severity_pv_name, final SeverityLevel severity)
+    {
+        // Write to map, handle in SeverityPVUpdater thread
+        // If SeverityPVUpdater is slow, and several updates arrive for the same PV,
+        // this will place the most recent severity for that PV in the map.
+        updates.put(severity_pv_name, severity);
+    }
+
+    /** Release all PVs */
     public static void stop()
     {
-        // TODO Stop all PVs
+        final Iterator<PV> pv_iter = pvs.values().iterator();
+        while (pv_iter.hasNext())
+        {
+            final PV pv = pv_iter.next();
+            PVPool.releasePV(pv);
+            pv_iter.remove();
+        }
     }
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/SeverityPVHandler.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.server/src/org/csstudio/alarm/beast/server/SeverityPVHandler.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.alarm.beast.server;
+
+import org.csstudio.alarm.beast.SeverityLevel;
+
+/** Handle the update of "severity PVs"
+ *
+ *  <p>Maintains the PV connections,
+ *  updates the PVs in a background thread.
+ *
+ *  @author Kay Kasemir
+ */
+public class SeverityPVHandler
+{
+
+    public static void update(final String severity_pv_name, final SeverityLevel severity)
+    {
+        System.out.println("Should update PV '" + severity_pv_name + "' to " + severity.name());
+        // TODO Write to queue, handle that in other thread
+    }
+
+    public static void stop()
+    {
+        // TODO Stop all PVs
+    }
+}

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui/html/alarm_system.html
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui/html/alarm_system.html
@@ -1003,7 +1003,7 @@
 
 
     <h3>Automated Actions</h3>
-    
+
     <p>These settings allow the alarm server or a separate tool
        like the "alarm-notifier" to react to alarms.</p>
 
@@ -1017,8 +1017,8 @@
 
     <p>The "Detail' of the automated action needs to be set to
        <code>sevrpv:NameOfPV</code>.
-	   The "Title" and "Delay" of the automated action are ignored.</p>
-    
+       The "Title" and "Delay" of the automated action are ignored.</p>
+
     <p>Whenever the alarm severity of the area or (sub-) system changes,
        the ordinal of the alarm severity will be written to the PV,
        i.e. a number 0 to 8 representing
@@ -1034,7 +1034,7 @@
 
 record(mbbi, "$(N)")
     </pre>
-    
+
     <p>When using "sevrpv:.." to send the alarm severity of nodes in the
        alarm hierarchy to PVs, note that these PVs will not be updated
        in case the alarm server is stopped, either on purpose or because
@@ -1042,7 +1042,7 @@ record(mbbi, "$(N)")
        The <code>org.csstudio.alarm.beast/heartbeat_pv</code> preference of
        the alarm server can be set to the name of a PV which will be set to 1
        every 10 seconds
-       (period can be changed via  
+       (period can be changed via
        The <code>org.csstudio.alarm.beast/heartbeat_secs</code>).
        A record like this can be used to verify a continuous heartbeat:
     </p>
@@ -1066,14 +1066,14 @@ record(bo, "$(S):AlarmServerHeartbeat")
     field(PINI, "YES")
 }
     </pre>
-    
+
 
     <h4>Notifications</h4>
 
     <p>The automated notifications are performed by a designated
        "alarm-notifier" that must be running in parallel to the alarm server.
     </p>
-    
+
     <p>If alarms persist for a certain time without being acknowledged
         or cleared, and automated notification can be generated.</p>
     <p>If you configure a notification for an alarm trigger PV, the

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui/html/alarm_system.html
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui/html/alarm_system.html
@@ -1002,7 +1002,78 @@
         actual command to invoke.</p>
 
 
-    <h3>Automated Notifications</h3>
+    <h3>Automated Actions</h3>
+    
+    <p>These settings allow the alarm server or a separate tool
+       like the "alarm-notifier" to react to alarms.</p>
+
+    <h4>Severity PVs</h4>
+
+    <p>The alarm server can update PVs with the current alarm severity
+       of an area, system or subsystem in the alarm hierarchy.</p>
+
+    <p>This can be useful for compatibility with ALH, or to trigger
+       further IOC logic based on alarms.</p>
+
+    <p>The "Detail' of the automated action needs to be set to
+       <code>sevrpv:NameOfPV</code>.
+	   The "Title" and "Delay" of the automated action are ignored.</p>
+    
+    <p>Whenever the alarm severity of the area or (sub-) system changes,
+       the ordinal of the alarm severity will be written to the PV,
+       i.e. a number 0 to 8 representing
+       OK, MINOR_ACK, MAJOR_ACK, INVALID_ACK, UNDEFINED_ACK,
+       MINOR, MAJOR, INVALID, UNDEFINED.
+       A suitable PV would be a numeric EPICS record, or this enumerated record:
+    </p>
+    <pre>
+# Example for "Severity PV"
+# used with automated action set to "sevrpv:NameOfPV"
+#
+# softIoc -s -m N=NameOfPV -d sevrpv.db
+
+record(mbbi, "$(N)")
+    </pre>
+    
+    <p>When using "sevrpv:.." to send the alarm severity of nodes in the
+       alarm hierarchy to PVs, note that these PVs will not be updated
+       in case the alarm server is stopped, either on purpose or because
+       of a malfunction.
+       The <code>org.csstudio.alarm.beast/heartbeat_pv</code> preference of
+       the alarm server can be set to the name of a PV which will be set to 1
+       every 10 seconds
+       (period can be changed via  
+       The <code>org.csstudio.alarm.beast/heartbeat_secs</code>).
+       A record like this can be used to verify a continuous heartbeat:
+    </p>
+    <pre>
+# Example for "Heartbeat PV"
+#
+# Alarm Server sets it to 1 every ~10 seconds,
+# see heartbeat_pv and heartbeat_secs preferences.
+#
+# softIoc -s -m S=Demo -d heartbeat.db
+
+record(bo, "$(S):AlarmServerHeartbeat")
+{
+    # If Alarm Server doesn't write '1' every 10 seconds,
+    # drop to 0 after 30 secs.
+    field(HIGH, "30")
+    field(ZNAM, "Timeout")
+    field(ZSV,  "MAJOR")
+    field(ONAM, "OK")
+    field(DOL,  "1")
+    field(PINI, "YES")
+}
+    </pre>
+    
+
+    <h4>Notifications</h4>
+
+    <p>The automated notifications are performed by a designated
+       "alarm-notifier" that must be running in parallel to the alarm server.
+    </p>
+    
     <p>If alarms persist for a certain time without being acknowledged
         or cleared, and automated notification can be generated.</p>
     <p>If you configure a notification for an alarm trigger PV, the
@@ -1010,9 +1081,6 @@
         configure a notification for a system or area, the default message
         will list the PVs in alarm below that section of the alarm tree.</p>
     <p>The configuration of an automated notification has three parts:</p>
-
-
-
 
     <ol>
         <li>Title: The title to be displayed as a context menu item. The
@@ -1025,9 +1093,6 @@
             notification, for example email, as listed below.</li>
     </ol>
 
-    <p>The automated notifications are performed by a designated
-        "alarm-notifier" that must be running in parallel to the alarm server.
-    </p>
 
 
     <h4>Email Notifications</h4>

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui/src/org/csstudio/alarm/beast/ui/ContextMenuHelper.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast.ui/src/org/csstudio/alarm/beast/ui/ContextMenuHelper.java
@@ -227,6 +227,9 @@ public class ContextMenuHelper
         {   // avoid duplicates
             if (addedAutoActions.contains(action))
                 continue;
+            // Skip sevrpv: actions
+            if (action.getDetails().startsWith("sevrpv:"))
+                continue;
              manager.add(new AutomatedAction(shell, item, action));
              addedAutoActions.add(action);
              if (addedAutoActions.size() > max_context_entries)

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/preferences.ini
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/preferences.ini
@@ -42,6 +42,13 @@ pv_start_delay=0
 
 #  Grace period in seconds for PVs to connect
 connection_grace_period=30
+
+# Optional heartbeat PV
+# When defined, alarm server will set it to 1 every 10 seconds
+#heartbeat_pv=Demo:AlarmServerHeartbeat
+
+# Heartbeat period in seconds
+heartbeat_secs=10
  
 # Number of entries shown in context menu for guidance or related
 # displays before they're summarized as "... more ..."

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/Preferences.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/Preferences.java
@@ -42,6 +42,8 @@ public class Preferences
     final public static String JMS_IDLE_TIMEOUT = "jms_idle_timeout";
     final public static String PV_START_DELAY = "pv_start_delay";
     final public static String CONNECTION_GRACE_PERIOD = "connection_grace_period";
+    final public static String HEARTBEAT_PV = "heartbeat_pv";
+    final public static String HEARTBEAT_SECS = "heartbeat_secs";
     final public static String COMMAND_DIRECTORY = "command_directory";
     final public static String COMMAND_CHECK_TIME = "command_check_time";
     final public static String COLOR_OK = "color_ok";
@@ -200,6 +202,20 @@ public class Preferences
     {
         final IPreferencesService service = Platform.getPreferencesService();
         return service.getLong(Activator.ID, CONNECTION_GRACE_PERIOD, 30, null);
+    }
+
+    /** @return Heartbeat PV */
+    public static String getHeartbeatPV()
+    {
+        final IPreferencesService service = Platform.getPreferencesService();
+        return service.getString(Activator.ID, HEARTBEAT_PV, "", null);
+    }
+
+    /** @return Heartbeat period in seconds */
+    public static long getHeartbeatSecs()
+    {
+        final IPreferencesService service = Platform.getPreferencesService();
+        return service.getLong(Activator.ID, HEARTBEAT_SECS, 10, null);
     }
 
     /** @return Directory where to run commands */


### PR DESCRIPTION
Implements  #2412 : 

Automated Action on Area, system, subsystem with detail `sevrpv:NameOfPV` instructs alarm server to write the severity of that node to a PV, very similar to ALH `$SEVRPV`.

In case of worries that the alarm server quits and thus will no longer update the PVs, a new `org.csstudio.alarm.beast/heartbeat_pv` preference can be set to the name of a PV that'll be periodically set to 1, usable for a heartbeat check.

Details are in the online help.