### PR TITLE
Css501 image widget

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/ImageFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/ImageFigure.java
@@ -25,6 +25,7 @@ import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.csstudio.opibuilder.editparts.ExecutionMode;
 import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.csstudio.opibuilder.widgets.FigureTransparencyHelper;
 import org.csstudio.swt.widgets.introspection.DefaultWidgetIntrospector;
@@ -133,12 +134,17 @@ public final class ImageFigure extends Figure implements Introspectable, SymbolI
                 // Case where there is no file specified
                 errorMsg = "No image file specified" + filePath;
             }
-            gfx.setBackgroundColor(getBackgroundColor());
-            gfx.setForegroundColor(getForegroundColor());
-            gfx.fillRectangle(bounds);
-            gfx.translate(bounds.getLocation());
-            TextPainter.drawText(gfx, errorMsg, bounds.width / 2, bounds.height / 2, TextPainter.CENTER);
-            return;
+            if (model.getExecutionMode() == ExecutionMode.RUN_MODE) {
+                image = null;
+                return;
+            } else {
+                gfx.setBackgroundColor(getBackgroundColor());
+                gfx.setForegroundColor(getForegroundColor());
+                gfx.fillRectangle(bounds);
+                gfx.translate(bounds.getLocation());
+                TextPainter.drawText(gfx, errorMsg, bounds.width / 2, bounds.height / 2, TextPainter.CENTER);
+                return;
+            }
         }
         image.setBounds(bounds);
         image.setAbsoluteScale(gfx.getAbsoluteScale());

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/ImageFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/ImageFigure.java
@@ -126,15 +126,18 @@ public final class ImageFigure extends Figure implements Introspectable, SymbolI
         if (bounds.width <= 0 || bounds.height <= 0) {
             return;
         }
-        if (image == null || image.isEmpty()) {
-            if (!filePath.isEmpty()) {
-                gfx.setBackgroundColor(getBackgroundColor());
-                gfx.setForegroundColor(getForegroundColor());
-                gfx.fillRectangle(bounds);
-                gfx.translate(bounds.getLocation());
-                TextPainter.drawText(gfx, "ERROR in loading image\n" + filePath, bounds.width / 2, bounds.height / 2,
-                        TextPainter.CENTER);
+        if (image == null || image.isEmpty() || image.getImagePath() == null) {
+            // Case where there has been an error loading the file
+            String errorMsg = "ERROR in loading image\n" + filePath;
+            if (filePath.isEmpty()) {
+                // Case where there is no file specified
+                errorMsg = "No image file specified" + filePath;
             }
+            gfx.setBackgroundColor(getBackgroundColor());
+            gfx.setForegroundColor(getForegroundColor());
+            gfx.fillRectangle(bounds);
+            gfx.translate(bounds.getLocation());
+            TextPainter.drawText(gfx, errorMsg, bounds.width / 2, bounds.height / 2, TextPainter.CENTER);
             return;
         }
         image.setBounds(bounds);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/ImageFigure.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.widgets/src/org/csstudio/opibuilder/widgets/figures/ImageFigure.java
@@ -122,7 +122,7 @@ public final class ImageFigure extends Figure implements Introspectable, SymbolI
         if (isLoadingImage()) {
             return;
         }
-        ImageUtils.crop(bounds, this.getInsets());
+        ImageUtils.crop(bounds.getCopy(), this.getInsets());
         if (bounds.width <= 0 || bounds.height <= 0) {
             return;
         }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/symbol/GIFSymbolImage.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/symbol/GIFSymbolImage.java
@@ -436,8 +436,12 @@ public class GIFSymbolImage extends AbstractSymbolImage {
                     }
                 }
                 loadingImage = false;
-                // fireSymbolImageLoaded();
-                Activator.getLogger().log(Level.WARNING, "ERROR in loading GIF image " + imagePath, e);
+                Display.getDefault().syncExec(new Runnable() {
+                    public void run() {
+                        fireSymbolImageLoaded();
+                    }
+                });
+                Activator.getLogger().log(Level.WARNING, "ERROR in loading GIF image " + imagePath, e.getMessage());
             }
         });
     }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/symbol/PNGSymbolImage.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/symbol/PNGSymbolImage.java
@@ -166,9 +166,12 @@ public class PNGSymbolImage extends AbstractSymbolImage {
                     }
                 }
                 loadingImage = false;
-                // fireSymbolImageLoaded();
-                Activator.getLogger().log(Level.WARNING,
-                        "ERROR in loading PNG image " + imagePath, exception);
+                Display.getDefault().syncExec(new Runnable() {
+                    public void run() {
+                        fireSymbolImageLoaded();
+                    }
+                });
+                Activator.getLogger().log(Level.WARNING, "ERROR in loading PNG image " + imagePath, exception.getMessage());
             }
         });
     }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/symbol/SVGSymbolImage.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.swt.widgets/src/org/csstudio/swt/widgets/symbol/SVGSymbolImage.java
@@ -265,8 +265,12 @@ public class SVGSymbolImage extends AbstractSymbolImage {
                     }
                 }
                 loadingImage = false;
-                // fireSymbolImageLoaded();
-                Activator.getLogger().log(Level.WARNING, "ERROR in loading SVG image " + imagePath, exception);
+                Display.getDefault().syncExec(new Runnable() {
+                    public void run() {
+                        fireSymbolImageLoaded();
+                    }
+                });
+                Activator.getLogger().log(Level.WARNING, "ERROR in loading SVG image " + imagePath, exception.getMessage());
             }
         });
     }


### PR DESCRIPTION
There was an odd bug when an image widget had a border.

Also show a placeholder in edit mode if no image is selected, otherwise the widget is invisible.

cc @rjwills28 