### PR TITLE
Remove duplicate action introduced by incorrect merge.

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/waveformview/WaveformView.java
@@ -268,8 +268,6 @@ public class WaveformView extends DataBrowserAwareView
                 mm.add(plot.getLegendAction());
                 mm.add(new Separator());
                 mm.add(new ToggleYAxisAction<Double>(plot, true));
-                mm.add(new Separator());
-                mm.add(plot.getSnapshotAction());
                 mm.add(new ToggleYAxisAutoscaleAction<Double>(plot, true));
                 mm.add(new Separator());
                 mm.add(plot.getSnapshotAction());


### PR DESCRIPTION
@berryma4 sorry it looks like there was an incorrect merge resolution so there's one more here.

You can see that the SnapshotAction was added to the context menu twice.