### PR TITLE
Changing the showView() method used to create the Console view if not…

### DIFF
--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ConsoleServiceSSHelperImpl.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder.rcp/src/org/csstudio/opibuilder/util/ConsoleServiceSSHelperImpl.java
@@ -20,6 +20,7 @@ import org.csstudio.ui.util.CustomMediaFactory;
 import org.csstudio.ui.util.thread.UIBundlingThread;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.ConsolePlugin;
@@ -257,7 +258,8 @@ public class ConsoleServiceSSHelperImpl extends ConsoleServiceSSHelper {
                 public void run() {
                     try {
                         final IViewPart view = PlatformUI.getWorkbench().getActiveWorkbenchWindow().
-                            getActivePage().showView("org.eclipse.ui.console.ConsoleView"); //$NON-NLS-1$
+                            getActivePage().showView("org.eclipse.ui.console.ConsoleView",null,
+                                    IWorkbenchPage.VIEW_VISIBLE); //$NON-NLS-1$
                         if(view != null && view instanceof ConsoleView){
                             UIBundlingThread.getInstance().addRunnable(new Runnable() {
                                 @Override


### PR DESCRIPTION
… present but not switching focus.

@shroffk @kasemir recent changes in Eclipse and gnome-shell means that CS-Studio is more likely to automatically switch workspaces on Linux. This example happens when an action on a standalone window opens the Console view in the main window.

We really need this change to mitigate the problem. The Console is still opened if necessary, but doesn't bring itself to the front or demand focus.

In practice I find the console jumping to the front is more disruptive than useful in any case.

We really need this fix for our 4.7 release, so unless there are concerns could someone approve the change?

cc @rjwills28 @aawdls @mjgaughran