### PR TITLE
Css442 opi contextmenu focus

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
@@ -97,6 +97,8 @@ public final class OPIRunnerContextMenuProvider extends ContextMenuProvider {
             menu.add(new AboutWebOPIAction());
         }
 
+        // Return focus to the OPI view
+        getViewer().getControl().setFocus();
 
 //        MenuManager cssMenu = new MenuManager("CSS", "css");
 //        cssMenu.add(new Separator("additions")); //$NON-NLS-1$

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/runmode/OPIRunnerContextMenuProvider.java
@@ -97,8 +97,8 @@ public final class OPIRunnerContextMenuProvider extends ContextMenuProvider {
             menu.add(new AboutWebOPIAction());
         }
 
-        // Return focus to the OPI view
-        getViewer().getControl().setFocus();
+        // Sets the event dispatcher to route events back to the EditDomain
+        getViewer().setEditDomain(getViewer().getEditDomain());
 
 //        MenuManager cssMenu = new MenuManager("CSS", "css");
 //        cssMenu.add(new Separator("additions")); //$NON-NLS-1$


### PR DESCRIPTION
After opening the context menu with right click and either selecting an item or cancelling, sometimes focus isn't returned to the OPI. This means that the next click on the OPI is not registered  as expected.

This PR fixes that problem.

cc @rjwills28 