### PR TITLE
Updating GitHub build workflow to specify the Maven version-3.6.3.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.6.3  
     - name: Build OSGi bundles with Maven
       run: mvn -f maven-osgi-bundles/pom.xml clean verify
     - name: Build the application


### PR DESCRIPTION
The build is failing with the latest 3.8.1, we think because of an http Maven repo.