### PR TITLE
Split of Batik bundles

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.core.filesystem;bundle-version="1.2.0",
  org.jdom,
  org.eclipse.ui.workbench;bundle-version="3.106.0",
  org.eclipse.ui.views;bundle-version="3.7.0",
- org.eclipse.ui
+ org.eclipse.ui,
+ org.apache.batik.util;bundle-version="[1.10.0,1.11.0)"
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.csstudio.opibuilder.editor.Activator
@@ -32,6 +33,6 @@ Export-Package: org.csstudio.opibuilder.actions,
  org.csstudio.opibuilder.visualparts,
  org.csstudio.opibuilder.wizards
 Import-Package: org.apache.batik,
- org.apache.batik.util,
+ org.apache.batik.util;version="[1.10.0,1.11.0)",
  org.eclipse.draw2d.geometry,
  org.eclipse.gef.commands

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/META-INF/MANIFEST.MF
@@ -15,9 +15,18 @@ Require-Bundle: org.eclipse.ui;resolution:=optional,
  org.eclipse.gef;bundle-version="3.4.0";resolution:=optional,
  org.apache.commons.lang,
  org.csstudio.ui.util;resolution:=optional,
- org.apache.batik.util,
  com.google.guava,
- org.apache.xmlgraphics.batik-all;bundle-version="1.10.0"
+ org.apache.xmlgraphics.batik-bridge;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-dom;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-svg-dom;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-transcoder;bundle-version="[1.10.0,1.11.0)",
+ org.apache.batik.util;bundle-version="[1.10.0,1.11.0)",
+ org.apache.batik.css;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-xml;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-awt-util;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-anim;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-gvt;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-script;bundle-version="[1.10.0,1.11.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.csstudio.swt.widgets.datadefinition,

--- a/core/utility/utility-plugins/org.csstudio.utility.batik/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.utility.batik/META-INF/MANIFEST.MF
@@ -10,12 +10,26 @@ Require-Bundle: org.w3c.dom.svg,
  org.eclipse.ui;resolution:=optional,
  org.apache.commons.lang,
  org.csstudio.java,
- org.apache.xmlgraphics.batik-all;bundle-version="1.10.0",
- javax.xml
-Export-Package: org.csstudio.utility.batik
+ javax.xml,
+ org.apache.xmlgraphics.batik-bridge;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-dom;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-svg-dom;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-transcoder;bundle-version="[1.10.0,1.11.0)",
+ org.apache.batik.css;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-xml;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-awt-util;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-anim;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-gvt;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-script;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-ext;bundle-version="[1.10.0,1.11.0)",
+ org.apache.xmlgraphics.batik-parser;bundle-version="[1.10.0,1.11.0)",
+ org.apache.batik.util;bundle-version="[1.10.0,1.11.0)"
+Export-Package: org.csstudio.utility.batik,
+ org.apache.batik.util;version="1.10.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Description: Extra utils for apache batik
 Bundle-ClassPath: .
 Import-Package: org.w3c.dom,
- org.w3c.dom.events
+ org.w3c.dom.events,
+ org.apache.batik.util;version="1.10.0"


### PR DESCRIPTION
As a consequence of https://github.com/ControlSystemStudio/maven-osgi-bundles/pull/85 we had to update some manifests to work with Batik subjars.

This should solve https://github.com/ControlSystemStudio/cs-studio/issues/2448
