### PR TITLE
Specify cheatsheets as dependency of features instead of products

### DIFF
--- a/applications/databrowser/databrowser-features/org.csstudio.trends.databrowser2.feature/feature.xml
+++ b/applications/databrowser/databrowser-features/org.csstudio.trends.databrowser2.feature/feature.xml
@@ -31,6 +31,20 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
    </url>
 
    <plugin
+         id="org.eclipse.ui.cheatsheets"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ui.cheatsheets.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.csstudio.archive.reader.channelarchiver"
          download-size="0"
          install-size="0"

--- a/applications/databrowser/databrowser-features/org.csstudio.trends.databrowser2.rap.feature/feature.xml
+++ b/applications/databrowser/databrowser-features/org.csstudio.trends.databrowser2.rap.feature/feature.xml
@@ -10,6 +10,20 @@
    </description>
 
    <plugin
+         id="org.eclipse.ui.cheatsheets"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ui.cheatsheets.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.csstudio.trends.databrowser2"
          download-size="0"
          install-size="0"

--- a/product/features/org.csstudio.product.ide.dependencies.feature/feature.xml
+++ b/product/features/org.csstudio.product.ide.dependencies.feature/feature.xml
@@ -198,20 +198,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.ui.cheatsheets"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.ui.cheatsheets.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.ui.console"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
We noticed that our product is missing the cheatsheets dependency and therefore clicking Help -> Cheat Sheets gives an error like this

![image](https://user-images.githubusercontent.com/17617270/137320840-9fe42c12-93a0-4d94-8118-933e4a6cb524.png)

It seems most correct to make this a dependency of features in the cs-studio base repo and not in the product. This commit adds it in the features and removes it from the org.csstudio.product.

We are happy to take feedback on this change as we are not certain of its impact on others.

Also please let me know if there is a branch naming convention we should be following.

cc. @MJGaughran @rjwills28 