### PR TITLE
MySQL 8 no longer needs ReplicationDriver

### DIFF
--- a/core/platform/platform-plugins/org.csstudio.platform.utility.rdb/src/org/csstudio/platform/utility/rdb/internal/MySQL_RDB.java
+++ b/core/platform/platform-plugins/org.csstudio.platform.utility.rdb/src/org/csstudio/platform/utility/rdb/internal/MySQL_RDB.java
@@ -18,8 +18,6 @@ import org.csstudio.platform.utility.rdb.Activator;
 import org.csstudio.platform.utility.rdb.RDBUtil;
 import org.csstudio.platform.utility.rdb.RDBUtil.Dialect;
 
-import com.mysql.jdbc.ReplicationDriver;
-
 /** Connect to a MySQL-based RDB
  *  @author Kay Kasemir
  *  @author Xihui Chen
@@ -50,23 +48,19 @@ public class MySQL_RDB implements RDBImpl
             props.put("password", password);
         }
         // Test if the connection should use replication driver or not
-        if (!url.startsWith("jdbc:mysql:replication"))
-        {   // Class loader locates the plain MySQL driver
-            Class.forName("com.mysql.jdbc.Driver").newInstance();
-            connection = DriverManager.getConnection(url, props);
-        }
-        else
-        {   // Use ReplicationDriver
-            final ReplicationDriver driver = new ReplicationDriver();
-
+        if (url.startsWith("jdbc:mysql:replication"))
+        {
             // We want this for failover on the slaves
             props.put("autoReconnect", "true");
 
             // We want to load balance between the slaves
             props.put("roundRobinLoadBalance", "true");
-
-            connection = driver.connect(url, props);
+            // Before Connector/J 8.0, this required ReplicationDriver(),
+            // but now normal driver can handle replication
         }
+        // Class loader locates the plain MySQL driver
+        Class.forName("com.mysql.jdbc.Driver").newInstance();
+        connection = DriverManager.getConnection(url, props);
 
         // Basic database info
         final Logger logger = Activator.getLogger();


### PR DESCRIPTION
Depends on MySQL client update, 
https://github.com/ControlSystemStudio/maven-osgi-bundles/pull/72
https://github.com/ControlSystemStudio/cs-studio-thirdparty/pull/70

Fixes #2491