### PR TITLE
Css564 annotation units fix

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
@@ -134,8 +134,22 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
 
         String localText = text;
         final String units = trace.getUnits();
-        if (!units.isEmpty())
-            localText += " " + units;
+
+        // Need to reformat to get the units in the correct place
+        if (!units.isEmpty()) {
+            String[] splt = localText.split("\\{2");
+            localText = "";
+            for (int i = 0; i < splt.length; i++) {
+                if (i == 0)
+                    localText += splt[i];
+                else {
+                    localText += "{2";
+                    localText += splt[i].substring(0, splt[i].indexOf("}") + 1);
+                    localText += " " + units;
+                    localText += splt[i].substring(splt[i].indexOf("}") + 1);
+                }
+            }
+        }
 
         Date date = Date.from((Instant) position);
         final String label;

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/AnnotationImpl.java
@@ -137,18 +137,7 @@ public class AnnotationImpl<XTYPE extends Comparable<XTYPE>> extends Annotation<
 
         // Need to reformat to get the units in the correct place
         if (!units.isEmpty()) {
-            String[] splt = localText.split("\\{2");
-            localText = "";
-            for (int i = 0; i < splt.length; i++) {
-                if (i == 0)
-                    localText += splt[i];
-                else {
-                    localText += "{2";
-                    localText += splt[i].substring(0, splt[i].indexOf("}") + 1);
-                    localText += " " + units;
-                    localText += splt[i].substring(splt[i].indexOf("}") + 1);
-                }
-            }
+            localText = localText.replaceAll("\\{2([^}]*)\\}", "\\{2$1\\} " + units);
         }
 
         Date date = Date.from((Instant) position);


### PR DESCRIPTION
The previous change added the units at the end of the format string, not necessarily attached to the value.

This corrects that bug.

@rjwills28 