### PR TITLE
Removed Import-Package that fails in Eclipse

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
@@ -33,6 +33,5 @@ Export-Package: org.csstudio.opibuilder.actions,
  org.csstudio.opibuilder.visualparts,
  org.csstudio.opibuilder.wizards
 Import-Package: org.apache.batik,
- org.apache.batik.util;version="[1.10.0,1.11.0)",
  org.eclipse.draw2d.geometry,
  org.eclipse.gef.commands

--- a/core/utility/utility-plugins/org.csstudio.utility.batik/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.utility.batik/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.csstudio.utility.batik;singleton:=true
 Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: CS-Studio <cs-studio-core@lists.sourceforge.net>
 Bundle-Activator: org.csstudio.utility.batik.Activator
-Require-Bundle: org.w3c.dom.svg,
+Require-Bundle: org.w3c.dom.svg, 
  org.eclipse.core.runtime,
  org.eclipse.ui;resolution:=optional,
  org.apache.commons.lang,
@@ -24,12 +24,10 @@ Require-Bundle: org.w3c.dom.svg,
  org.apache.xmlgraphics.batik-ext;bundle-version="[1.10.0,1.11.0)",
  org.apache.xmlgraphics.batik-parser;bundle-version="[1.10.0,1.11.0)",
  org.apache.batik.util;bundle-version="[1.10.0,1.11.0)"
-Export-Package: org.csstudio.utility.batik,
- org.apache.batik.util;version="1.10.0"
+Export-Package: org.csstudio.utility.batik
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Description: Extra utils for apache batik
 Bundle-ClassPath: .
 Import-Package: org.w3c.dom,
- org.w3c.dom.events,
- org.apache.batik.util;version="1.10.0"
+ org.w3c.dom.events


### PR DESCRIPTION
This PR solves the issue introduced with https://github.com/ControlSystemStudio/cs-studio/pull/2601. With this commit it should be possible to use CSS from Eclipse (up to 2018-12) again.

Note that in Eclipse 2019-03 and later, it won't work as described in https://github.com/ControlSystemStudio/cs-studio/pull/2601#issuecomment-514946448