### PR TITLE
Latest data point not plotted after a disconnect

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.reader.appliance/src/org/csstudio/archive/reader/appliance/ApplianceValueIterator.java
@@ -127,7 +127,11 @@ public abstract class ApplianceValueIterator implements ValueIterator {
      */
     @Override
     public synchronized boolean hasNext() {
-        return !closed && mainIterator != null && mainIterator.hasNext();
+        boolean hasNext = !closed && mainIterator != null && mainIterator.hasNext();
+        if (reuseMessage && !hasNext) {
+            hasNext = true;
+        }
+        return hasNext;
     }
 
     /*


### PR DESCRIPTION
An issue was introduced in https://github.com/ControlSystemStudio/cs-studio/pull/2713 where we attempted to show PV disconnections in the data browser. In the current implementation we attempt to detect a 'disconnect' messages in the metadata of a data item and add an extra data point to signal this. On the following `next()` call to the iterator it uses the previous message (which was just replaced with the disconnect) to make sure no data is missed.

It turns out there is a particular case that causes a problem when it is the final message from the archiver that contains the disconnect. What this means is that now the `next()` function never gets called as the iterator is empty (so `hasNext()` returns `false`) and so we can miss the following (i.e. latest) value. This means that the value after the last disconnect does not get plotted.

This PR contains a fix for this where I have updated the `hasNext()` method of the iterator to return `true` if we still need to process the most recent message (meaning that `next()` will be called one final time).