### PR TITLE
Css561 plot bin shift

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance.test/src/org/csstudio/archive/reader/appliance/ApplianceArchiveReaderNewOptimizedTest.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance.test/src/org/csstudio/archive/reader/appliance/ApplianceArchiveReaderNewOptimizedTest.java
@@ -2,7 +2,9 @@ package org.csstudio.archive.reader.appliance;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import org.csstudio.archive.reader.ArchiveReader;
 import org.csstudio.archive.reader.appliance.testClasses.TestApplianceArchiveReader;
@@ -68,6 +70,12 @@ public class ApplianceArchiveReaderNewOptimizedTest extends AbstractArchiverRead
         ArchiveVType[] vals = getValuesStatistics("test_pv", 10, start, end);
         assertEquals("Number of values comparison", 10, vals.length);
 
+        // Offset the start time to reflect the difference between
+        // the timestamp provided by the AA and data browser
+        // (i.e. middle/start of bin.
+        Duration duruation = Duration.between(start,end);
+        long intervalSecs = (duruation.toSeconds())/(10);
+        start = start.minus(intervalSecs/2, ChronoUnit.SECONDS);
         long startM = start.toEpochMilli();
 
         ArchiveVStatistics val = null;

--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceOptimizedValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceOptimizedValueIterator.java
@@ -1,7 +1,9 @@
 package org.csstudio.archive.reader.appliance;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Iterator;
 
 import org.csstudio.archive.vtype.ArchiveVNumber;
@@ -33,6 +35,7 @@ public class ApplianceOptimizedValueIterator extends ApplianceValueIterator {
 
     private final int requestedPoints;
     private final boolean useStatistics;
+    private long intervalSecs;
 
     /**
      * Constructor that fetches data from appliance archive reader.
@@ -57,6 +60,8 @@ public class ApplianceOptimizedValueIterator extends ApplianceValueIterator {
         this.requestedPoints = points;
         this.useStatistics = useStatistics;
         this.display = determineDisplay(reader, name, end);
+        Duration duruation = Duration.between(start,end);
+        this.intervalSecs = (duruation.toSeconds())/(points);
         fetchData();
     }
 
@@ -152,8 +157,10 @@ public class ApplianceOptimizedValueIterator extends ApplianceValueIterator {
                         "The optimized post processor returned less than 5 values per sample.");
             }
             if (useStatistics) {
+                Instant t0 = TimestampHelper.fromSQLTimestamp(message.getTimestamp());
+                Instant tshifted = t0.minus(intervalSecs/2, ChronoUnit.SECONDS);
                 return new ArchiveVStatistics(
-                        TimestampHelper.fromSQLTimestamp(message.getTimestamp()),
+                        tshifted,
                         getSeverity(message.getSeverity()),
                         String.valueOf(message.getStatus()),
                         display,


### PR DESCRIPTION
A detail that is not often obvious: the AA provides a timestamp that is in the middle of a 'bin', whereas the databrowser was plotting that value at the start of the bin.

cc @rjwills28 