### PR TITLE
Ignore exception thrown when loading scripts via HTTP

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/script/AbstractScriptStore.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/script/AbstractScriptStore.java
@@ -148,7 +148,12 @@ public abstract class AbstractScriptStore implements IScriptStore{
             compileString(scriptData.getScriptText());
         else{
             // Determine system path to the script
-            final IPath syspath = ResourceUtil.workspacePathToSysPath(absoluteScriptPath);
+            IPath syspath = null;
+            try {
+                syspath = ResourceUtil.workspacePathToSysPath(absoluteScriptPath);
+            } catch (Exception e) {
+                // Ignore exception thrown if script path is a URL
+            }
             final File file = syspath == null
                             ? null
                             : syspath.toFile();


### PR DESCRIPTION
Exception is thrown when workspace path is a URL. 

Looks like the regression was caused by ab3e1702

Fix issue #2586 