### PR TITLE
Numeric to string for alarm status

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/META-INF/MANIFEST.MF
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.csstudio.archive.vtype,
  org.diirt.util,
  org.diirt.vtype,
+ org.epics.jca;bundle-version="2.4.1",
  com.sun.xml.bind.jaxb-impl,
  jaxb-api
 Bundle-ActivationPolicy: lazy

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
@@ -30,6 +30,8 @@ import edu.stanford.slac.archiverappliance.PB.EPICSEvent.FieldValue;
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadType;
 
+import gov.aps.jca.dbr.Status;
+
 /**
  *
  * <code>ApplianceValueIterator</code> is the base class for different value iterators.
@@ -147,14 +149,14 @@ public abstract class ApplianceValueIterator implements ValueIterator {
             return new ArchiveVNumber(
                     TimestampHelper.fromSQLTimestamp(dataMessage.getTimestamp()),
                     getSeverity(dataMessage.getSeverity()),
-                    String.valueOf(dataMessage.getStatus()),
+                    getStatus(dataMessage.getStatus()),
                     display == null ? getDisplay(mainStream.getPayLoadInfo()) : display,
                     dataMessage.getNumberValue());
         } else if (type == PayloadType.SCALAR_ENUM) {
             return new ArchiveVEnum(
                     TimestampHelper.fromSQLTimestamp(dataMessage.getTimestamp()),
                     getSeverity(dataMessage.getSeverity()),
-                    String.valueOf(dataMessage.getStatus()),
+                    getStatus(dataMessage.getStatus()),
                      null, //TODO get the labels from somewhere
                     dataMessage.getNumberValue().intValue());
         } else if (type == PayloadType.SCALAR_STRING) {
@@ -164,7 +166,7 @@ public abstract class ApplianceValueIterator implements ValueIterator {
             return new ArchiveVString(
                     TimestampHelper.fromSQLTimestamp(dataMessage.getTimestamp()),
                     getSeverity(dataMessage.getSeverity()),
-                    String.valueOf(dataMessage.getStatus()),
+                    getStatus(dataMessage.getStatus()),
                     String.valueOf(dataMessage.getMessage().getField(valDescriptor)));
         } else if (type == PayloadType.WAVEFORM_DOUBLE
                 || type == PayloadType.WAVEFORM_FLOAT){
@@ -188,7 +190,7 @@ public abstract class ApplianceValueIterator implements ValueIterator {
             return new ArchiveVNumberArray(
                     TimestampHelper.fromSQLTimestamp(dataMessage.getTimestamp()),
                     getSeverity(dataMessage.getSeverity()),
-                    String.valueOf(dataMessage.getStatus()),
+                    getStatus(dataMessage.getStatus()),
                     display == null ? getDisplay(mainStream.getPayLoadInfo()) : display,
                     val);
         } else if (type == PayloadType.WAVEFORM_INT
@@ -207,7 +209,7 @@ public abstract class ApplianceValueIterator implements ValueIterator {
             return new ArchiveVNumberArray(
                     TimestampHelper.fromSQLTimestamp(dataMessage.getTimestamp()),
                     getSeverity(dataMessage.getSeverity()),
-                    String.valueOf(dataMessage.getStatus()),
+                    getStatus(dataMessage.getStatus()),
                     display == null ? getDisplay(mainStream.getPayLoadInfo()) : display,
                     val);
         } else if (type == PayloadType.WAVEFORM_BYTE) {
@@ -218,7 +220,7 @@ public abstract class ApplianceValueIterator implements ValueIterator {
             return new ArchiveVNumberArray(
                     TimestampHelper.fromSQLTimestamp(dataMessage.getTimestamp()),
                     getSeverity(dataMessage.getSeverity()),
-                    String.valueOf(dataMessage.getStatus()),
+                    getStatus(dataMessage.getStatus()),
                     display == null ? getDisplay(mainStream.getPayLoadInfo()) : display,
                     new ArrayByte(((ByteString)dataMessage.getMessage().getField(valDescriptor)).toByteArray()));
         }
@@ -319,5 +321,16 @@ public abstract class ApplianceValueIterator implements ValueIterator {
         } else {
             return AlarmSeverity.UNDEFINED;
         }
+    }
+
+    /**
+     * Determines alarm status from the given numerical representation.
+     *
+     * @param status numerical representation of alarm severity
+     *
+     * @return alarm status
+     */
+    protected static String getStatus(int status) {
+        return Status.forValue(status).getName();
     }
 }

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
@@ -326,7 +326,7 @@ public abstract class ApplianceValueIterator implements ValueIterator {
     /**
      * Determines alarm status from the given numerical representation.
      *
-     * @param status numerical representation of alarm severity
+     * @param status numerical representation of alarm status
      *
      * @return alarm status
      */


### PR DESCRIPTION
Currently, Databrowser "Inspect samples" view shows the alarm status as a numeric enum value when source is archiver appliance. This PR is to provide numeric to string conversion for alarm status field so that status field is represented as string enum as it is more user friendly.  