### PR TITLE
Css537 modal displays

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
@@ -17,6 +17,6 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.4.0",
  org.csstudio.ui.util,
  org.csstudio.utility.file;bundle-version="1.0.0",
  org.csstudio.utility.product;bundle-version="1.2.2",
- org.eclipse.fx.ui.workbench3;bundle-version="3.4.3"
-Import-Package: org.csstudio.opibuilder.widgets.model,
- org.eclipse.gef.ui.actions
+ org.eclipse.fx.ui.workbench3;bundle-version="3.4.3",
+ org.csstudio.opibuilder.widgets
+Import-Package: org.eclipse.gef.ui.actions

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/META-INF/MANIFEST.MF
@@ -18,4 +18,5 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.4.0",
  org.csstudio.utility.file;bundle-version="1.0.0",
  org.csstudio.utility.product;bundle-version="1.2.2",
  org.eclipse.fx.ui.workbench3;bundle-version="3.4.3"
-Import-Package: org.eclipse.gef.ui.actions
+Import-Package: org.csstudio.opibuilder.widgets.model,
+ org.eclipse.gef.ui.actions

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -18,6 +18,8 @@ import org.csstudio.opibuilder.persistence.XMLUtil;
 import org.csstudio.opibuilder.util.MacrosInput;
 import org.csstudio.opibuilder.util.ResourceUtil;
 import org.csstudio.opibuilder.util.SingleSourceHelper;
+import org.csstudio.opibuilder.widgets.model.RectangleModel;
+import org.csstudio.opibuilder.widgets.model.TextInputModel;
 import org.csstudio.ui.util.thread.UIBundlingThread;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -44,10 +46,15 @@ import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.events.ShellListener;
+import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
@@ -98,8 +105,13 @@ public final class OPIShell implements IOPIRuntime {
     private final Shell shell;
     private final ActionRegistry actionRegistry;
     private final GraphicalViewer viewer;
+
+    // Flag indicating that a modal dialog is currently displayed.
+    private boolean isModalDialogDisplayed = false;
+
     // Variables that change if OPI input is changed.
     private DisplayModel displayModel;
+
     private IPath path;
     // macrosInput should not be null.  If there are no macros it should
     // be an empty MacrosInput object.
@@ -208,6 +220,57 @@ public final class OPIShell implements IOPIRuntime {
             }
         });
 
