### PR TITLE
2453 data browser cancel search

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
@@ -52,10 +52,10 @@ abstract public class SearchJob extends Job
                 final ArchiveReader reader = ArchiveRepository.getInstance().getArchiveReader(archive.getUrl());
             )
             {
-           	    if (monitor.isCanceled()) {
-           	    	monitor.done();
+                if (monitor.isCanceled()) {
+                    monitor.done();
                     return Status.CANCEL_STATUS;
-           	    }
+                }
                 monitor.subTask(archive.getName());
                 final String[] names;
                 if (pattern_is_glob)

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/SearchJob.java
@@ -52,6 +52,10 @@ abstract public class SearchJob extends Job
                 final ArchiveReader reader = ArchiveRepository.getInstance().getArchiveReader(archive.getUrl());
             )
             {
+           	    if (monitor.isCanceled()) {
+           	    	monitor.done();
+                    return Status.CANCEL_STATUS;
+           	    }
                 monitor.subTask(archive.getName());
                 final String[] names;
                 if (pattern_is_glob)


### PR DESCRIPTION
This cancels more frequently.

We had another problem which probably wants a timeout on the XmlRpcClient calls, but as we hope to drop the Channel Archiver pretty soon we figured it was a bit tricky to fix.

cc @skyfrench