### PR TITLE
New preference to configure what CS-Studio should do when closing the last window.

### DIFF
--- a/core/utility/utility-plugins/org.csstudio.trayicon/preferences.ini
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/preferences.ini
@@ -3,3 +3,4 @@
 
 minimize_to_tray = prompt
 start_minimized = false
+close_option = Warn of last window

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/Messages.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/Messages.java
@@ -11,6 +11,9 @@ public class Messages extends NLS {
     public static String TrayDialog_minimize;
     public static String TrayDialog_exit;
     public static String TrayDialog_cancel;
+    public static String TrayDialog_doNotWarnAgain;
+    public static String TrayDialog_closeTitle;
+    public static String TrayDialog_warning;
 
     public static String TrayPreferences_saveFailed;
     public static String TrayPreferences_minimize;
@@ -18,6 +21,11 @@ public class Messages extends NLS {
     public static String TrayPreferences_always;
     public static String TrayPreferences_never;
     public static String TrayPreferences_prompt;
+    
+    public static String TrayPreferences_closeOption;
+    public static String TrayPreferences_askToMinimize;
+    public static String TrayPreferences_warn;
+    public static String TrayPreferences_close;
 
     public static String TrayIcon_open;
     public static String TrayIcon_exit;

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchWindowAdvisor.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayApplicationWorkbenchWindowAdvisor.java
@@ -23,8 +23,12 @@ public class TrayApplicationWorkbenchWindowAdvisor extends ApplicationWorkbenchW
             Messages.TrayDialog_minimize,
             Messages.TrayDialog_exit,
             Messages.TrayDialog_cancel};
+    public static final String[] CLOSE_BUTTON_LABELS = {
+        Messages.TrayDialog_exit,
+        Messages.TrayDialog_cancel};
     private static final int MINIMIZE_BUTTON_ID = 256;
     private static final int EXIT_BUTTON_ID = 257;
+    private static final int CLOSE_EXIT_BUTTON_ID = 256;
     private static final int CANCEL_BUTTON_ID = IDialogConstants.CANCEL_ID;
     private static final int DIALOG_CLOSED = -1;
 
@@ -65,6 +69,35 @@ public class TrayApplicationWorkbenchWindowAdvisor extends ApplicationWorkbenchW
         }
         return response;
     }
