### PR TITLE
Configurable annotation formats and improvement of annotation editability in the databrowser

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/Messages.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/Messages.java
@@ -16,6 +16,7 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS
 {
     public static String AddAnnotation;
+    public static String AddAnnotation_Error;
     public static String AddAnnotation_Content;
     public static String AddAnnotation_Content_Help;
     public static String AddAnnotation_DefaultText;

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/RTPlot.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.csstudio.swt.rtplot.data.PlotDataItem;
 import org.csstudio.swt.rtplot.data.PlotDataProvider;
+import org.csstudio.swt.rtplot.internal.AddAnnotationDialogAction;
 import org.csstudio.swt.rtplot.internal.AnnotationImpl;
 import org.csstudio.swt.rtplot.internal.MouseMode;
 import org.csstudio.swt.rtplot.internal.Plot;
@@ -51,6 +52,7 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
     final protected ToolbarHandler<XTYPE> toolbar;
     final private ToggleToolbarAction toggle_toolbar;
     final private ToggleLegendAction toggle_legend;
+    final private AddAnnotationDialogAction<XTYPE> annotation_action;
     final private Action snapshot;
 
     protected RTPlot(final Composite parent, final Class<XTYPE> type)
@@ -64,6 +66,7 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
         toggle_toolbar = new ToggleToolbarAction(this);
         toggle_legend =  new ToggleLegendAction(this);
         snapshot = new SnapshotAction(this);
+        annotation_action = new AddAnnotationDialogAction<XTYPE>(this,plot.getShell());
 
         toolbar.addContextMenu(toggle_toolbar);
 
@@ -104,6 +107,12 @@ public class RTPlot<XTYPE extends Comparable<XTYPE>> extends Composite
         return toggle_legend;
     }
 
+    /** @return {@link Action} that can open the Add Annotation dialog*/
+    public Action getAddAnnotationAction()
+    {
+        return annotation_action;
+    }
+    
     /** @return {@link Action} that can show/hide the toolbar */
     public Action getToolbarAction()
     {

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AddAnnotationDialog.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AddAnnotationDialog.java
@@ -122,7 +122,9 @@ public class AddAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialog
         final Text info = new Text(composite, SWT.MULTI | SWT.WRAP | SWT.READ_ONLY);
         info.setBackground(composite.getBackground());
         info.setText(Messages.AddAnnotation_Content_Help);
-        info.setLayoutData(new GridData(SWT.FILL, 0, true, false, 2, 1));
+        gd = new GridData(SWT.FILL, 0, true, false, 2, 1);
+        gd.widthHint = 500;
+        info.setLayoutData(gd);
         return composite;
     }
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AddAnnotationDialog.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AddAnnotationDialog.java
@@ -7,7 +7,10 @@
  ******************************************************************************/
 package org.csstudio.swt.rtplot.internal;
 
+import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.csstudio.swt.rtplot.Messages;
@@ -137,8 +140,18 @@ public class AddAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialog
 
         if (traces.isEmpty())
             MessageDialog.openInformation(getShell(), Messages.AddAnnotation, Messages.AddAnnotation_NoTraces);
-        else
+        else {
+          try {
+            Date date = Date.from((Instant) Instant.now());
+            // Check that the format would work.
+            MessageFormat.format(text.getText(), "temp", date, 2.0);
             plot.addAnnotation(traces.get(selected), text.getText());
+          } catch (IllegalArgumentException ex) {
+            // Keep dialog open to fix 
+            MessageDialog.openInformation(getShell(), Messages.AddAnnotation_Error, "Invalid entry: " + ex.getMessage());
+            return;
+          }
+        }
         super.okPressed();
     }
 }

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AddAnnotationDialogAction.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AddAnnotationDialogAction.java
@@ -1,0 +1,32 @@
+package org.csstudio.swt.rtplot.internal;
+
+import org.csstudio.swt.rtplot.Activator;
+import org.csstudio.swt.rtplot.Messages;
+import org.csstudio.swt.rtplot.RTPlot;
+import org.csstudio.swt.rtplot.data.PlotDataItem;
+import org.eclipse.jface.action.Action;
+import org.eclipse.swt.widgets.Shell;
+
+/** Action to display the 'Add Annotation' dialog.
+ *
+ *  @param <XTYPE> Data type used for the {@link PlotDataItem}
+ *  @author Rebecca Williams (OSL)
+ */
+public class AddAnnotationDialogAction<XTYPE extends Comparable<XTYPE>> extends Action
+{
+    final private RTPlot<XTYPE> plot;
+    private Shell shell;
+
+    public AddAnnotationDialogAction(final RTPlot<XTYPE> plot, Shell shell)
+    {
+        super(Messages.AddAnnotation, Activator.getIcon("add_annotation"));
+        this.plot = plot;
+        this.shell = shell;
+    }
+
+    @Override
+    public void run()
+    {
+       new AddAnnotationDialog<XTYPE>(shell, plot).open();
+    }
+}

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
@@ -130,16 +130,32 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
         final boolean in_range = xaxis.getScreenRange().contains(x);
 
         String localText = text;
