### PR TITLE
Fixing the case where no data is plotted in the databrowser as the AA returns an empty iterator

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
@@ -101,6 +101,10 @@ public abstract class ApplianceValueIterator implements ValueIterator {
         }
         if (mainStream != null) {
             mainIterator = mainStream.iterator();
+            // Stream is not null but did the stream contain any data?
+            if (!mainIterator.hasNext()) {
+              throw new ArchiverApplianceException("Fetched datastream is empty");
+            }
         } else {
             throw new ArchiverApplianceException("Could not fetch data.");
         }


### PR DESCRIPTION
This fix is for an issue where recent archive history from the AA is not plotted in the databrowser due to the fact that the PV has not changed within the timeframe requested.
If a requested timeframe for optimized data (from the AA) contains no events then the AA returns a `GenMsgIterator` that is empty. Currently the databrowser checks that a `GenMsgIterator` is received from the AA request and registers a fail if not, in which case it will revert to some other request type. However it does not check that the `GenMsgIterator` is not empty, which leads to nothing being plotted. This change fixes this by performing an additional check that the `GenMsgIterator` is not empty and so will catch the case when it is and fall back to another request type.