### PR TITLE
Update JCA version to 2.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <cs-studio.version>4.6</cs-studio.version>
     <cs-studio.version.long>4.6.0-SNAPSHOT</cs-studio.version.long>
 
-    <epics.jca.version>2.4.8</epics.jca.version>
+    <epics.jca.version>2.4.10</epics.jca.version>
 
     <eclipse.central.url>http://download.eclipse.org</eclipse.central.url>
     <eclipse.mirror.url>${eclipse.central.url}</eclipse.mirror.url>


### PR DESCRIPTION
The latest release of JCA fixes an issue where the code could block during a socket connection by adding a configurable timeout. This would be a useful fix to have in CS-Studio. PR is to update the JCA dependency to the latest JCA version (2.4.10).