### PR TITLE
Css208 save external opi plots

### DIFF
--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource.rcp/src/org/csstudio/utility/singlesource/rcp/RCPResourceHelper.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource.rcp/src/org/csstudio/utility/singlesource/rcp/RCPResourceHelper.java
@@ -134,12 +134,19 @@ public class RCPResourceHelper extends ResourceHelper
         if (ws_file == null)
             return super.getOutputStream(input);
         
+        // Determine the path to the file. 
         IPath p = getPath(input);
-        final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        // back to non-workspace implementation if null
         if (p == null)
           return super.getOutputStream(input);
         
-        //  back to non-workspace implementation
+        // If workspace root does not contain the path (i.e. the file is outside
+        // of the workspace) but the file does actually exist then revert to the 
+        // super non-workspace implementation.
+        // Otherwise if the file path is within the workspace (findMember = true)
+        // and/or it is a new file (does not exist yet) then continue in this
+        // implementation.
+        final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
         if (root.findMember(p) == null && super.exists(p)) {
           return super.getOutputStream(input);
         }

--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource.rcp/src/org/csstudio/utility/singlesource/rcp/RCPResourceHelper.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource.rcp/src/org/csstudio/utility/singlesource/rcp/RCPResourceHelper.java
@@ -133,6 +133,16 @@ public class RCPResourceHelper extends ResourceHelper
         // Fall back to non-workspace implementation
         if (ws_file == null)
             return super.getOutputStream(input);
+        
+        IPath p = getPath(input);
+        final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        if (p == null)
+          return super.getOutputStream(input);
+        
+        //  back to non-workspace implementation
+        if (root.findMember(p) == null && super.exists(p)) {
+          return super.getOutputStream(input);
+        }
 
         // Have workspace file
         // Check write access.

--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource/src/org/csstudio/utility/singlesource/PathEditorInput.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource/src/org/csstudio/utility/singlesource/PathEditorInput.java
@@ -97,9 +97,8 @@ public class PathEditorInput implements IPathEditorInput, IPersistableElement
     }
 
     /** {@inheritDoc} */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Object getAdapter(final Class adapter)
+    public <T> T getAdapter(final Class<T> adapter)
     {
         if (adapter == IPathEditorInput.class) 
           return Platform.getAdapterManager().getAdapter(this, adapter);

--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource/src/org/csstudio/utility/singlesource/PathEditorInput.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource/src/org/csstudio/utility/singlesource/PathEditorInput.java
@@ -8,6 +8,7 @@
 package org.csstudio.utility.singlesource;
 
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IPathEditorInput;
@@ -96,10 +97,13 @@ public class PathEditorInput implements IPathEditorInput, IPersistableElement
     }
 
     /** {@inheritDoc} */
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public Object getAdapter(final Class adapter)
     {
+        if (adapter == IPathEditorInput.class) 
+          return Platform.getAdapterManager().getAdapter(this, adapter);
+      
         return SingleSourcePlugin.getResourceHelper().adapt(path, adapter);
     }
 

--- a/core/utility/utility-plugins/org.csstudio.utility.singlesource/src/org/csstudio/utility/singlesource/ResourceHelper.java
+++ b/core/utility/utility-plugins/org.csstudio.utility.singlesource/src/org/csstudio/utility/singlesource/ResourceHelper.java
@@ -114,8 +114,7 @@ public class ResourceHelper
      *  @param adapter Desired class, for example IFile
      *  @return Adapted path or <code>null</code>
      */
-    @SuppressWarnings("rawtypes")
-    public Object adapt(final IPath path, final Class adapter)
+    public <T> T adapt(final IPath path, final Class<T> adapter)
     {
         // By default, don't adapt, but log to aid in future extension of this code.
         final Logger logger = Logger.getLogger(getClass().getName());


### PR DESCRIPTION
This one is quite rare, but:

* if you have an OPI file that contains a databrowser widget
* then you open the databrowser plot
* then you try to save the plot file
* AND the plot file is not inside your workspace
* then you see an error

This commit fixes this via somewhat obscure Eclipse trickery. 