### PR TITLE
Databrowser: shade the area of the plot that's in the future.

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -671,8 +671,8 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
             final Color orig = gc.getBackground();
             // Use light gray for bright background, otherwise dark gray
             final Color shade = (background.getHSB()[2] >= 0.5)
-                    ? new Color(getDisplay(), 240, 240, 240, 0)
-                    : new Color(getDisplay(), 50, 50, 50, 0);
+                    ? new Color(getDisplay(), 240, 240, 240)
+                    : new Color(getDisplay(), 50, 50, 50);
             gc.setBackground(shade);
             gc.fillRectangle(future_x, 0, area_copy.width - future_x, area_copy.height);
             gc.setBackground(orig);

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -47,6 +47,7 @@ import org.eclipse.swt.events.MouseMoveListener;
 import org.eclipse.swt.events.MouseTrackListener;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.GC;
@@ -662,6 +663,21 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
 
         title_part.paint(gc, media, title_font);
         legend.paint(gc, media, legend_font, traces);
+
+        // Shade the area in the plot that's in the future.
+        if (x_axis instanceof TimeAxis)
+        {
+            final int future_x = ((TimeAxis)x_axis).getScreenCoord(Instant.now());
+            final Color orig = gc.getBackground();
+            // Use light gray for bright background, otherwise dark gray
+            final Color shade = (background.getHSB()[2] >= 0.5)
+                    ? new Color(getDisplay(), 240, 240, 240, 0)
+                    : new Color(getDisplay(), 50, 50, 50, 0);
+            gc.setBackground(shade);
+            gc.fillRectangle(future_x, 0, area_copy.width - future_x, area_copy.height);
+            gc.setBackground(orig);
+            shade.dispose();
+        }
 
         // Fetch x_axis transformation and use that to paint all traces,
         // because X Axis tends to change from scrolling


### PR DESCRIPTION
I slightly changed Kay's suggestion - it's a slightly lighter colour and the grid lines will be painted over the top.

See #2452 and #2457 

![future](https://user-images.githubusercontent.com/2440055/43788673-e8123dc4-9a65-11e8-8d95-4ddadbd5e191.png)
