### PR TITLE
phoebus-integration

### DIFF
--- a/applications/phoebus/phoebus-features/org.csstudio.phoebus.integration.feature/feature.xml
+++ b/applications/phoebus/phoebus-features/org.csstudio.phoebus.integration.feature/feature.xml
@@ -22,5 +22,17 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+   <plugin
+         id="org.csstudio.phoebus.integration.alarm"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+   <plugin
+         id="org.csstudio.phoebus.integration.channel"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/applications/phoebus/phoebus-plugins/pom.xml
+++ b/applications/phoebus/phoebus-plugins/pom.xml
@@ -9,6 +9,7 @@
   <packaging>pom</packaging>
   <modules>
     <module>org.csstudio.phoebus.integration</module>
+    <module>org.csstudio.phoebus.integration.alarm</module>
     <module>org.csstudio.phoebus.integration.channel</module>
   </modules>
 </project>


### PR DESCRIPTION
Fixed missing plugin and module.

@shroffk 
I can't having the plug-ins working. I don't remember if there is a setting or a convention on where Java 11 is and where Phoebus applications are.

Should we add a preference pane?