### PR TITLE
Css546 stddev plot

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -84,12 +84,32 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                         {
                             final PlotDataItem<XTYPE> item = data.get(i);
                             final double value = item.getValue();
-                            if (! Double.isFinite(value))
-                                continue;
-                            if (value < low)
-                                low = value;
-                            if (value > high)
-                                high = value;
+                            final double max = item.getMax();
+                            final double min = item.getMin();
+                            
+                            if (!Double.isFinite(max)) 
+                            {
+                                if (!Double.isFinite(value))
+                                    continue;
+                                else if (value > high) 
+                                    high = value;
+                            } 
+                            else if (max > high)
+                            {
+                                high = max;                              
+                            }
+                            
+                            if (!Double.isFinite(min)) 
+                            {
+                                if (!Double.isFinite(value))
+                                    continue;
+                                else if (value < low) 
+                                    low = value;
+                            } 
+                            else if (min < low) 
+                            {
+                                low = min;  
+                            }
                         }
                     }
                 }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/PlotProcessor.java
@@ -87,8 +87,14 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                             final double max = item.getMax();
                             final double min = item.getMin();
                             
+                            // Determine whether the upper range (high) needs to be
+                            // updated based on this PlotDataItem. Use the data max
+                            // as the primary indicator with the data value as
+                            // fallback.
                             if (!Double.isFinite(max)) 
                             {
+                                // If max = NAN then check the data value and use
+                                // that to determine the high (if not NAN)
                                 if (!Double.isFinite(value))
                                     continue;
                                 else if (value > high) 
@@ -96,11 +102,19 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                             } 
                             else if (max > high)
                             {
+                                // Else use the max to check if it is higher than the 
+                                // current high and if so update high. 
                                 high = max;                              
                             }
                             
+                            // Determine whether the lower range (low) needs to be
+                            // updated based on this PlotDataItem. Use the data min
+                            // as the primary indicator with the data value as
+                            // fallback.
                             if (!Double.isFinite(min)) 
                             {
+                                // If min = NAN then check the data value and use
+                                // that to determine the low (if not NAN)
                                 if (!Double.isFinite(value))
                                     continue;
                                 else if (value < low) 
@@ -108,6 +122,8 @@ public class PlotProcessor<XTYPE extends Comparable<XTYPE>>
                             } 
                             else if (min < low) 
                             {
+                                // Else use the min to check if it is lower than the 
+                                // current low and if so update low. 
                                 low = min;  
                             }
                         }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
@@ -117,27 +117,23 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
                 gc.setAlpha(alpha);
                 drawMinMaxArea(gc, x_transform, y_axis, data);
                 gc.setAlpha(255);
-                drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
                 drawValueStaircase(gc, x_transform, y_axis, data, trace.getWidth());
                 break;
             case AREA_DIRECT:
                 gc.setAlpha(alpha);
                 drawMinMaxArea(gc, x_transform, y_axis, data);
                 gc.setAlpha(255);
-                drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
                 drawValueLines(gc, x_transform, y_axis, data, trace.getWidth());
                 break;
             case LINES:
                 drawMinMaxLines(gc, x_transform, y_axis, data, trace.getWidth());
                 gc.setAlpha(alpha);
-                drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
                 gc.setAlpha(255);
                 drawValueStaircase(gc, x_transform, y_axis, data, trace.getWidth());
                 break;
             case LINES_DIRECT:
                 drawMinMaxLines(gc, x_transform, y_axis, data, trace.getWidth());
                 gc.setAlpha(alpha);
-                drawStdDevLines(gc, x_transform, y_axis, data, trace.getWidth());
                 gc.setAlpha(255);
                 drawValueLines(gc, x_transform, y_axis, data, trace.getWidth());
                 break;
@@ -325,43 +321,6 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
         }
         flushPolyLine(gc, min, line_width);
         flushPolyLine(gc, max, line_width);
-    }
-
-    /** Draw std. deviation outline
-     *  @param gc GC
-     *  @param x_transform Horizontal axis
-     *  @param y_axis Value axis
-     *  @param data Data
-     *  @param line_width
-     */
-    final private void drawStdDevLines(final GC gc, final ScreenTransform<XTYPE> x_transform, final YAxisImpl<XTYPE> y_axis,
-            final PlotDataProvider<XTYPE> data, final int line_width)
-    {
-        final IntList lower_poly = new IntList(INITIAL_ARRAY_SIZE);
-        final IntList upper_poly = new IntList(INITIAL_ARRAY_SIZE);
-
-        final int N = data.size();
-        for (int i = 0;  i < N;  ++i)
-        {
-            final PlotDataItem<XTYPE> item = data.get(i);
-            double value = item.getValue();
-            double dev = item.getStdDev();
-            if (Double.isNaN(value) ||  ! (dev > 0))
-            {
-                flushPolyLine(gc, lower_poly, line_width);
-                flushPolyLine(gc, upper_poly, line_width);
-            }
-            else
-            {
-                final int x = clipX(x_transform.transform(item.getPosition()));
-                final int low_y = clipY(y_axis.getScreenCoord(value - dev));
-                final int upp_y = clipY(y_axis.getScreenCoord(value + dev));
-                lower_poly.add(x);  lower_poly.add(low_y);
-                upper_poly.add(x);  upper_poly.add(upp_y);
-            }
-        }
-        flushPolyLine(gc, lower_poly, line_width);
-        flushPolyLine(gc, upper_poly, line_width);
     }
 
     /** @param gc GC


### PR DESCRIPTION
It has been discussed and agreed that the standard deviation plotted in the databrowser is confusing and not that useful (see https://github.com/ControlSystemStudio/phoebus/issues/1656). The plotting of the standard deviation has therefore been removed.

In addition, the auto-scaling of the y-axis does include the min and max values plotted in the AREA trace. The min and max can often fall outside of the y-axis range and so are not always easily visible. This set of changes instead uses the min/max (where applicable) to determine the the appropriate y-axis range so that they are always visible. 