### PR TITLE
Specify minor version of Java to use in GitHub action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 11.0.19
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4
       with:


### PR DESCRIPTION
There is a problem with the CSS build using the latest version of Java11 (11.0.21). This is what is used by the GitHub CI by default if you only specifying the major version of Java to use as we currently do (i.e. 11).
The error is due to a signing issue in the jython-standalone package we download:
```
Error:  Failed to execute goal org.reficio:p2-maven-plugin:1.3.0:site (default-cli) on project maven-osgi-repository: 
Execution default-cli of goal org.reficio:p2-maven-plugin:1.3.0:site failed: java.lang.RuntimeException: Error while bundling jar or 
source: jython-standalone-2.7.1.jar: The JAR/ZIP file (/home/runner/.m2/repository/org/python/jython-standalone/2.7.1/jython-
standalone-2.7.1.jar.d0685bba-07f7-4512-bcd6-f690f85bd948) seems corrupted, error: Invalid CEN header (invalid extra data field
 size for tag: 0xbfef at 130358) -> [Help 1]
```
This check is something that has been introduced from Java 11.0.20 as an extra security check. Without the jython-standalone signature being fixed the only solution for us is to specify the use of Java 11.0.19 in the GitHub CI build. 