### PR TITLE
Optimized with last sample

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/preferences.ini
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/preferences.ini
@@ -1,3 +1,7 @@
 useStatisticsForOptimizedData=true
 useNewOptimizedOperator=true
+
+# Query the AA using the 'Optimized With Last Sample' post processor.
+# Setting to false means that the 'Optimized' post processor will be 
+# used. 
 ppOptimizedWithLastSample=false

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/preferences.ini
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/preferences.ini
@@ -1,2 +1,3 @@
 useStatisticsForOptimizedData=true
 useNewOptimizedOperator=true
+ppOptimizedWithLastSample=false

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceArchiveReaderConstants.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceArchiveReaderConstants.java
@@ -52,6 +52,8 @@ public class ApplianceArchiveReaderConstants {
     public static final String OP_MEAN = "mean_";
     /** Operator for the optimized post processor */
     public static final String OP_OPTIMIZED = "optimized_";
+    /** Operator for the optimized with last sample post processor */
+    public static final String OP_OPTIMIZED_WITH_LAST_SAMPLE = "optimLastSample_";
 
     /** The schema delimiter: ca://pvName or pva://pvname */
     static final String SCHEMA_DELIMITER = "://";

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceOptimizedValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceOptimizedValueIterator.java
@@ -65,8 +65,15 @@ public class ApplianceOptimizedValueIterator extends ApplianceValueIterator {
      */
     @Override
     protected void fetchDataInternal(String pvName) throws ArchiverApplianceException {
-        String optimized = new StringBuilder().append(ApplianceArchiveReaderConstants.OP_OPTIMIZED)
+        final IPreferencesService prefs = Platform.getPreferencesService();
+        Boolean ppOptimizedWithLastSample = prefs.getBoolean(Activator.PLUGIN_ID, "ppOptimizedWithLastSample", false, null);
+        String optimized;
+        if (ppOptimizedWithLastSample)
+            optimized = new StringBuilder().append(ApplianceArchiveReaderConstants.OP_OPTIMIZED_WITH_LAST_SAMPLE)
                 .append(requestedPoints).append('(').append(pvName).append(')').toString();
+        else
+            optimized = new StringBuilder().append(ApplianceArchiveReaderConstants.OP_OPTIMIZED)
+            .append(requestedPoints).append('(').append(pvName).append(')').toString();
         super.fetchDataInternal(optimized);
     }
 

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceOptimizedValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceOptimizedValueIterator.java
@@ -14,6 +14,8 @@ import org.diirt.util.text.NumberFormats;
 import org.diirt.vtype.Display;
 import org.diirt.vtype.VType;
 import org.diirt.vtype.ValueFactory;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
 
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadType;


### PR DESCRIPTION
This pull request adds a preference setting to allow using the 'optimized with last sample' algorithm that we have recently added to the Archiver Appliance: https://github.com/slacmshankar/epicsarchiverap/pull/112

The default is to use the original algorithm.

This gives much better behaviour, as discussed at some length here: https://github.com/ControlSystemStudio/cs-studio/issues/2483

cc @rjwills28 