### PR TITLE
Allow the launching of phoebus without server

### DIFF
--- a/applications/phoebus/phoebus-plugins/org.csstudio.phoebus.integration/preferences.ini
+++ b/applications/phoebus/phoebus-plugins/org.csstudio.phoebus.integration/preferences.ini
@@ -9,5 +9,7 @@ phoebus_home=C:\\git\\phoebus\\phoebus-product\\target
 # The version of the phoebus product to be used.
 phoebus_version=0.0.1-SNAPSHOT
 
-#phoebus server port
+# Launch phoebus with a server port
+phoebus_with_server=true
+# Phoebus server port, if set to -1 the phoebus launcher will use any free port
 phoebus_port=4918

--- a/applications/phoebus/phoebus-plugins/org.csstudio.phoebus.integration/src/org/csstudio/phoebus/integration/PhoebusLauncherService.java
+++ b/applications/phoebus/phoebus-plugins/org.csstudio.phoebus.integration/src/org/csstudio/phoebus/integration/PhoebusLauncherService.java
@@ -35,6 +35,7 @@ public class PhoebusLauncherService {
     private static String phoebus_location = prefs.getString(Activator.PLUGIN_ID, PreferenceConstants.PhoebusHome, "/phoebus", null);
     private static String phoebus_version = prefs.getString(Activator.PLUGIN_ID, PreferenceConstants.PhoebusVersion, "0.0.1-SNAPSHOT", null);
 
+    private static boolean phoebus_with_server = prefs.getBoolean(Activator.PLUGIN_ID, PreferenceConstants.PhoebusWithServer, true, null);
     private static int phoebus_port = prefs.getInt(Activator.PLUGIN_ID, PreferenceConstants.PhoebusPort, -1, null);
 
     private static final int port;
@@ -102,9 +103,9 @@ public class PhoebusLauncherService {
     }
 
     /**
-     * creates a list of basic arguments needed to lauch the phoebus framework
+     * Creates a list of basic arguments needed to launch the phoebus framework
      *
-     * @return
+     * @return {@link List} of basic phoebus launch arguments
      */
     private static List<String> basicArguments() {
         List<String> processArguments = new ArrayList<>();
@@ -112,15 +113,18 @@ public class PhoebusLauncherService {
             File phoebusFile = findExecutableOnPath(phoebus_system_launcher_name).get();
             phoebus_location = phoebusFile.getParent();
             processArguments.add(phoebusFile.getAbsolutePath());
-            processArguments.add("-server");
-            processArguments.add(String.valueOf(port));
         } else {
             processArguments.add("java");
             processArguments.add("-jar");
             processArguments.add("product-" + phoebus_version + ".jar");
+        }
+        if(phoebus_with_server) {
             if (phoebus_port > 0) {
                 processArguments.add("-server");
                 processArguments.add(String.valueOf(phoebus_port));
+            } else {
+                processArguments.add("-server");
+                processArguments.add(String.valueOf(port));
             }
         }
         return processArguments;

--- a/applications/phoebus/phoebus-plugins/org.csstudio.phoebus.integration/src/org/csstudio/phoebus/integration/PreferenceConstants.java
+++ b/applications/phoebus/phoebus-plugins/org.csstudio.phoebus.integration/src/org/csstudio/phoebus/integration/PreferenceConstants.java
@@ -13,6 +13,8 @@ public class PreferenceConstants {
     public static final String PhoebusUseSystemLauncher = "phoebus_use_system_launcher";
     public static final String PhoebusSystemLauncherName = "phoebus_system_launcher_name";
 
+    // Launch phoebus with a server port
+    public static final String PhoebusWithServer = "phoebus_with_server";
     // The tcp port associated with the phoebus applications.
     public static final String PhoebusPort = "phoebus_port";
 }


### PR DESCRIPTION
At nsls2, the run-phoebus script takes care of finding the port so the phoebus launcher service only needs to launch phoebus using the system launcher and not worry about the port.