### PR TITLE
Fixing bug that causes archived data not to be plotted after it has been fetched

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/HistoricSamples.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/HistoricSamples.java
@@ -133,6 +133,7 @@ public class HistoricSamples extends PlotSamples
             return;
         samples = merged;
         computeVisibleSize();
+        have_new_samples.set(true);
     }
 
     /** Delete all samples */


### PR DESCRIPTION
We found an issue where the plot is not updated immediately after data is fetched from the Archiver Appliance. Instead, in order to get the new data plotted, the user has to interact with the plot in some way which will call an update to the plot and so show the new data. 

The issue is that the databrowser is not registering that there are new samples for a PV item. This is because when the new samples are merged with the current values, the `have_new_samples` boolean is not set to true (as is done in the case of live data). A value of true is required in order for a redraw to be executed. 