-        // Set the default format
-        if (text.contains("{2}")) {
-          localText = text.replace("{2}","{2,number,#}");
-        }
         final String units = trace.getUnits();
         if (!units.isEmpty())
-          localText += " " + units;
+            localText += " " + units;
 
         Date date = Date.from((Instant) position);
-        final String label = MessageFormat.format(localText, trace.getName(), date, value);
+        final String label;
+        if (text.contains("{1}") && text.contains("{2}")) 
+        {   // Set the default format for both value and date
+            label = MessageFormat.format(localText, trace.getName(), 
+              xaxis.getTicks().format(position), 
+              yaxis.getTicks().formatDetailed(value));
+        } 
+        else if (text.contains("{1}")) 
+        {   // Set default format for the date only
+            label = MessageFormat.format(localText, trace.getName(), 
+              xaxis.getTicks().format(position), value);
+        } 
+        else if (text.contains("{2}")) 
+        {   // Set default format for the value only
+            label = MessageFormat.format(localText, trace.getName(), 
+              date, yaxis.getTicks().formatDetailed(value));
+        } 
+        else 
+        {   // Allow user format for date and value
+            label = MessageFormat.format(localText, trace.getName(), date, value);
+        }
             
         // Layout like this when in_range
         //

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
@@ -130,6 +130,10 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
         final boolean in_range = xaxis.getScreenRange().contains(x);
 
         String localText = text;
+        // Set the default format
+        if (text.contains("{2}")) {
+          localText = text.replace("{2}","{2,number,#}");
+        }
         final String units = trace.getUnits();
         if (!units.isEmpty())
           localText += " " + units;

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
@@ -7,13 +7,15 @@
  ******************************************************************************/
 package org.csstudio.swt.rtplot.internal;
 
+import java.text.MessageFormat;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Optional;
 
 import org.csstudio.swt.rtplot.Annotation;
 import org.csstudio.swt.rtplot.SWTMediaPool;
 import org.csstudio.swt.rtplot.Trace;
 import org.csstudio.swt.rtplot.data.PlotDataItem;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
@@ -127,18 +129,14 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
         final int y = Double.isFinite(value) ? yaxis.getScreenCoord(value) : yaxis.getScreenRange().getLow();
         final boolean in_range = xaxis.getScreenRange().contains(x);
 
-        String value_text = yaxis.getTicks().formatDetailed(value);
+        String localText = text;
         final String units = trace.getUnits();
-        if (! units.isEmpty())
-            value_text += " " + units;
-        final String label = NLS.bind(text,
-                new Object[]
-                {
-                    trace.getName(),
-                    xaxis.getTicks().format(position),
-                    value_text
-                });
+        if (!units.isEmpty())
+          localText += " " + units;
 
+        Date date = Date.from((Instant) position);
+        final String label = MessageFormat.format(localText, trace.getName(), date, value);
+            
         // Layout like this when in_range
         //
         //    Text

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
@@ -17,7 +17,6 @@ import org.csstudio.swt.rtplot.SWTMediaPool;
 import org.csstudio.swt.rtplot.data.PlotDataItem;
 import org.csstudio.swt.rtplot.undo.RemoveAnnotationAction;
 import org.csstudio.swt.rtplot.undo.UpdateAnnotationTextAction;
