### PR TITLE
cs-studio #2467 (CSS-495): DataBrowser 'Stagger' traces disables autoscale

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
@@ -25,6 +25,7 @@ import org.csstudio.swt.rtplot.internal.ToggleLegendAction;
 import org.csstudio.swt.rtplot.internal.ToggleToolbarAction;
 import org.csstudio.swt.rtplot.internal.ToolbarHandler;
 import org.csstudio.swt.rtplot.internal.TraceImpl;
+import org.csstudio.swt.rtplot.internal.YAxisImpl;
 import org.csstudio.swt.rtplot.undo.UndoableActionManager;
 import org.eclipse.jface.action.Action;
 import org.eclipse.swt.SWT;
@@ -243,6 +244,10 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
     /** Stagger the range of axes */
     public void stagger()
     {
+        for (YAxisImpl<XTYPE> axis : plot.getYAxes()) {
+            axis.setAutoscale(false);
+            plot.fireAutoScaleChange(axis);
+        }
         plot.stagger();
     }
 


### PR DESCRIPTION
If the 'Stagger' traces button is clicked on the DataBrowser, autoscaling is now turned off for all value axes. Previously any introduced Stagger was undone by the plot auto-scaling back to the originals afterwards.