### PR TITLE
Resize the legend area when traces are hidden

### DIFF
--- a/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/LegendPart.java
+++ b/applications/appunorganized/appunorganized-plugins/org.csstudio.swt.rtplot/src/org/csstudio/swt/rtplot/internal/LegendPart.java
@@ -66,14 +66,18 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
         final Font orig_font = gc.getFont();
         gc.setFont(font);
 
+        int items = 0;
         int max_width = 1, max_height = 1; // Start with 1 pixel to avoid later div-by-0
         for (Trace<XTYPE> trace : traces)
         {
+            if (!trace.isVisible())
+                continue;
             final Point size = gc.textExtent(trace.getLabel());
             if (size.x > max_width)
                 max_width = size.x;
             if (size.y > max_height)
                 max_height = size.y;
+            items++;
         }
         // Arrange in grid with some extra space
         grid_x = max_width + max_height / 2;
@@ -81,7 +85,6 @@ public class LegendPart<XTYPE extends Comparable<XTYPE>> extends PlotPart
 
         gc.setFont(orig_font);
 
-        final int items = traces.size();
         final int items_per_row = Math.max(1, bounds_width / grid_x); // Round down, counting full items
         final int rows = (items + items_per_row-1) / items_per_row;   // Round up
         return rows * grid_y;


### PR DESCRIPTION
We came across an issue in the databrowser where the area taken up to display the traces legend does not shrink when traces are hidden. This is particular noticeable if the plot contains many traces of which most are hidden. 
It turns out that in the code the legend area is determined using all the traces even if they are not being displayed. This PR fixes this issue by only considering the visible traces.