### PR TITLE
Attempt to fix tests that use JAXB after JDK-11 changes.

### DIFF
--- a/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault.test/META-INF/MANIFEST.MF
+++ b/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault.test/META-INF/MANIFEST.MF
@@ -6,4 +6,9 @@ Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.csstudio.logbook.olog.property.fault
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.11.0",
- org.hamcrest.core;bundle-version="1.1.0"
+ org.hamcrest.core;bundle-version="1.1.0",
+ jaxb-api;bundle-version="2.3.1",
+ com.sun.xml.bind.jaxb-impl;bundle-version="2.3.1",
+ javax.activation;bundle-version="1.1.1",
+ javax.activation-api;bundle-version="1.2.0"
+Import-Package: com.sun.xml.bind.v2

--- a/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault.test/src/org/csstudio/logbook/olog/property/fault/FaultConfigurationParsingTest.java
+++ b/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault.test/src/org/csstudio/logbook/olog/property/fault/FaultConfigurationParsingTest.java
@@ -14,23 +14,32 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
 import org.csstudio.logbook.olog.property.fault.FaultConfiguration.Group;
+import org.csstudio.logbook.olog.property.fault.FaultConfigurationFactory;
 import org.junit.Test;
 
 public class FaultConfigurationParsingTest {
 
     @Test
     public void parserTest() throws JAXBException {
+        final ClassLoader orig = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(JAXBContext.class.getClassLoader());
 
-        JAXBContext context = JAXBContext.newInstance(FaultConfiguration.class);
-        Unmarshaller um = context.createUnmarshaller();
-        JAXBElement<FaultConfiguration> fc2 = um.unmarshal(new StreamSource(new File("resources/default_fault_config.xml")),
-                FaultConfiguration.class);
-        FaultConfiguration fc = fc2.getValue();
-        assertEquals("areas not equal", fc.getAreas(), Arrays.asList("Global", "Linac", "BR", "SR"));
-        assertEquals("subsystems not equal", fc.getSubsystems(), Arrays.asList("Diagnostics", "EPS", "RF", "Controls"));
-        assertEquals("devices not equal", fc.getDevices(), Arrays.asList("M01", "M02", "M03"));
-        List<Group> testGroups = Arrays.asList(new Group("Controls", "Kunal Shroff", "shroffk@bnl.gov"),
-                new Group("Operations", "Reid Smith", "smithr@bnl.gov"));
-        assertTrue("groups not equal", fc.getGroups().containsAll(testGroups));
+        try {
+	        JAXBContext context = JAXBContext.newInstance(FaultConfiguration.class.getPackageName(),
+	                FaultConfigurationFactory.class.getClassLoader());
+	        Unmarshaller um = context.createUnmarshaller();
+	        JAXBElement<FaultConfiguration> fc2 = um.unmarshal(new StreamSource(new File("resources/default_fault_config.xml")),
+	                FaultConfiguration.class);
+	        FaultConfiguration fc = fc2.getValue();
+	        assertEquals("areas not equal", fc.getAreas(), Arrays.asList("Global", "Linac", "BR", "SR"));
+	        assertEquals("subsystems not equal", fc.getSubsystems(), Arrays.asList("Diagnostics", "EPS", "RF", "Controls"));
+	        assertEquals("devices not equal", fc.getDevices(), Arrays.asList("M01", "M02", "M03"));
+	        List<Group> testGroups = Arrays.asList(new Group("Controls", "Kunal Shroff", "shroffk@bnl.gov"),
+	                new Group("Operations", "Reid Smith", "smithr@bnl.gov"));
+	        assertTrue("groups not equal", fc.getGroups().containsAll(testGroups));
+        } finally {
+            Thread.currentThread().setContextClassLoader(orig);
+        }
     }
+
 }

--- a/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault.test/src/org/csstudio/logbook/olog/property/fault/FaultConfigurationParsingTest.java
+++ b/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault.test/src/org/csstudio/logbook/olog/property/fault/FaultConfigurationParsingTest.java
@@ -25,18 +25,18 @@ public class FaultConfigurationParsingTest {
         Thread.currentThread().setContextClassLoader(JAXBContext.class.getClassLoader());
 
         try {
-	        JAXBContext context = JAXBContext.newInstance(FaultConfiguration.class.getPackageName(),
-	                FaultConfigurationFactory.class.getClassLoader());
-	        Unmarshaller um = context.createUnmarshaller();
-	        JAXBElement<FaultConfiguration> fc2 = um.unmarshal(new StreamSource(new File("resources/default_fault_config.xml")),
-	                FaultConfiguration.class);
-	        FaultConfiguration fc = fc2.getValue();
-	        assertEquals("areas not equal", fc.getAreas(), Arrays.asList("Global", "Linac", "BR", "SR"));
-	        assertEquals("subsystems not equal", fc.getSubsystems(), Arrays.asList("Diagnostics", "EPS", "RF", "Controls"));
-	        assertEquals("devices not equal", fc.getDevices(), Arrays.asList("M01", "M02", "M03"));
-	        List<Group> testGroups = Arrays.asList(new Group("Controls", "Kunal Shroff", "shroffk@bnl.gov"),
-	                new Group("Operations", "Reid Smith", "smithr@bnl.gov"));
-	        assertTrue("groups not equal", fc.getGroups().containsAll(testGroups));
+            JAXBContext context = JAXBContext.newInstance(FaultConfiguration.class.getPackageName(),
+                    FaultConfigurationFactory.class.getClassLoader());
+            Unmarshaller um = context.createUnmarshaller();
+            JAXBElement<FaultConfiguration> fc2 = um.unmarshal(new StreamSource(new File("resources/default_fault_config.xml")),
+                    FaultConfiguration.class);
+            FaultConfiguration fc = fc2.getValue();
+            assertEquals("areas not equal", fc.getAreas(), Arrays.asList("Global", "Linac", "BR", "SR"));
+            assertEquals("subsystems not equal", fc.getSubsystems(), Arrays.asList("Diagnostics", "EPS", "RF", "Controls"));
+            assertEquals("devices not equal", fc.getDevices(), Arrays.asList("M01", "M02", "M03"));
+            List<Group> testGroups = Arrays.asList(new Group("Controls", "Kunal Shroff", "shroffk@bnl.gov"),
+                    new Group("Operations", "Reid Smith", "smithr@bnl.gov"));
+            assertTrue("groups not equal", fc.getGroups().containsAll(testGroups));
         } finally {
             Thread.currentThread().setContextClassLoader(orig);
         }

--- a/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/META-INF/MANIFEST.MF
+++ b/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/META-INF/MANIFEST.MF
@@ -29,5 +29,6 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
-Import-Package: com.sun.xml.bind.v2,
+Import-Package: com.sun.istack,
+ com.sun.xml.bind.v2,
  org.eclipse.ui.part

--- a/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/src/org/csstudio/logbook/olog/property/fault/jaxb.index
+++ b/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/src/org/csstudio/logbook/olog/property/fault/jaxb.index
@@ -1,0 +1,1 @@
+FaultConfiguration

--- a/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/src/org/csstudio/logbook/olog/property/fault/jaxb.properties
+++ b/applications/logbook/logbook-plugins/org.csstudio.logbook.olog.property.fault/src/org/csstudio/logbook/olog/property/fault/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=com.sun.xml.bind.v2.ContextFactory


### PR DESCRIPTION
These copy the changes in the rest of cs-studio, but the test still
fails to find JAXB-API.

Don't merge! This doesn't fix the problem for me.

@berryma4 @shroffk 