### PR TITLE
Css569 databrowser background

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -694,17 +694,23 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         // Shade the area in the plot that's in the future.
         if (x_axis instanceof TimeAxis)
         {
-            final int future_x = ((TimeAxis)x_axis).getScreenCoord(Instant.now());
-            if (future_x < area_copy.width) {
-                final Color orig = gc.getBackground();
-                // Use light gray for bright background, otherwise dark gray
-                final Color shade = (background.getHSB()[2] >= 0.5) ? new Color(getDisplay(), 240, 240, 240)
-                        : new Color(getDisplay(), 50, 50, 50);
-                gc.setBackground(shade);
-                gc.fillRectangle(future_x, 0, area_copy.width - future_x, area_copy.height);
-                gc.setBackground(orig);
-                shade.dispose();
+            final int now_x = ((TimeAxis)x_axis).getScreenCoord(Instant.now());
+            final Color orig = gc.getBackground();
+            // Use light gray for bright background, otherwise dark gray
+            final Color shade = (background.getHSB()[2] >= 0.5) ? new Color(getDisplay(), 240, 240, 240)
+                    : new Color(getDisplay(), 50, 50, 50);
+            gc.setBackground(shade);
+
+            // Shading only needed if 'now' is on the plot or in the past.
+            if (now_x < 0) {
+                // 'Now' off left of screen: fill entire background with gray.
+                gc.fillRectangle(0, 0, area_copy.width, area_copy.height);
+            } else if (now_x < area_copy.width) {
+                // 'Now' on screen: partially fill with gray.
+                gc.fillRectangle(now_x, 0, area_copy.width - now_x, area_copy.height);
             }
+            gc.setBackground(orig);
+            shade.dispose();
         }
 
         // Fetch x_axis transformation and use that to paint all traces,

--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/Plot.java
@@ -695,15 +695,16 @@ public class Plot<XTYPE extends Comparable<XTYPE>> extends Canvas implements Pai
         if (x_axis instanceof TimeAxis)
         {
             final int future_x = ((TimeAxis)x_axis).getScreenCoord(Instant.now());
-            final Color orig = gc.getBackground();
-            // Use light gray for bright background, otherwise dark gray
-            final Color shade = (background.getHSB()[2] >= 0.5)
-                    ? new Color(getDisplay(), 240, 240, 240)
-                    : new Color(getDisplay(), 50, 50, 50);
-            gc.setBackground(shade);
-            gc.fillRectangle(future_x, 0, area_copy.width - future_x, area_copy.height);
-            gc.setBackground(orig);
-            shade.dispose();
+            if (future_x < area_copy.width) {
+                final Color orig = gc.getBackground();
+                // Use light gray for bright background, otherwise dark gray
+                final Color shade = (background.getHSB()[2] >= 0.5) ? new Color(getDisplay(), 240, 240, 240)
+                        : new Color(getDisplay(), 50, 50, 50);
+                gc.setBackground(shade);
+                gc.fillRectangle(future_x, 0, area_copy.width - future_x, area_copy.height);
+                gc.setBackground(orig);
+                shade.dispose();
+            }
         }
 
         // Fetch x_axis transformation and use that to paint all traces,


### PR DESCRIPTION
This refers to the logic for painting the area of the databrowser plot that is in the future in grey.

The previous implementation could draw large rectangles outside the databrowser plot area. In some circumstances the rectangle size could overflow and draw in the wrong location.

cc @rjwills28 