### PR TITLE
Adding case when PV control and display limits are not set to use the…

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/AbstractMarkedWidgetEditPart.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/editparts/AbstractMarkedWidgetEditPart.java
@@ -105,6 +105,10 @@ public abstract class AbstractMarkedWidgetEditPart extends AbstractScaledWidgetE
                                             upperLimit = meta.getUpperDisplayLimit();
                                             lowerLimit = meta.getLowerDisplayLimit();
                                         }
+                                        if (!(lowerLimit < upperLimit)) {
+                                            upperLimit = model.getMaximum();
+                                            lowerLimit = model.getMinimum();
+                                        }
                                         if(!Double.isNaN(upperLimit)) {
                                             model.setPropertyValue(AbstractMarkedWidgetModel.PROP_MAX, upperLimit);
                                         }


### PR DESCRIPTION
… min and max configured in the widget properties.

Otherwise if 'limits from PV' is set but DRVH and DRVL are at their default 0 then you cannot use the slider.