+        /*
+         * Workaround for modal dialogs.
+         *
+         * Display an overlay warning widget over the current OPI displays to inform the
+         * user that a modal dialog is open somewhere in the workspace. Once the dialog
+         * is closed, then the OPI shells are reverted to their original states.
+         */
+        display.addFilter(SWT.Activate, new Listener() {
+            @Override
+            public void handleEvent(Event event) {
+                Shell active = PlatformUI.getWorkbench().getDisplay().getActiveShell();
+
+                int modalStyleMask = SWT.APPLICATION_MODAL | SWT.PRIMARY_MODAL | SWT.SYSTEM_MODAL;
+                boolean isModal = (active.getStyle() & modalStyleMask) > 0;
+
+                if (isModal) {
+                    if (!isModalDialogDisplayed) {
+                        for (OPIShell o : OPIShell.getAllShells()) {
+                            o.shell.setText("Modal dialog detected!");
+                            o.shell.setCursor(new Cursor(display, SWT.CURSOR_WAIT));
+                            try {
+                                o.addModalWarningOverlayToDisplayModel(active.getText());
+                            } catch (Exception e) {
+                                log.log(Level.WARNING, "Failed to add modal dialog overlay to OPI shell.", e);
+                            }
+                        }
+                        isModalDialogDisplayed = true;
+
+                        // SWT.Close and shellClosed events only trigger when pressing the 'x' button,
+                        // not when the shell is closed via other buttons, therefore need to listen
+                        // for the dispose event instead.
+                        active.addDisposeListener(new DisposeListener() {
+                            @Override
+                            public void widgetDisposed(DisposeEvent event) {
+                                // Revert OPI shells.
+                                for (OPIShell s : OPIShell.getAllShells()) {
+                                    s.setTitle();
+                                    s.shell.setCursor(new Cursor(display, SWT.CURSOR_ARROW));
+                                    try {
+                                        s.createDisplayModel();
+                                        isModalDialogDisplayed = false;
+                                    } catch (Exception e) {
+                                        log.log(Level.WARNING, "Failed to regenerate display model.", e);
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+        });
     }
 
     /**
@@ -265,6 +328,39 @@ public final class OPIShell implements IOPIRuntime {
     public void close() {
         shell.close();
         dispose();
+    }
+
+    private void addModalWarningOverlayToDisplayModel(String modalDialogTitle) throws Exception {
+        Rectangle shellArea = shell.getClientArea();
+        int shellHeight = shellArea.height;
+        int shellWidth = shellArea.width;
+
+        TextInputModel modalDialogWarningOverlayModel = new TextInputModel();
+        int modalWarningWidth = 330;
+        int modalWarningHeight = 70;
+        modalDialogWarningOverlayModel.setText("⚠️ Please close the \"" + modalDialogTitle + "\" modal dialog.");
+        RGB yellowish = new RGB(255, 255, 150);
+        modalDialogWarningOverlayModel.setBackgroundColor(yellowish);
+        modalDialogWarningOverlayModel.setWidth(modalWarningWidth);
+        modalDialogWarningOverlayModel.setHeight(modalWarningHeight);
+        modalDialogWarningOverlayModel.setLocation(shellWidth / 2 - modalWarningWidth / 2,
+                shellHeight / 2 - modalWarningHeight / 2);
+        modalDialogWarningOverlayModel.setPropertyValue("horizontal_alignment", "1"); // centred
+        modalDialogWarningOverlayModel.setPropertyValue("border_style", "3");
+
+        // Mimic RHEL7 greying out over the background when a modal dialog appears.
+        RectangleModel rectangleOverlayModel = new RectangleModel();
+        rectangleOverlayModel.setSize(shellWidth, shellHeight);
+        RGB grey = new RGB(128, 128, 128);
+        rectangleOverlayModel.setBackgroundColor(grey);
+        rectangleOverlayModel.setPropertyValue("alpha", 180);
+
+        displayModel.addChild(rectangleOverlayModel);
+        displayModel.addChild(modalDialogWarningOverlayModel);
+
+        viewer.setContents(displayModel);
+        displayModel.setViewer(viewer);
+        displayModel.setOpiRuntime(this);
     }
 
     private DisplayModel createDisplayModel() throws Exception {

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/runmode/OPIShell.java
@@ -259,12 +259,14 @@ public final class OPIShell implements IOPIRuntime {
                                     s.setTitle();
                                     s.shell.setCursor(new Cursor(display, SWT.CURSOR_ARROW));
                                     try {
+                                        // Regenerate display model to remove temporary children warning widgets.
                                         s.createDisplayModel();
                                         isModalDialogDisplayed = false;
                                     } catch (Exception e) {
                                         log.log(Level.WARNING, "Failed to regenerate display model.", e);
                                     }
                                 }
+                                active.removeDisposeListener(this);
                             }
                         });
                     }
@@ -338,7 +340,8 @@ public final class OPIShell implements IOPIRuntime {
         TextInputModel modalDialogWarningOverlayModel = new TextInputModel();
         int modalWarningWidth = 330;
         int modalWarningHeight = 70;
-        modalDialogWarningOverlayModel.setText("⚠️ Please close the \"" + modalDialogTitle + "\" modal dialog.");
+        modalDialogWarningOverlayModel
+                .setText(String.format("⚠️ Please close the \"%s\" modal dialog.", modalDialogTitle));
         RGB yellowish = new RGB(255, 255, 150);
         modalDialogWarningOverlayModel.setBackgroundColor(yellowish);
         modalDialogWarningOverlayModel.setWidth(modalWarningWidth);
@@ -353,7 +356,7 @@ public final class OPIShell implements IOPIRuntime {
         rectangleOverlayModel.setSize(shellWidth, shellHeight);
         RGB grey = new RGB(128, 128, 128);
         rectangleOverlayModel.setBackgroundColor(grey);
-        rectangleOverlayModel.setPropertyValue("alpha", 180);
+        rectangleOverlayModel.setPropertyValue("alpha", 150);
 
         displayModel.addChild(rectangleOverlayModel);
         displayModel.addChild(modalDialogWarningOverlayModel);


### PR DESCRIPTION
Specific functionality for standalone windows.

If a standalone window is open and a CS-Studio also has a modal dialog open, the standalone window will not respond. This is the same as OPIs in a workbench, but it is less obvious to the user what is happening.

This change means that if the standalone window is blocked and the user clicks on that window, a widget appears to make it clear what is happening. When the modal dialog is closed everything returns to normal.

![image](https://user-images.githubusercontent.com/2440055/124559954-2d068600-de34-11eb-93b1-c1b0098c3884.png)
