### PR TITLE
#2553 Archive Engine: Nanoseconds Incorrect

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.writer.rdb/src/org/csstudio/archive/writer/rdb/RDBArchiveWriter.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.writer.rdb/src/org/csstudio/archive/writer/rdb/RDBArchiveWriter.java
@@ -473,12 +473,21 @@ public class RDBArchiveWriter implements ArchiveWriter
     {
         // Set the stuff that's common to each type
         insert_xx.setInt(1, channel.getId());
-        insert_xx.setTimestamp(2, stamp);
         insert_xx.setInt(3, severity);
         insert_xx.setInt(4, status.getId());
-        // MySQL nanosecs
-        if (rdb.getDialect() == Dialect.MySQL  ||  rdb.getDialect() == Dialect.PostgreSQL)
+
+        if (rdb.getDialect() == Dialect.Oracle)
+            insert_xx.setTimestamp(2, stamp);
+        else
+        {
+            // Truncate the time stamp
+            Timestamp truncated = Timestamp.from(stamp.toInstant());
+            truncated.setNanos(0);
+            insert_xx.setTimestamp(2, truncated);
+            // Set the nanos in a separate column
             insert_xx.setInt(6, stamp.getNanos());
+        }
+
         // Batch
         insert_xx.addBatch();
     }


### PR DESCRIPTION
Timestamp truncated for MySQL and PostgreSQL to avoid rounding it "up" to the nearest second