### PR TITLE
Update preparation

### DIFF
--- a/core/ui/ui-plugins/org.csstudio.perspectives/META-INF/MANIFEST.MF
+++ b/core/ui/ui-plugins/org.csstudio.perspectives/META-INF/MANIFEST.MF
@@ -21,5 +21,6 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="3.5.0",
  javax.annotation;bundle-version="1.2.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Import-Package: javax.inject
 Export-Package: org.csstudio.perspectives
 Bundle-Activator: org.csstudio.perspectives.Plugin

--- a/core/utility/utility-plugins/org.csstudio.utility.batik/META-INF/MANIFEST.MF
+++ b/core/utility/utility-plugins/org.csstudio.utility.batik/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Require-Bundle: org.w3c.dom.svg,
  org.apache.xmlgraphics.batik-ext;bundle-version="[1.10.0,1.11.0)",
  org.apache.xmlgraphics.batik-parser;bundle-version="[1.10.0,1.11.0)",
  org.apache.batik.util;bundle-version="[1.10.0,1.11.0)",
+ org.apache.batik.constants;bundle-version="[1.10.0,1.11.0)",
  org.apache.xmlgraphics.batik-codec;bundle-version="[1.10.0,1.11.0)"
 Export-Package: org.csstudio.utility.batik
 Bundle-ActivationPolicy: lazy

--- a/maven-osgi-bundles/repository/pom.xml
+++ b/maven-osgi-bundles/repository/pom.xml
@@ -185,6 +185,15 @@
                     <Require-Bundle>com.squareup.retrofit2.converter-moshi,com.squareup.okhttp3.logging-interceptor</Require-Bundle>
                   </instructions>
                 </artifact>
+                <!-- Batik: a few packages are available in the Orbit repository at version 1.10.
+                     We have to fill in the ones that are not available in Orbit and manage their
+                     dependencies.
+                     The orbit packages have different style names:
+                      * org.apache.batik.css
+                      * org.apache.batik.constants
+                      * org.apache.batik.i18n
+                      * org.apache.batik.util
+                -->
                 <artifact>
                   <id>org.apache.xmlgraphics:batik-bridge:1.10</id>
                   <instructions>
@@ -209,13 +218,13 @@
                       <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.xmlgraphics.batik-codec;bundle-version="1.10.0"</Require-Bundle>
                   </instructions>
                 </artifact>
-		<artifact>
+                <artifact>
                   <id>org.apache.xmlgraphics:batik-codec:1.10</id>
                   <instructions>
                       <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
                   </instructions>
                 </artifact>
-		<artifact>
+                <artifact>
                   <id>org.apache.xmlgraphics:batik-xml:1.10</id>
                   <instructions>
                       <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>

--- a/maven-osgi-bundles/repository/pom.xml
+++ b/maven-osgi-bundles/repository/pom.xml
@@ -8,6 +8,11 @@
     <artifactId>maven-osgi-bundles</artifactId>
     <version>4.6.0-SNAPSHOT</version>
   </parent>
+  <properties>
+    <!-- Allow updating all Batik bundles with one change.  -->
+    <batik.version>1.10</batik.version>
+    <batik.version.full>1.10.0</batik.version.full>
+  </properties>
   <profiles>
     <profile>
       <id>uploadRepo</id>
@@ -185,9 +190,9 @@
                     <Require-Bundle>com.squareup.retrofit2.converter-moshi,com.squareup.okhttp3.logging-interceptor</Require-Bundle>
                   </instructions>
                 </artifact>
-                <!-- Batik: a few packages are available in the Orbit repository at version 1.10.
-                     We have to fill in the ones that are not available in Orbit and manage their
-                     dependencies.
+                <!-- Batik: a few packages are available in the Orbit repository,
+                     currently at version 1.10.  We have to fill in the ones that
+                     are not available in Orbit and manage their dependencies.
                      The orbit packages have different style names:
                       * org.apache.batik.css
                       * org.apache.batik.constants
@@ -195,75 +200,75 @@
                       * org.apache.batik.util
                 -->
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-bridge:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-bridge:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}",org.apache.batik.constants;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-dom:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-dom:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}",org.apache.batik.constants;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-svg-dom:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-svg-dom:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-transcoder:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-transcoder:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.xmlgraphics.batik-codec;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}",org.apache.xmlgraphics.batik-codec;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-codec:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-codec:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-xml:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-xml:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}",org.apache.batik.constants;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-awt-util:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-awt-util:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-anim:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-anim:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0",org.apache.batik.constants;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}",org.apache.batik.constants;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-gvt:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-gvt:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-script:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-script:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-ext:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-ext:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>
-                  <id>org.apache.xmlgraphics:batik-parser:1.10</id>
+                  <id>org.apache.xmlgraphics:batik-parser:${batik.version}</id>
                   <instructions>
-                      <Require-Bundle>org.apache.batik.util;bundle-version="1.10.0"</Require-Bundle>
+                      <Require-Bundle>org.apache.batik.util;bundle-version="${batik.version.full}"</Require-Bundle>
                   </instructions>
                 </artifact>
                 <artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <!-- PROPERTIES -->
   <properties>
     <!-- VERSIONS -->
-    <tycho.version>1.6.0</tycho.version>
+    <tycho.version>1.7.0</tycho.version>
     <tycho-extras.version>${tycho.version}</tycho-extras.version>
 
     <cs-studio.version>4.6</cs-studio.version>


### PR DESCRIPTION
@shroffk these changes are necessary to build against Eclipse 2020-06. As before, I need to check runtime behaviour as well as the build passing.

I haven't made that update but once these changes are merged I am able to build against that version using Maven properties.