### PR TITLE
Simplify use of generics (4.5.x)

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
@@ -7,7 +7,6 @@
  ******************************************************************************/
 package org.csstudio.swt.rtplot;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -48,40 +47,21 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
 {
     final protected Plot<XTYPE> plot;
     final protected ToolbarHandler<XTYPE> toolbar;
-    final private ToggleToolbarAction<XTYPE> toggle_toolbar;
-    final private ToggleLegendAction<XTYPE> toggle_legend;
+    final private ToggleToolbarAction toggle_toolbar;
+    final private ToggleLegendAction toggle_legend;
     final private Action snapshot;
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     protected RTPlot(final Composite parent, final Class<XTYPE> type)
     {
         super(parent, SWT.NULL);
 
         setLayout(new FormLayout());
 
-        // To avoid unchecked casts, factory methods for..() would need
-        // pass already constructed Plot<T> and Toolbar<T>, where T is set,
-        // into constructor.
-        // But they cannot be created outside of this Composite constructor
-        // because they need parent == this.
-        if (type == Double.class)
-        {
-            plot = (Plot) new Plot<Double>(this, Double.class);
-            toolbar = (ToolbarHandler) new ToolbarHandler<Double>((RTPlot)this);
-            toggle_toolbar = (ToggleToolbarAction) new ToggleToolbarAction<Double>((RTPlot)this, true);
-            toggle_legend = (ToggleLegendAction) new ToggleLegendAction<Double>((RTPlot)this, true);
-            snapshot = new SnapshotAction(this);
-        }
-        else if (type == Instant.class)
-        {
-            plot = (Plot) new Plot<Instant>(this, Instant.class);
-            toolbar = (ToolbarHandler) new ToolbarHandler<Instant>((RTPlot)this);
-            toggle_toolbar = (ToggleToolbarAction) new ToggleToolbarAction<Double>((RTPlot)this, true);
-            toggle_legend = (ToggleLegendAction) new ToggleLegendAction<Double>((RTPlot)this, true);
-            snapshot = new SnapshotAction(this);
-        }
-        else
-            throw new IllegalArgumentException("Cannot handle " + type.getName());
+        plot = new Plot<XTYPE>(this, type);
+        toolbar = new ToolbarHandler<XTYPE>(this);
+        toggle_toolbar = new ToggleToolbarAction(this, true);
+        toggle_legend =  new ToggleLegendAction(this, true);
+        snapshot = new SnapshotAction(this);
 
         toolbar.addContextMenu(toggle_toolbar);
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/SnapshotAction.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/SnapshotAction.java
@@ -31,11 +31,11 @@ import org.eclipse.swt.widgets.Shell;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class SnapshotAction<XTYPE extends Comparable<XTYPE>> extends Action
+public class SnapshotAction extends Action
 {
-    final private RTPlot<XTYPE> plot;
+    final private RTPlot<?> plot;
 
-    public SnapshotAction(final RTPlot<XTYPE> plot)
+    public SnapshotAction(final RTPlot<?> plot)
     {
         super(Messages.Snapshot, Activator.getIcon("camera"));
         this.plot = plot;

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToggleLegendAction.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToggleLegendAction.java
@@ -13,11 +13,11 @@ import org.eclipse.jface.action.Action;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ToggleLegendAction<XTYPE extends Comparable<XTYPE>> extends Action
+public class ToggleLegendAction extends Action
 {
-    final private RTPlot<XTYPE> plot;
+    final private RTPlot<?> plot;
 
-    public ToggleLegendAction(final RTPlot<XTYPE> plot, final boolean is_visible)
+    public ToggleLegendAction(final RTPlot<?> plot, final boolean is_visible)
     {
         super(is_visible ? Messages.Legend_Hide : Messages.Legend_Show,
               Activator.getIcon("legend"));

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToggleToolbarAction.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/ToggleToolbarAction.java
@@ -16,11 +16,11 @@ import org.eclipse.jface.action.Action;
  *  @author Kay Kasemir
  */
 @SuppressWarnings("nls")
-public class ToggleToolbarAction<XTYPE extends Comparable<XTYPE>> extends Action
+public class ToggleToolbarAction extends Action
 {
-    final private RTPlot<XTYPE> plot;
+    final private RTPlot<?> plot;
 
-    public ToggleToolbarAction(final RTPlot<XTYPE> plot, final boolean is_visible)
+    public ToggleToolbarAction(final RTPlot<?> plot, final boolean is_visible)
     {
         super(is_visible ? Messages.Toolbar_Hide : Messages.Toolbar_Show,
               Activator.getIcon("toolbar"));


### PR DESCRIPTION
With wildcards we can avoid some of the casts.

Backport to 4.5.x