### PR TITLE
2289 refresh

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -364,7 +364,7 @@ public final class OPIShell implements IOPIRuntime {
      */
     private static void sendUpdateCommand() {
         IServiceLocator serviceLocator = PlatformUI.getWorkbench();
-        ICommandService commandService = (ICommandService) serviceLocator.getService(ICommandService.class);
+        ICommandService commandService = serviceLocator.getService(ICommandService.class);
         try {
             Command command = commandService.getCommand(OPI_SHELLS_CHANGED_ID);
             command.executeWithChecks(new ExecutionEvent());

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -31,12 +31,15 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditDomain;
 import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.KeyHandler;
+import org.eclipse.gef.KeyStroke;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.editparts.ScalableRootEditPart;
 import org.eclipse.gef.tools.DragEditPartsTracker;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.ShellEvent;
@@ -117,8 +120,10 @@ public final class OPIShell implements IOPIRuntime {
         actionRegistry = new ActionRegistry();
 
         viewer = new GraphicalViewerImpl();
+
         viewer.createControl(shell);
         viewer.setEditPartFactory(new WidgetEditPartFactory(ExecutionMode.RUN_MODE));
+        viewer.setKeyHandler(new KeyHandler());
 
         viewer.setRootEditPart(new ScalableRootEditPart() {
             @Override
@@ -204,7 +209,10 @@ public final class OPIShell implements IOPIRuntime {
      */
     public void registerWithView(IViewPart view) {
         this.view = view;
-        actionRegistry.registerAction(new RefreshOPIAction(this));
+        RefreshOPIAction refreshAction = new RefreshOPIAction(this);
+        actionRegistry.registerAction(refreshAction);
+        // Explicitly bind refresh action to the F5 keypress.
+        viewer.getKeyHandler().put(KeyStroke.getPressed(SWT.F5, 0), refreshAction);
         SingleSourceHelper.registerRCPRuntimeActions(actionRegistry, this);
         OPIRunnerContextMenuProvider contextMenuProvider = new OPIRunnerContextMenuProvider(viewer, this);
         getSite().registerContextMenu(contextMenuProvider, viewer);


### PR DESCRIPTION
Allow use of F5 to refresh standalone windows. This only affects standalone windows; it already works for OPIs in the workbench.

Closes #2289.