### PR TITLE
Update to JCA version 2.4.8

### DIFF
--- a/maven-osgi-bundles/epics/plugins/org.csstudio.platform.libs.epics/pom.xml
+++ b/maven-osgi-bundles/epics/plugins/org.csstudio.platform.libs.epics/pom.xml
@@ -116,6 +116,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.5.0</version>
         <extensions>true</extensions>
         <configuration>
         <unpackBundle>true</unpackBundle>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <cs-studio.version>4.6</cs-studio.version>
     <cs-studio.version.long>4.6.0-SNAPSHOT</cs-studio.version.long>
 
-    <epics.jca.version>2.4.3</epics.jca.version>
+    <epics.jca.version>2.4.8</epics.jca.version>
 
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
     <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>


### PR DESCRIPTION
This PR updates the JCA dependency in CS-Studio to use the latest release 2.4.8, which contains new features that we would like to use in CS-Studio (e.g. https://github.com/epics-base/jca/pull/74).

Note that the version of the `org.apache.felix maven-bundle-plugin` also needs to be specified otherwise a default, outdated version (2.1) is used and this gives `ArrayIndexOutOfBoundsException` exceptions when building the `org.csstudio:org.csstudio.platform.libs.epics` bundle (see description of similar [issue](https://issues.apache.org/jira/browse/FELIX-4556)). I've updated to a version that does not have this problem.