### PR TITLE
Css567 show trace bug

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/Controller.java
@@ -507,12 +507,10 @@ public class Controller
 
             @Override
             public void changedItemVisibility(final ModelItem item)
-            {   // Add/remove from plot, but don't need to get archived data
-                // When made visible, note that item could be in 'middle'
-                // of existing traces, so need to re-create all
+            {   // Show or hide trace by changing visibility.
                 if (item.isVisible())
                     plot.showTrace(item);
-                else // Hide trace by changing visibility
+                else
                     plot.hideTrace(item);
             }
 
@@ -690,8 +688,7 @@ public class Controller
         for (AxisConfig axis : model.getAxes())
             plot.updateAxis(i++, axis);
         for (ModelItem item : model.getItems())
-            if (item.isVisible())
-                plot.addTrace(item);
+            plot.addTrace(item);
     }
 
     /** (Re-) create traces in plot for each item in the model and add
@@ -704,8 +701,7 @@ public class Controller
         for (AxisConfig axis : model.getAxes())
             plot.updateAxis(i++, axis);
         for (ModelItem item : model.getItems())
-            if (item.isVisible())
-                plot.addTrace(item);
+            plot.addTrace(item);
 
         plot.setAnnotations(oldAnno);
     }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -372,13 +372,12 @@ public class ModelBasedPlot
         try
         {
             trace = findTrace(item);
+
         }
         catch (IllegalArgumentException ex)
-        {   // Could be called with a trace that was not visible,
-            // so it was never in the plot,
-            // and now gets removed.
-            // --> No error, because trace to be removed is already
-            //     absent from plot
+        {   // If trace was hidden when loaded, it will not have
+            // been added to the plot so it must be added now.
+            addTrace(item);
             return;
         }
         trace.setVisible(true);

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/ui/ModelBasedPlot.java
@@ -324,62 +324,27 @@ public class ModelBasedPlot
     /** @param item ModelItem to remove from plot */
     public void removeTrace(final ModelItem item)
     {
-        final Trace<Instant> trace;
-        try
-        {
-            trace = findTrace(item);
-        }
-        catch (IllegalArgumentException ex)
-        {   // Could be called with a trace that was not visible,
-            // so it was never in the plot,
-            // and now gets removed.
-            // --> No error, because trace to be removed is already
-            //     absent from plot
-            return;
-        }
+        final Trace<Instant> trace = findTrace(item);
         plot.removeTrace(trace);
         plot.removeAnnotation(trace);
         items_by_trace.remove(trace);
     }
 
-    /** Hide a trace by changing the trace visibity
+    /** Hide a trace by changing the trace visibility
      *  @param item ModelItem to hide from plot
      */
     public void hideTrace(final ModelItem item)
     {
-        final Trace<Instant> trace;
-        try
-        {
-            trace = findTrace(item);
-        }
-        catch (IllegalArgumentException ex)
-        {   // Could be called with a trace that was not visible,
-            // so it was never in the plot,
-            // and now gets removed.
-            // --> No error, because trace to be removed is already
-            //     absent from plot
-            return;
-        }
+        final Trace<Instant> trace = findTrace(item);
         trace.setVisible(false);
     }
 
-    /** Show a trace by changing the trace visibity
+    /** Show a trace by changing the trace visibility
      *  @param item ModelItem to show in plot
      */
     public void showTrace(final ModelItem item)
     {
-        final Trace<Instant> trace;
-        try
-        {
-            trace = findTrace(item);
-
-        }
-        catch (IllegalArgumentException ex)
-        {   // If trace was hidden when loaded, it will not have
-            // been added to the plot so it must be added now.
-            addTrace(item);
-            return;
-        }
+        final Trace<Instant> trace = findTrace(item);
         trace.setVisible(true);
     }
 
@@ -388,10 +353,6 @@ public class ModelBasedPlot
      */
     public void updateTrace(final ModelItem item)
     {
-        // Invisible items have no trace, nothing to update,
-        // and findTrace() would throw an exception
-        if (! item.isVisible())
-            return;
         final Trace<Instant> trace = findTrace(item);
         // Update Trace with item's configuration
         final String name = item.getResolvedDisplayName();


### PR DESCRIPTION
A previous change introduced a bug: traces may be hidden in a plot file but if you then try to show them they do not appear.

Becky fixed the problem, but I wondered if there was a simpler way of doing this: always add all traces to the plot and only show them if they are visible.

We need a review from @kasemir: it might be that you think this is memory hungry, for example.

cc @rjwills28 