+    
+    /**
+     * Display warning that this is the last window.
+     *
+     * @return xx_BUTTON_ID of clicked button or DIALOG_CLOSED
+     */
+    private int warnOfLastWindow() {
+        Shell parent = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+        ScopedPreferenceStore store = new ScopedPreferenceStore(InstanceScope.INSTANCE, Plugin.ID);
+        MessageDialogWithToggle dialog = new MessageDialogWithToggle(parent, Messages.TrayDialog_closeTitle, null,
+                Messages.TrayDialog_warning, MessageDialog.QUESTION, CLOSE_BUTTON_LABELS, 2,
+                Messages.TrayDialog_doNotWarnAgain, false);
+        dialog.open();
+
+        int response = dialog.getReturnCode();
+
+        // Store the decision if checkbox selected on the form
+        if (dialog.getToggleState()) {
+            if (response == CLOSE_EXIT_BUTTON_ID) {
+                store.setValue(TrayIconPreferencePage.CLOSE_OPTION, Messages.TrayPreferences_close);
+            }
+            try {
+                store.save();
+            } catch (IOException e) {
+                Plugin.getLogger().warning(Messages.TrayPreferences_saveFailed + e.getMessage());
+            }
+        }
+        return response;
+    }
 
     /**
      * Manage a close event based on the user preferences, user action
@@ -74,12 +107,14 @@ public class TrayApplicationWorkbenchWindowAdvisor extends ApplicationWorkbenchW
      *      * user:CANCEL
      *      * user:DIALOG_CLOSED
      *  ii) continue to close this window and possibly the application (return preWindowShellClose())
-     *      * preference:NEVER
+     *      * minimize preference:NEVER
+     *      * close option preference:Just Close
      *      * user:EXIT
      *      * multiple open windows
      *      * application already minimised
      *  iii) create trayIcon, minimise window but do not exit (return False)
-     *      * preference:ALWAYS
+     *      * minimize preference:ALWAYS
+     *      * close option preference:Ask to minimize
      *      * user:MINIMIZE
      *
      * @see org.eclipse.ui.application.WorkbenchWindowAdvisor#preWindowShellClose
@@ -88,36 +123,48 @@ public class TrayApplicationWorkbenchWindowAdvisor extends ApplicationWorkbenchW
     public boolean preWindowShellClose() {
 
         boolean closeWindow;
-        int userAction = DIALOG_CLOSED;
+        int userAction = DIALOG_CLOSED; // For the minimize dialog
+        int userAction2 = DIALOG_CLOSED; // For the warning dialog
         int numWindows = PlatformUI.getWorkbench().getWorkbenchWindowCount();
 
         IPreferencesService prefs = Platform.getPreferencesService();
+        String closePref = prefs.getString(
+            Plugin.ID, TrayIconPreferencePage.CLOSE_OPTION, null, null);
         String minPref = prefs.getString(
                 Plugin.ID, TrayIconPreferencePage.MINIMIZE_TO_TRAY, null, null);
-
-        if (minPref.equals(MessageDialogWithToggle.PROMPT) &&
-                numWindows == 1) {  // no prompt if multiple windows
-            userAction = promptForAction();
+        
+        // Display warning dialog and get users action to cancel or exit
+        if (closePref.equals(Messages.TrayPreferences_warn) && numWindows == 1) {
+          userAction2 = warnOfLastWindow();
+        }
+        
+        // Dialog to minimize will only display if preference for close option is to ask to minimize
+        if (closePref.equals(Messages.TrayPreferences_askToMinimize) && minPref.equals(MessageDialogWithToggle.PROMPT) &&
+            numWindows == 1) {
+          userAction = promptForAction();
         }
 
-        if (numWindows > 1 ||
-                trayIcon.isMinimized() ||
-                minPref.equals(MessageDialogWithToggle.NEVER) ||
-                userAction == EXIT_BUTTON_ID) {  // user action: exit
-            // allow to continue
-            closeWindow = super.preWindowShellClose();
-        }
-        else if (minPref.equals(MessageDialogWithToggle.ALWAYS) ||
-                userAction == MINIMIZE_BUTTON_ID) {
-            // minimise the window and block application exit
-            trayIcon.minimize();
-            closeWindow = false;
+        // Case where the application will close. minPref is only application if closePref is ask to minimize 
+        if (numWindows > 1 || trayIcon.isMinimized() || 
+            (closePref.equals(Messages.TrayPreferences_askToMinimize) && minPref.equals(MessageDialogWithToggle.NEVER))
+            || closePref.equals(Messages.TrayPreferences_close)
+            || userAction == EXIT_BUTTON_ID
+            || userAction2 == CLOSE_EXIT_BUTTON_ID) { // user action: exit
+          // allow to continue
+          closeWindow = super.preWindowShellClose();
+        } 
+        // Case where the application will minimize. minPref is only application if closePref is ask to minimize 
+        else if ( (closePref.equals(Messages.TrayPreferences_askToMinimize) && minPref.equals(MessageDialogWithToggle.ALWAYS))
+            || userAction == MINIMIZE_BUTTON_ID) {
+          // minimise the window and block application exit
+          trayIcon.minimize();
+          closeWindow = false;
         }
         else {  // user_action is CANCEL_BUTTON_ID or DIALOG_CLOSED
-            // block application exit
-            closeWindow = false;
+          // block application exit
+          closeWindow = false;
         }
-
+        
         return closeWindow;
     }
 }

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayIconPreferencePage.java
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/TrayIconPreferencePage.java
@@ -14,12 +14,20 @@ public class TrayIconPreferencePage extends FieldEditorPreferencePage implements
 
     public static final String MINIMIZE_TO_TRAY = "minimize_to_tray";
     public static final String START_MINIMIZED = "start_minimized";
+    public static final String CLOSE_OPTION = "close_option";
     private ScopedPreferenceStore store;
 
     @Override
     protected void createFieldEditors() {
         final Composite parent = getFieldEditorParent();
 
+        RadioGroupFieldEditor closeOptions = new RadioGroupFieldEditor(CLOSE_OPTION,
+            Messages.TrayPreferences_minimize, 3,
+            new String[][] { { Messages.TrayPreferences_askToMinimize, Messages.TrayPreferences_askToMinimize},
+                { Messages.TrayPreferences_warn,Messages.TrayPreferences_warn },
+                { Messages.TrayPreferences_close, Messages.TrayPreferences_close} },
+            parent, true);
+        addField(closeOptions);
         RadioGroupFieldEditor minimizeOnCloseEditor = new RadioGroupFieldEditor(
                 MINIMIZE_TO_TRAY,
                 Messages.TrayPreferences_minimize, 3,

--- a/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/messages.properties
+++ b/core/utility/utility-plugins/org.csstudio.trayicon/src/org/csstudio/trayicon/messages.properties
@@ -6,12 +6,21 @@ TrayDialog_minimize=Minimize
 TrayDialog_exit=Exit Now
 TrayDialog_cancel=Cancel
 
+TrayDialog_doNotWarnAgain=Do not warn me again
+TrayDialog_closeTitle=Closing the last window
+TrayDialog_warning=Warning! This is the last CS-Studio window.
+
 TrayPreferences_saveFailed=Failed to save preference:
 TrayPreferences_minimize=Minimize to system tray when closing last window?
 TrayPreferences_startMinimized=Start CS-Studio minimized?
 TrayPreferences_always=Always
 TrayPreferences_never=Never
 TrayPreferences_prompt=Prompt
+
+TrayPreferences_closeOption=Closing last window options
+TrayPreferences_askToMinimize=Ask to minimize
+TrayPreferences_warn=Warn of last window
+TrayPreferences_close=Just close
 
 TrayIcon_open=Open Window
 TrayIcon_exit=Exit CS-Studio


### PR DESCRIPTION
Gnome3 does not have a tray and so the option that is displayed when the last CS-Studio window is closed to minimize to tray makes no sense in this case. If the window is minimized to tray it then becomes impossible to get back. 

We have created a new preference that dictates what to do when closing the last CS-Studio window. There are 3 options: ask to minimize to tray (which will bring up the previous minimize to tray dialog with the same functionality), warn that the last window is being closed (options to cancel or exit), or finally just close the window with no prompts. The 'warning of last window' dialog also allows the user to select 'do not warn again'.