### PR TITLE
Fix build on the latest version of Java 11

### DIFF
--- a/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences.test/src/org/csstudio/diirt/util/core/preferences/pojo/jaxb.properties
+++ b/core/diirt/diirt-plugins/org.csstudio.diirt.util.core.preferences.test/src/org/csstudio/diirt/util/core/preferences/pojo/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=com.sun.xml.bind.v2.ContextFactory

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,7 +93,7 @@
                       jacoco-maven-plugin
                     </artifactId>
                     <versionRange>
-                      [0.5.3.201107060350,)
+                      [0.8.3,)
                     </versionRange>
                     <goals>
                       <goal>prepare-agent</goal>
@@ -269,7 +269,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.5.3.201107060350</version>
+        <version>0.8.3</version>
         <configuration>
           <includes>*</includes>
           <destFile>${project.basedir}/../target/jacoco.exec</destFile>

--- a/core/ui/ui-plugins/org.csstudio.perspectives.test/src/org/csstudio/perspectives/PerspectiveSaverUnitTest.java
+++ b/core/ui/ui-plugins/org.csstudio.perspectives.test/src/org/csstudio/perspectives/PerspectiveSaverUnitTest.java
@@ -9,9 +9,7 @@ package org.csstudio.perspectives;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -28,9 +26,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
-import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.e4.core.services.events.IEventBroker;
-import org.eclipse.e4.ui.model.application.ui.MSnippetContainer;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder;
@@ -82,11 +78,9 @@ public class PerspectiveSaverUnitTest {
     public void setUp() {
         try {
             URL workspaceUrl = new URL("file:" + workspaceLocation);
-            when(instanceLocation.getDataArea(anyString())).thenReturn(workspaceUrl);
-            doNothing().when(preferences).put(anyString(), anyString());
-            when(prefsService.getString(anyString(), anyString(), anyString(), any(IScopeContext[].class))).thenReturn("dummy");
+            when(prefsService.getString(any(), any(), any(), any())).thenReturn("dummy");
             // Return first argument if cloneElement() is called on mockModelService.
-            when(mockModelService.cloneElement(any(MUIElement.class), any(MSnippetContainer.class))).thenAnswer(new Answer<MUIElement>() {
+            when(mockModelService.cloneElement(any(), any())).thenAnswer(new Answer<MUIElement>() {
                 @Override
                 public MUIElement answer(InvocationOnMock invocation) {
                     Object[] args = invocation.getArguments();
@@ -119,7 +113,6 @@ public class PerspectiveSaverUnitTest {
     @Test
     public void handleEventIgnoresEventsIfNoSaveDirPreferenceIsSet() {
         // Return null from preference query.
-        when(prefsService.getString(anyString(), anyString(), anyString(), any(IScopeContext[].class))).thenReturn(null);
         Event testEvent = createTestEvent(UIEvents.EventTags.ELEMENT, new Object());
         saver.handleEvent(testEvent);
         verify(mockModelService, never()).findElements(any(MUIElement.class), any(String.class), any(Class.class), any(List.class));


### PR DESCRIPTION
I noticed that CS-Studio no longer builds on the latest version of Java 11 used by the CI job (Java 11.0.19). I investigated and as of Java 11.0.17 the version of JaCoCo that we used for tests and code coverage is no longer supported. 
I updated the version of JaCoCo to 0.8.3, which officially supports Java 11. This led to a few issues with some of the tests, which I have fixed so that CS-Studio now builds successfully and all of the tests pass.
