### PR TITLE
Css470 annotations

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
@@ -2,7 +2,7 @@ AddAnnotation=Add Annotation
 AddAnnotation_Content=Content:
 AddAnnotation_Content_Help=Annotation will replace:\n \u2022 {0} with name of trace\
 \n \u2022 {1} with timestamp \n \u2022 {2} with value at that timestamp \
-\n\nAdvanced formatting options:\n \u2022 {1,date,HH}: \
+\n\nAdvanced formatting options:\n \u2022 {1,date,HH:mm:ss}: \
 yyyy or yy year, MM month, dd day, HH hours, mm minutes, ss seconds, SSS milliseconds\
 \n \u2022 {2,number,#.00}: # gives 0 d.p., #.00 gives 2 d.p.
 AddAnnotation_DefaultText={0}\n{1}, {2}

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/messages.properties
@@ -4,7 +4,7 @@ AddAnnotation_Content_Help=Annotation will replace:\n \u2022 {0} with name of tr
 \n \u2022 {1} with timestamp \n \u2022 {2} with value at that timestamp \
 \n\nAdvanced formatting options:\n \u2022 {1,date,HH}: \
 yyyy or yy year, MM month, dd day, HH hours, mm minutes, ss seconds, SSS milliseconds\
-\n \u2022 {2,number,#.##}: # gives 0 d.p., #.## gives 2 d.p.
+\n \u2022 {2,number,#.00}: # gives 0 d.p., #.00 gives 2 d.p.
 AddAnnotation_DefaultText={0}\n{1}, {2}
 AddAnnotation_Error=Error with annotation format
 AddAnnotation_NoTraces=To add annotation, first add traces to the plot


### PR DESCRIPTION
Minor improvement to the annotation help:

* suggest `#.00` (which formats 12 as 12.00) instead of `#.##` (which formats 12 as 12)
* better example datetime format

cc @rjwills28 