### PR TITLE
Show PV disconnections in the data browser

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/TracePainter.java
@@ -189,6 +189,7 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
         for (int i=0; i<N; ++i)
         {
             final PlotDataItem<XTYPE> item = data.get(i);
+
             final int x = clipX(Math.round(x_transform.transform(item.getPosition())));
             final double value = item.getValue();
             if (value_poly.size() > 0  && x != last_x)
@@ -200,6 +201,9 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
             if (Double.isNaN(value))
             {
                 flushPolyLine(gc, value_poly, line_width);
+                if (last_y != -1) {
+                    highlightDiscontinuity(gc, x_transform, item);
+                }
                 last_x = last_y = -1;
             }
             else
@@ -238,6 +242,10 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
             if (Double.isNaN(value))
             {
                 flushPolyLine(gc, value_poly, line_width);
+                if (last_y != -1)
+                {
+                    highlightDiscontinuity(gc, x_transform, item);
+                }
                 last_x = last_y = -1;
             }
             else
@@ -408,6 +416,21 @@ public class TracePainter<XTYPE extends Comparable<XTYPE>>
     final private void drawPoint(final GC gc, final int x, final int y, final int size)
     {
         gc.fillOval(x-size/2, y-size/2, size, size);
+    }
+
+    /**
+     * Plot an additional vertical dashed line to indicate a transition to a
+     * non-plottable value, to highlight events such as an archiver disconnect.
+     * @param gc GC
+     * @param x_transform Horizontal axis
+     * @param item PlotDataItem
+     */
+    final private void highlightDiscontinuity(final GC gc, final ScreenTransform<XTYPE> x_transform,
+            final PlotDataItem<XTYPE> item) {
+        final int x1 = clipX(x_transform.transform(item.getPosition()));
+        gc.setLineStyle(SWT.LINE_DOT);
+        gc.drawLine(x1, y_min, x1, y_max);
+        gc.setLineStyle(SWT.LINE_SOLID);
     }
 
     /** Fill area. All lists will be cleared.


### PR DESCRIPTION
Show in the databrowser the events where the archiver appliance disconnected from a PV. This is analogous to the behaviour of the old Java ArchiveViewer for the channel archiver. The disconnect is indicated with a dashed vertical line. This behaviour is enabled by a preference. 

Please see example display in the screenshot below.

![image](https://user-images.githubusercontent.com/17617270/145218944-5eab8c32-8ae9-4ff3-94c4-a88c8879674b.png)
