### PR TITLE
Changes to allow building using JDK11.

### DIFF
--- a/applications/apputil/apputil-plugins/org.csstudio.utility.clock/META-INF/MANIFEST.MF
+++ b/applications/apputil/apputil-plugins/org.csstudio.utility.clock/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.core.di,
  org.eclipse.e4.core.di.extensions,
  org.eclipse.e4.ui.model.workbench,
- org.eclipse.e4.ui.di
+ org.eclipse.e4.ui.di,
+ javax.annotation
 Import-Package: javax.annotation;version="1.1.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov>, Xihui Chen 

--- a/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/META-INF/MANIFEST.MF
+++ b/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.ui,
  edu.msu.nscl.olog.api,
  org.csstudio.email.ui,
  org.diirt.util,
- org.eclipse.swt
+ org.eclipse.swt,
+ jaxb-api
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.validation/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Require-Bundle: org.csstudio.opibuilder;bundle-version="4.0.0",
  org.eclipse.gef;bundle-version="3.9.100",
  org.csstudio.opibuilder.widgets;bundle-version="3.4.0",
  org.csstudio.opibuilder.editor;bundle-version="3.1.4",
- org.apache.commons.io;bundle-version="2.0.1"
+ org.apache.commons.io;bundle-version="2.0.1",
+ jaxb-api
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.csstudio.opibuilder.validation.Activator

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -66,11 +66,11 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/oxygen</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.7</eclipse-update-site>
+        <eclipse-site>${eclipse.mirror.url}/releases/photon</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.8</eclipse-update-site>
         <rap-site>${eclipse.mirror.url}/rt/rap/3.1</rap-site>
         <rap-gef-site>http://archive.eclipse.org/rt/rap/incubator/nightly/gef/20150327-1849</rap-gef-site>
-        <efx-site>${eclipse.mirror.url}/efxclipse/runtime-released/2.4.0/site</efx-site>
+        <efx-site>${eclipse.mirror.url}/efxclipse/runtime-released/3.4.0/site</efx-site>
       </properties>
     </profile>
     <profile>

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences/META-INF/MANIFEST.MF
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences/META-INF/MANIFEST.MF
@@ -8,7 +8,9 @@ Bundle-Vendor: European Spallation Source ERIC
 Require-Bundle: org.apache.commons.io;bundle-version="2.5.0",
  org.apache.commons.lang3;bundle-version="3.1.0",
  org.eclipse.core.runtime,
