### PR TITLE
Checkboxes in databrowser Properties and Axes tabs do not show when the row is highlighted

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/AxesTableHandler.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/AxesTableHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.CellLabelProvider;
 import org.eclipse.jface.viewers.CheckboxCellEditor;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.StyledCellLabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.Viewer;
@@ -114,7 +115,7 @@ public class AxesTableHandler implements IStructuredContentProvider
 
         // Visible? Column ----------
         col = TableHelper.createColumn(table_layout, axes_table, Messages.AxisVisibility, 45, 10);
-        col.setLabelProvider(new CellLabelProvider()
+        col.setLabelProvider(new StyledCellLabelProvider()
         {
             @Override
             public void update(final ViewerCell cell)
@@ -190,7 +191,7 @@ public class AxesTableHandler implements IStructuredContentProvider
 
         // Use Axis Name ----------
         col = TableHelper.createColumn(table_layout, axes_table, Messages.UseAxisName, 95, 10);
-        col.setLabelProvider(new CellLabelProvider()
+        col.setLabelProvider(new StyledCellLabelProvider()
         {
             @Override
             public void update(final ViewerCell cell)
@@ -229,7 +230,7 @@ public class AxesTableHandler implements IStructuredContentProvider
 
         // Use Trace Names ----------
         col = TableHelper.createColumn(table_layout, axes_table, Messages.UseTraceNames, 110, 10);
-        col.setLabelProvider(new CellLabelProvider()
+        col.setLabelProvider(new StyledCellLabelProvider()
         {
             @Override
             public void update(final ViewerCell cell)
@@ -268,7 +269,7 @@ public class AxesTableHandler implements IStructuredContentProvider
 
         // Show Grid? ----------
         col = TableHelper.createColumn(table_layout, axes_table, Messages.Grid, 50, 5);
-        col.setLabelProvider(new CellLabelProvider()
+        col.setLabelProvider(new StyledCellLabelProvider()
         {
             @Override
             public void update(final ViewerCell cell)
@@ -307,7 +308,7 @@ public class AxesTableHandler implements IStructuredContentProvider
 
         // Use Right Side? ----------
         col = TableHelper.createColumn(table_layout, axes_table, Messages.AxisOnRight, 80, 10);
-        col.setLabelProvider(new CellLabelProvider()
+        col.setLabelProvider(new StyledCellLabelProvider()
         {
             @Override
             public void update(final ViewerCell cell)
@@ -461,7 +462,7 @@ public class AxesTableHandler implements IStructuredContentProvider
 
         // Auto scale Column ----------
         col = TableHelper.createColumn(table_layout, axes_table, Messages.AutoScale, 80, 10);
-        col.setLabelProvider(new CellLabelProvider()
+        col.setLabelProvider(new StyledCellLabelProvider()
         {
             @Override
             public void update(final ViewerCell cell)

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/TraceTableHandler.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/propsheet/TraceTableHandler.java
@@ -44,6 +44,7 @@ import org.eclipse.jface.viewers.CheckboxCellEditor;
 import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.StyledCellLabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.Viewer;
@@ -141,7 +142,7 @@ public class TraceTableHandler implements IStructuredContentProvider
 
         // Visible Column ----------
         TableViewerColumn view_col = TableHelper.createColumn(table_layout, table_viewer, Messages.TraceVisibility, 45, 1);
-        view_col.setLabelProvider(new CellLabelProvider()
+        view_col.setLabelProvider(new StyledCellLabelProvider()
         {
             @Override
             public void update(final ViewerCell cell)


### PR DESCRIPTION
If a row is selected in the Properties or Axes tab in the databrowser, then the checkbox disappears (e.g. the checkbox indicating whether the trace is shown or not). Instead you just see a blue square and cannot tell what whether the checkbox is selected or not.

The image was not getting painted on top of the 'blue' selected row. I changed the `LabelProvider` for all of these checkbox fields from a `CellLabelProvider` (basic implementation) with a `StyleCellLabelProvider`, which allows for styled cells to be painted and updated from a listener. This fixes the issue. 
