### PR TITLE
Css392 enum labels

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -269,6 +269,8 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                 for (TraceImpl<XTYPE> trace : axis.getTraces())
                 {
                     final PlotDataProvider<XTYPE> data = trace.getData();
+                    
+
                     final PlotDataItem<XTYPE> sample;
                     data.getLock().lock();
                     try
@@ -290,6 +292,18 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                         final String units = trace.getUnits();
                         if (! units.isEmpty())
                             label += " " + units;
+                        
+                        String info = sample.getInfo();
+                        if (info != null) {
+                          if (info.contains("(")) {
+                            // Must be an enum with labels saved in info
+                            String[] splt = info.split("\t");
+                            if (splt.length > 1) {
+                              String enumVal = splt[1];
+                              label += " " + enumVal;
+                            }
+                          }
+                        }
                         markers.add(new CursorMarker(cursor_x, axis.getScreenCoord(value), trace.getColor(), label));
                     }
                 }

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance.test/src/org/csstudio/archive/reader/appliance/testClasses/TestDataRetrieval.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance.test/src/org/csstudio/archive/reader/appliance/testClasses/TestDataRetrieval.java
@@ -51,6 +51,6 @@ public class TestDataRetrieval implements DataRetrieval{
      */
     @Override
     public GenMsgIterator getDataForPV(String name, Timestamp start, Timestamp end, boolean arg3, HashMap<String, String> arg4) {
-        throw new UnsupportedOperationException();
+        return getDataForPV(name, start, end);
     }
 }

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
@@ -309,7 +309,7 @@ public abstract class ApplianceValueIterator implements ValueIterator {
                 headers.put(fieldValue.getName(), fieldValue.getVal());
             }
         }
-        
+
         String lopr = headers.get(ApplianceArchiveReaderConstants.LOPR);
         String low = headers.get(ApplianceArchiveReaderConstants.LOW);
         String lolo = headers.get(ApplianceArchiveReaderConstants.LOLO);


### PR DESCRIPTION
Adding the ability to display the enum labels (and not just the value) in the databrowser 'Cursor Value' field and in the Cross-hair tool for an enum type PV.
E.g. Cursor value: Open (1) instead of simply <1>. 