- org.epics.jca;bundle-version="2.3.6"
+ org.epics.jca;bundle-version="2.3.6",
+ jaxb-api;bundle-version="2.4.0",
+ org.eclipse.persistence.moxy;bundle-version="2.7.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.csstudio.diirt.util.core.preferences;uses:="org.osgi.framework,org.eclipse.osgi.util,org.eclipse.core.runtime.preferences",
  org.csstudio.diirt.util.core.preferences.pojo;uses:="org.csstudio.diirt.util.core.preferences"

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences/src/org/csstudio/diirt/util/core/preferences/pojo/ChannelAccess.java
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences/src/org/csstudio/diirt/util/core/preferences/pojo/ChannelAccess.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.csstudio.diirt.util.core.preferences.DIIRTPreferences;
 import org.csstudio.diirt.util.core.preferences.pojo.DataSourceOptions.MonitorMask;
 import org.csstudio.diirt.util.core.preferences.pojo.DataSourceOptions.VariableArraySupport;
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
 
 /**
  * Plain Old Java Object representing a {@code ca.xml} file.
@@ -89,7 +90,7 @@ public class ChannelAccess {
         File datasourcesDir = new File(confDir, DataSources.DATASOURCES_DIR);
         File channelAccessDir = new File(datasourcesDir, CA_DIR);
         File channelAccessFile = new File(channelAccessDir, CA_FILE);
-        JAXBContext jc = JAXBContext.newInstance(ChannelAccess.class);
+        JAXBContext jc = JAXBContextFactory.createContext(new Class[]{ChannelAccess.class},null);
         Unmarshaller u = jc.createUnmarshaller();
         ChannelAccess ca = (ChannelAccess) u.unmarshal(channelAccessFile);
 
@@ -208,7 +209,7 @@ public class ChannelAccess {
 
         FileUtils.forceMkdir(caDir);
 
-        JAXBContext context = JAXBContext.newInstance(ChannelAccess.class);
+        JAXBContext context = JAXBContextFactory.createContext(new Class[]{ChannelAccess.class},null);
         Marshaller marshaller = context.createMarshaller();
 
         try ( Writer writer = new FileWriter(new File(caDir, CA_FILE)) ) {

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences/src/org/csstudio/diirt/util/core/preferences/pojo/DataSources.java
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences/src/org/csstudio/diirt/util/core/preferences/pojo/DataSources.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -76,7 +77,7 @@ public class DataSources {
 
         File datasourcesDir = new File(confDir, DATASOURCES_DIR);
         File datasourcesFile = new File(datasourcesDir, DATASOURCES_FILE);
-        JAXBContext jc = JAXBContext.newInstance(DataSources.class);
+        JAXBContext jc = JAXBContextFactory.createContext(new Class[]{DataSources.class},null);
         Unmarshaller u = jc.createUnmarshaller();
         DataSources ds = (DataSources) u.unmarshal(datasourcesFile);
 
@@ -168,7 +169,7 @@ public class DataSources {
 
         FileUtils.forceMkdir(dsDir);
 
-        JAXBContext context = JAXBContext.newInstance(DataSources.class);
+        JAXBContext context = JAXBContextFactory.createContext(new Class[]{DataSources.class},null);
         Marshaller marshaller = context.createMarshaller();
 
         try ( Writer writer = new FileWriter(new File(dsDir, DATASOURCES_FILE)) ) {

--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util/META-INF/MANIFEST.MF
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util/META-INF/MANIFEST.MF
@@ -19,5 +19,9 @@ Require-Bundle: org.eclipse.equinox.preferences;bundle-version="3.5.200",
  org.csstudio.startup;bundle-version="3.2.1",
  org.csstudio.utility.product;bundle-version="1.3.0",
  org.csstudio.diirt.util.core.preferences;bundle-version="1.0.2",
- org.diirt.util;bundle-version="3.0.1"
+ org.diirt.util;bundle-version="3.0.1",
+ org.jacorb.omgapi,
+ jaxb-api;bundle-version="2.4.0",
+ org.eclipse.persistence.moxy;bundle-version="2.7.3",
+ org.eclipse.persistence.asm;bundle-version="2.7.3"
 Export-Package: org.csstudio.diirt.util

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,11 +66,11 @@
         </property>
       </activation>
       <properties>
-        <eclipse-site>${eclipse.mirror.url}/releases/oxygen</eclipse-site>
-        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.7</eclipse-update-site>
+        <eclipse-site>${eclipse.mirror.url}/releases/photon</eclipse-site>
+        <eclipse-update-site>${eclipse.mirror.url}/eclipse/updates/4.8</eclipse-update-site>
         <rap-site>${eclipse.mirror.url}/rt/rap/3.1</rap-site>
         <rap-gef-site>http://archive.eclipse.org/rt/rap/incubator/nightly/gef/20150327-1849</rap-gef-site>
-        <efx-site>${eclipse.mirror.url}/efxclipse/runtime-released/2.4.0/site</efx-site>
+        <efx-site>${eclipse.mirror.url}/efxclipse/runtime-released/3.4.0/site</efx-site>
       </properties>
     </profile>
     <profile>

--- a/core/ui/ui-plugins/org.csstudio.perspectives/META-INF/MANIFEST.MF
+++ b/core/ui/ui-plugins/org.csstudio.perspectives/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="3.5.0",
  org.eclipse.core.commands;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.11.0",
  org.eclipse.ui.workbench;bundle-version="3.107.0",
- org.eclipse.ui;bundle-version="3.107.0"
+ org.eclipse.ui;bundle-version="3.107.0",
+ javax.annotation
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.csstudio.perspectives

--- a/core/utility/utility-plugins/org.csstudio.logging/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.logging/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: Kay Kasemir <kasemirk@ornl.gov> - SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.osgi;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
- org.csstudio.platform.libs.jms;bundle-version="1.1.1"
+ org.csstudio.platform.libs.jms;bundle-version="1.1.1",
+ javax.annotation
 Export-Package: org.csstudio.logging
 Import-Package: org.csstudio.java.time

--- a/core/utility/utility-plugins/org.csstudio.startup/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.startup/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.ide;bundle-version="3.6.0",
  org.eclipse.core.filesystem;bundle-version="1.3.0",
  org.eclipse.core.resources,
- org.csstudio.openfile;bundle-version="3.0.0"
+ org.csstudio.openfile;bundle-version="3.0.0",
+ javax.annotation
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: DESY/SNS/Cosylab
 Export-Package: org.csstudio.startup.application,


### PR DESCRIPTION
These changes build and run the basic functionality. There are also changes to `maven-osgi-bundles` and `diirt` required. Don't merge, this is for discussion.

The biggest problem is JAXB - I've had to hard-code to the Eclipse Moxy implementation when it should select dynamically according to the plugins available.