### PR TITLE
Write PVPool content after a call to PVPool.releasePV

### DIFF
--- a/core/base/base-plugins/org.csstudio.vtype.pv/preferences.ini
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/preferences.ini
@@ -9,6 +9,11 @@ mqtt_broker=tcp://localhost:1883
 # potentially lowering CPU load on IOCs
 large_array_threshold=100000
 
+# If true, the last statement of PVPool.releasePV()
+# will be printing to the standard output the
+# content of the PVPool itself.
+print_pvpool_content_on_release=false
+
 ##
 ## EPICS Channel Access Settings
 ##

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/PVPool.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/PVPool.java
@@ -184,6 +184,17 @@ public class PVPool
         }
         if (references == 0)
             pv.close();
+
+		System.out.println("PV Pool after release:");
+
+		if ( getPVReferences().isEmpty() ) {
+			System.out.println("  <empty>");
+		} else {
+			for ( ReferencedEntry<PV> ref : getPVReferences() ) {
+				System.out.println("  " + ref);
+			}
+		}
+
     }
 
     /** @return PVs currently in the pool with reference count information */

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/PVPool.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/PVPool.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.csstudio.vtype.pv.RefCountMap.ReferencedEntry;
+import org.csstudio.vtype.pv.internal.Preferences;
 
 /** Pool of {@link PV}s
  *
@@ -185,14 +186,20 @@ public class PVPool
         if (references == 0)
             pv.close();
 
-		System.out.println("PV Pool after release:");
+		if ( Preferences.isPrintPVPoolContentOnRelease() ) {
 
-		if ( getPVReferences().isEmpty() ) {
-			System.out.println("  <empty>");
-		} else {
-			for ( ReferencedEntry<PV> ref : getPVReferences() ) {
-				System.out.println("  " + ref);
+			StringBuilder builder = new StringBuilder("PV Pool after release:\n");
+
+			if ( getPVReferences().isEmpty() ) {
+				builder.append("  <empty>\n");
+			} else {
+				for ( ReferencedEntry<PV> ref : getPVReferences() ) {
+					builder.append("  ").append(ref).append("\n");
+				}
 			}
+
+			System.out.println(builder.deleteCharAt(builder.length() - 1).toString());
+
 		}
 
     }

--- a/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/internal/Preferences.java
+++ b/core/base/base-plugins/org.csstudio.vtype.pv/src/org/csstudio/vtype/pv/internal/Preferences.java
@@ -38,4 +38,12 @@ public class Preferences
         return getString(PVPlugin.ID, "mqtt_broker", MQTT_PVFactory.BROKER_URL);
     }
 
+    public static boolean isPrintPVPoolContentOnRelease()
+    {
+        final IPreferencesService service = Platform.getPreferencesService();
+        if (service == null)
+            return false;
+        return service.getBoolean(PVPlugin.ID, "print_pvpool_content_on_release", false, null);
+    }
+
 }


### PR DESCRIPTION
Added a preference to enable the printout in the `org.csstudio.vtype.pv ` plugin:

```
# If true, the last statement of PVPool.releasePV()
# will be printing to the standard output the
# content of the PVPool itself.
print_pvpool_content_on_release=false
```