### PR TITLE
Enable Github build verification for all branches

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,7 @@ name: Maven library build with Maven
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
As we now do not work on master branch anymore, just remove the restriction on Github actions and run them always.