### PR TITLE
Work around intermittent crash when saving snapshot from Data Browser

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/SnapshotAction.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/SnapshotAction.java
@@ -76,6 +76,8 @@ public class SnapshotAction extends Action
                     try
                     {    // Create snapshot, save to file
                         final ImageLoader loader = new ImageLoader();
+                        // In Eclipse 2020-12 we cannot seem to get the Image on
+                        // a background thread so must schedule it on the UI thread.
                         shell.getDisplay().syncExec(() -> {
                             final Image image = plot.getImage();
                             loader.data = new ImageData[] { image.getImageData() };


### PR DESCRIPTION
Our users report that intermittently CSS will crash when saving a snapshot from the data browser.

The output is

```[xcb] Unknown request in queue while dequeuing
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
java: xcb_io.c:165: dequeue_pending_request: Assertion `!xcb_xlib_unknown_req_in_deq' failed.
```

We deduced this is another manifrstation of the issue described here https://github.com/ControlSystemStudio/cs-studio/issues/2660 and here https://github.com/ControlSystemStudio/phoebus/issues/705

This PR implements a similar workaround for the Save Snapshot. i.e.  to create the image on the UI thread.

The [SWT issue is still open on eclipse.org](https://bugs.eclipse.org/bugs/show_bug.cgi?id=568859). One commenter reports that a later Eclipse version no longer has this behaviour, so it is possible that it will not be fixed in 2020-12. I expect that for us to upgrade the Eclipse version is a very big task and therefore prefer to implement this workaround in order to fix this crash for an upcoming DLS release.

cc @rjwills28 