-import org.csstudio.swt.rtplot.util.MultiLineInputDialog;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.InputDialog;
 import org.eclipse.swt.SWT;
@@ -108,10 +107,33 @@ public class EditAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialo
         return composite;
     }
 
+    
     private void editAnnotation(final Annotation<XTYPE> annotation)
     {
-        final InputDialog editor = new MultiLineInputDialog(getShell(), "Edit Annotation", "Modify the annotation text",
-                annotation.getText(), null);
+      final InputDialog editor= new InputDialog(getShell(), "Edit Annotation", "Modify the annotation text", 
+          annotation.getText(), null) {
+          @Override
+          protected int getInputTextStyle()
+          {
+              return SWT.MULTI | SWT.BORDER | SWT.V_SCROLL;
+          }
+
+          /** Increase height */
+          @Override
+          protected Control createDialogArea(Composite parent)
+          {
+              final Control res = super.createDialogArea(parent);
+              ((GridData) this.getText().getLayoutData()).heightHint = 100;
+              
+              final Label info = new Label((Composite) res, SWT.WRAP);
+              info.setText(Messages.AddAnnotation_Content_Help);
+              GridData gd = new GridData(SWT.FILL, SWT.TOP, true, true, 1, 1);
+              gd.widthHint = 500;
+              info.setLayoutData(gd);
+              return res;
+          }
+        };
+
         if (editor.open() == OK)
         {
             final String new_text = editor.getValue();

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
@@ -21,11 +21,14 @@ import org.csstudio.swt.rtplot.data.PlotDataItem;
 import org.csstudio.swt.rtplot.undo.RemoveAnnotationAction;
 import org.csstudio.swt.rtplot.undo.UpdateAnnotationTextAction;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IInputValidator;
 import org.eclipse.jface.dialogs.InputDialog;
+import org.eclipse.jface.resource.StringConverter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -34,6 +37,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swt.widgets.Text;
 
 /** Dialog for editing or removing annotations
  *  @param <XTYPE> Data type used for the {@link PlotDataItem}
@@ -112,19 +116,22 @@ public class EditAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialo
     }
 
     private IInputValidator createFormatValidator(final Annotation<XTYPE> annotation) {
-      final IInputValidator validator = new IInputValidator() {
-        public String isValid(String new_text) {
-          try {
-            Date date = Date.from((Instant) annotation.getPosition());
-            MessageFormat.format(new_text, annotation.getTrace().getName(), date ,
-                annotation.getValue());
-          } catch (IllegalArgumentException ex) {
-            return "Invalid entry: " + ex.getMessage();
-          }
-          return null;
-        }
-      };
-      return validator;
+        final IInputValidator validator = new IInputValidator() {
+            public String isValid(String new_text) {
+                try 
+                {
+                    Date date = Date.from((Instant) annotation.getPosition());
+                    MessageFormat.format(new_text, annotation.getTrace().getName(), date ,
+                        annotation.getValue());
+                } 
+                catch (IllegalArgumentException ex) 
+                {
+                    return "Invalid entry: " + ex.getMessage();
+                }
+                return null;
+            }
+        };
+        return validator;
     }
     
     private void editAnnotation(final Annotation<XTYPE> annotation)
@@ -132,6 +139,10 @@ public class EditAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialo
       
       final InputDialog editor= new InputDialog(getShell(), "Edit Annotation", "Modify the annotation text", 
           annotation.getText(), createFormatValidator(annotation)) {
+        
+          private Text errorMessageText;
+          private String errorMessage;
+          
           @Override
           protected int getInputTextStyle()
           {
@@ -150,7 +161,35 @@ public class EditAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialo
               GridData gd = new GridData(SWT.FILL, SWT.TOP, true, true, 1, 1);
               gd.widthHint = 500;
               info.setLayoutData(gd);
+              
+              errorMessageText = new Text((Composite)res, SWT.READ_ONLY | SWT.WRAP);
+              errorMessageText.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL
+                  | GridData.HORIZONTAL_ALIGN_FILL));
+              errorMessageText.setBackground(errorMessageText.getDisplay()
+                  .getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+              errorMessageText.setForeground(new Color(res.getDisplay(),255,0,0));
+              setErrorMessage(errorMessage);
+              
               return res;
+          }
+          
+          @Override
+          public void setErrorMessage(String errorMessage) 
+          {
+              this.errorMessage = "\n"+errorMessage;
+              if (errorMessageText != null && !errorMessageText.isDisposed()) 
+              {
+                  errorMessageText.setText(errorMessage == null ? " \n " : errorMessage); //$NON-NLS-1$
+                  boolean hasError = errorMessage != null && (StringConverter.removeWhiteSpaces(errorMessage)).length() > 0;
+                  errorMessageText.setEnabled(hasError);
+                  errorMessageText.setVisible(hasError);
+                  errorMessageText.getParent().update();
+                  Control button = getButton(IDialogConstants.OK_ID);
+                  if (button != null) 
+                  {
+                    button.setEnabled(errorMessage == null);
+                  }
+              }
           }
         };
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/EditAnnotationDialog.java
@@ -7,7 +7,10 @@
  ******************************************************************************/
 package org.csstudio.swt.rtplot.internal;
 
+import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.csstudio.swt.rtplot.Annotation;
@@ -18,6 +21,7 @@ import org.csstudio.swt.rtplot.data.PlotDataItem;
 import org.csstudio.swt.rtplot.undo.RemoveAnnotationAction;
 import org.csstudio.swt.rtplot.undo.UpdateAnnotationTextAction;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IInputValidator;
 import org.eclipse.jface.dialogs.InputDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
@@ -107,11 +111,27 @@ public class EditAnnotationDialog<XTYPE extends Comparable<XTYPE>> extends Dialo
         return composite;
     }
 
+    private IInputValidator createFormatValidator(final Annotation<XTYPE> annotation) {
+      final IInputValidator validator = new IInputValidator() {
+        public String isValid(String new_text) {
+          try {
+            Date date = Date.from((Instant) annotation.getPosition());
+            MessageFormat.format(new_text, annotation.getTrace().getName(), date ,
+                annotation.getValue());
+          } catch (IllegalArgumentException ex) {
+            return "Invalid entry: " + ex.getMessage();
+          }
+          return null;
+        }
+      };
+      return validator;
+    }
     
     private void editAnnotation(final Annotation<XTYPE> annotation)
     {
+      
       final InputDialog editor= new InputDialog(getShell(), "Edit Annotation", "Modify the annotation text", 
-          annotation.getText(), null) {
+          annotation.getText(), createFormatValidator(annotation)) {
           @Override
           protected int getInputTextStyle()
           {

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -25,6 +25,7 @@ import org.csstudio.swt.rtplot.Activator;
 import org.csstudio.swt.rtplot.Annotation;
 import org.csstudio.swt.rtplot.AxisRange;
 import org.csstudio.swt.rtplot.Messages;
+import org.csstudio.swt.rtplot.RTPlot;
 import org.csstudio.swt.rtplot.RTPlotListener;
 import org.csstudio.swt.rtplot.SWTMediaPool;
 import org.csstudio.swt.rtplot.Trace;
@@ -131,6 +132,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
     final private TracePainter<XTYPE> trace_painter = new TracePainter<XTYPE>();
     final private List<AnnotationImpl<XTYPE>> annotations = new CopyOnWriteArrayList<>();
     final private LegendPart<XTYPE> legend;
+    final private RTPlot<XTYPE> plot;
 
     final private PlotProcessor<XTYPE> plot_processor;
 
@@ -210,6 +212,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
     {
         super(parent, SWT.NO_BACKGROUND);
 
+        this.plot = (RTPlot<XTYPE>) parent;
         title_font = parent.getFont();
         label_font = parent.getFont();
         scale_font = parent.getFont();
@@ -243,7 +246,11 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         () ->
         {
             plot_processor.autoscale();
-            updateImageBuffer();
+            // In Eclipse 2020-12 we cannot seem to run updateImageBuffer() on
+            // a background thread. Schedule it on the UI thread.
+            display.asyncExec(() -> { updateImageBuffer(); });
+            // This will place the redraw task on the UI thread, presumably after
+            // the updateImageBuffer() call.
             redrawSafely();
         });
 
@@ -1233,7 +1240,10 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
     @Override
     public void mouseDoubleClick(final MouseEvent e)
     {
-        // NOP
+        if (selectMouseAnnotation()) 
+        {
+            new EditAnnotationDialog<XTYPE>(getShell(), this.plot).open();
+        }
     }
 
     /** MouseTrackListener: {@inheritDoc} */

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -246,11 +246,7 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         () ->
         {
             plot_processor.autoscale();
-            // In Eclipse 2020-12 we cannot seem to run updateImageBuffer() on
-            // a background thread. Schedule it on the UI thread.
-            display.asyncExec(() -> { updateImageBuffer(); });
-            // This will place the redraw task on the UI thread, presumably after
-            // the updateImageBuffer() call.
+            updateImageBuffer();
             redrawSafely();
         });
 

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
@@ -1,14 +1,15 @@
 AddAnnotation=Add Annotation
 AddAnnotation_Content=Content:
-AddAnnotation_Content_Help=Annotation will replace\n{0} with name of trace,\n{1} with position \
-(format the date by changing HH/mm where HH = hours, mm = minutes, ss = seconds, .SS = milliseconds), \
- and\n{2} with value at that position \
-(format the number of d.p. displayed for the value by adding #.### (for 3 d.p.)).
-AddAnnotation_DefaultText={0}\n{1,date,HH:mm}, {2,number,#}
+AddAnnotation_Content_Help=Annotation will replace:\n \u2022 Unknown macro: {0} \n    with name of trace,\
+\n \u2022 Unknown macro: {1} \n    with timestamp, \
+\n \u2022 Unknown macro: {2} \n    with value at that timestamp \
+\n\nAdvanced formatting options:\n \u2022 Unknown macro: {1,date,HH}\n    : \
+yyyy or yy year, MM month, dd day, HH hours, mm minutes, ss seconds, SSS milliseconds\
+\n \u2022 Unknown macro: {2,number,#.##}\n    : # gives 0 d.p., #.## gives 2 d.p.
+AddAnnotation_DefaultText={0}\n{1,date,HH:mm}, {2}
+AddAnnotation_Error=Error with annotation format
 AddAnnotation_NoTraces=To add annotation, first add traces to the plot
-AddAnnotation_Text_TT=Enter text to display in this annotation\n\
-{1} Format the date by changing HH/mm where HH = hours, mm = minutes, ss = seconds, .SS = milliseconds.\
-\n{2} Format the number of d.p. displayed for the value by adding #.### (for 3 d.p.).
+AddAnnotation_Text_TT=Enter text to display in this annotation
 AddAnnotation_Trace=Trace:
 AddAnnotation_Trace_TT=Select trace for this annotation
 Crosshair_Cursor=Cross-hair cursor

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
@@ -1,12 +1,11 @@
 AddAnnotation=Add Annotation
 AddAnnotation_Content=Content:
-AddAnnotation_Content_Help=Annotation will replace:\n \u2022 Unknown macro: {0} \n    with name of trace,\
-\n \u2022 Unknown macro: {1} \n    with timestamp, \
-\n \u2022 Unknown macro: {2} \n    with value at that timestamp \
-\n\nAdvanced formatting options:\n \u2022 Unknown macro: {1,date,HH}\n    : \
+AddAnnotation_Content_Help=Annotation will replace:\n \u2022 {0} with name of trace\
+\n \u2022 {1} with timestamp \n \u2022 {2} with value at that timestamp \
+\n\nAdvanced formatting options:\n \u2022 {1,date,HH}: \
 yyyy or yy year, MM month, dd day, HH hours, mm minutes, ss seconds, SSS milliseconds\
-\n \u2022 Unknown macro: {2,number,#.##}\n    : # gives 0 d.p., #.## gives 2 d.p.
-AddAnnotation_DefaultText={0}\n{1,date,HH:mm}, {2}
+\n \u2022 {2,number,#.##}: # gives 0 d.p., #.## gives 2 d.p.
+AddAnnotation_DefaultText={0}\n{1}, {2}
 AddAnnotation_Error=Error with annotation format
 AddAnnotation_NoTraces=To add annotation, first add traces to the plot
 AddAnnotation_Text_TT=Enter text to display in this annotation

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
@@ -1,7 +1,7 @@
 AddAnnotation=Add Annotation
 AddAnnotation_Content=Content:
 AddAnnotation_Content_Help=Annotation will replace\n{0} with name of trace,\n{1} with position and\n{2} with value at that position.
-AddAnnotation_DefaultText={0}\n{1}, {2}
+AddAnnotation_DefaultText={0}\n{1,date,HH:mm}, {2,number,#}
 AddAnnotation_NoTraces=To add annotation, first add traces to the plot
 AddAnnotation_Text_TT=Enter text to display in this annotation
 AddAnnotation_Trace=Trace:
@@ -10,7 +10,9 @@ Crosshair_Cursor=Cross-hair cursor
 EditAnnotation=Edit Annotation
 EditAnnotation_Text=Content
 EditAnnotation_Trace=Trace
-EditAnnotation_Info=Double-click annotation to edit its text. Un-check one or more annotations to remove.
+EditAnnotation_Info=Double-click annotation to edit its text. Un-check one or more annotations to remove. \n\
+\{1\} Format the date by changing HH/mm where HH = hours, mm = minutes, ss = seconds, .SS = milliseconds.\
+\n\{2\} Format the number of d.p. displayed for the value by adding #.### (for 3 d.p.).
 Legend_Show=Show Legend
 NameUnitsFmt={0} [{1}]
 Pan=Pan

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
@@ -1,18 +1,21 @@
 AddAnnotation=Add Annotation
 AddAnnotation_Content=Content:
-AddAnnotation_Content_Help=Annotation will replace\n{0} with name of trace,\n{1} with position and\n{2} with value at that position.
+AddAnnotation_Content_Help=Annotation will replace\n{0} with name of trace,\n{1} with position \
+(format the date by changing HH/mm where HH = hours, mm = minutes, ss = seconds, .SS = milliseconds), \
+ and\n{2} with value at that position \
+(format the number of d.p. displayed for the value by adding #.### (for 3 d.p.)).
 AddAnnotation_DefaultText={0}\n{1,date,HH:mm}, {2,number,#}
 AddAnnotation_NoTraces=To add annotation, first add traces to the plot
-AddAnnotation_Text_TT=Enter text to display in this annotation
+AddAnnotation_Text_TT=Enter text to display in this annotation\n\
+{1} Format the date by changing HH/mm where HH = hours, mm = minutes, ss = seconds, .SS = milliseconds.\
+\n{2} Format the number of d.p. displayed for the value by adding #.### (for 3 d.p.).
 AddAnnotation_Trace=Trace:
 AddAnnotation_Trace_TT=Select trace for this annotation
 Crosshair_Cursor=Cross-hair cursor
 EditAnnotation=Edit Annotation
 EditAnnotation_Text=Content
 EditAnnotation_Trace=Trace
-EditAnnotation_Info=Double-click annotation to edit its text. Un-check one or more annotations to remove. \n\
-\{1\} Format the date by changing HH/mm where HH = hours, mm = minutes, ss = seconds, .SS = milliseconds.\
-\n\{2\} Format the number of d.p. displayed for the value by adding #.### (for 3 d.p.).
+EditAnnotation_Info=Double-click annotation to edit its text. Un-check one or more annotations to remove.
 Legend_Show=Show Legend
 NameUnitsFmt={0} [{1}]
 Pan=Pan

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/editor/DataBrowserEditor.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/editor/DataBrowserEditor.java
@@ -399,6 +399,7 @@ public class DataBrowserEditor extends EditorPart
         else {
             manager.add(plot.getPlot().getToolbarAction());
             manager.add(plot.getPlot().getLegendAction());
+            manager.add(plot.getPlot().getAddAnnotationAction());
             manager.add(new Separator());
             manager.add(new AddPVAction(op_manager, shell, model, false));
             manager.add(new AddPVAction(op_manager, shell, model, true));


### PR DESCRIPTION
This allows the user to input custom formats for the annotation values (e.g. specify the number of dp) and the timestamps. The formats are verified before adding to the plot. This is added as an 'advanced' option, while the original formatting implementation is still maintained for the general case.
In addition, two new features have been added to improve user interaction with annotations. These include being able to select 'Add annotation' from the right-click menu on the databrowser plot and being able to edit existing annotations by double-clicking on them. 