### PR TITLE
Only show legend for a trace when visible in the plot

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/LegendPart.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/LegendPart.java
@@ -109,6 +109,9 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
         int x = bounds.x, y = bounds.y;
         for (Trace<XTYPE> trace : traces)
         {
+            if (!trace.isVisible())
+                continue;
+
             gc.setForeground(media.get(trace.getColor()));
             gc.drawText(trace.getLabel(), x, y, true);
             x += grid_x;


### PR DESCRIPTION
In 51800c12 we changed to always create all traces, and only show them when they are visible.

After this we are no longer correctly hiding the legend for a trace when the trace is hidden in the plot. This commit fixes this issue.